### PR TITLE
feat: add agent steering (mid-execution intervention)

### DIFF
--- a/app/agent/__init__.py
+++ b/app/agent/__init__.py
@@ -1,5 +1,11 @@
 """Agent module"""
 from .agent import SkillsAgent, AgentResult, AgentStep, StreamEvent
-from .tools import TOOLS, call_tool
+from .event_stream import EventStream
+from .steering import write_steering_message, poll_steering_messages, cleanup_steering_dir
+from .tools import TOOLS, call_tool, acall_tool
 
-__all__ = ["SkillsAgent", "AgentResult", "AgentStep", "StreamEvent", "TOOLS", "call_tool"]
+__all__ = [
+    "SkillsAgent", "AgentResult", "AgentStep", "StreamEvent", "EventStream",
+    "write_steering_message", "poll_steering_messages", "cleanup_steering_dir",
+    "TOOLS", "call_tool", "acall_tool",
+]

--- a/app/agent/event_stream.py
+++ b/app/agent/event_stream.py
@@ -1,0 +1,63 @@
+"""Async event channel between agent (producer) and API endpoint (consumer).
+
+Inspired by Pi Agent's EventStream — a CSP-style push/pull channel using asyncio.Queue.
+Supports bidirectional communication: agent pushes events, API injects steering messages.
+"""
+import asyncio
+from typing import Optional
+
+from app.agent.agent import StreamEvent
+
+
+class EventStream:
+    """Async event channel for streaming agent events to API consumers.
+
+    Producer (agent): calls push() / close()
+    Consumer (API endpoint): async iterates over the stream
+    Steering (API endpoint → agent): inject() / has_injection() / get_injection()
+    """
+
+    def __init__(self):
+        self._queue: asyncio.Queue[Optional[StreamEvent]] = asyncio.Queue()
+        self._injection_queue: asyncio.Queue[str] = asyncio.Queue()
+        self._closed = False
+
+    async def push(self, event: StreamEvent):
+        """Push an event into the stream. No-op if already closed."""
+        if not self._closed:
+            await self._queue.put(event)
+
+    async def close(self):
+        """Signal that no more events will be pushed (sends sentinel)."""
+        if not self._closed:
+            self._closed = True
+            await self._queue.put(None)
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    # --- Steering injection (API → Agent) ---
+
+    async def inject(self, message: str):
+        """API endpoint: inject a steering message for the agent to consume."""
+        await self._injection_queue.put(message)
+
+    def has_injection(self) -> bool:
+        """Agent: check if any steering messages are waiting (non-blocking)."""
+        return not self._injection_queue.empty()
+
+    def get_injection_nowait(self) -> Optional[str]:
+        """Agent: consume a steering message (non-blocking). Returns None if empty."""
+        try:
+            return self._injection_queue.get_nowait()
+        except asyncio.QueueEmpty:
+            return None
+
+    async def __aiter__(self):
+        """Async iterate over events until the stream is closed."""
+        while True:
+            event = await self._queue.get()
+            if event is None:
+                break
+            yield event

--- a/app/agent/steering.py
+++ b/app/agent/steering.py
@@ -1,0 +1,76 @@
+"""Filesystem-based steering message queue for cross-worker communication.
+
+When uvicorn runs with multiple workers, each worker is a separate process
+with its own memory. The SSE stream lives in one worker, but a steer POST
+may land on any worker. This module uses the shared filesystem (/tmp) as a
+cross-process message queue.
+
+Flow:
+1. Steer endpoint writes a .msg file to /tmp/agent_steering/{trace_id}/
+2. A polling task in the streaming worker reads .msg files and injects
+   them into the local EventStream
+3. The agent loop picks up injected messages at tool boundaries
+
+Atomicity:
+- write_steering_message uses write-then-rename to prevent partial reads.
+  rename() is atomic on the same filesystem (Linux guarantee).
+- Filenames include time_ns + random suffix to prevent collision across workers.
+- Polling only reads .msg files, ignoring .tmp files being written.
+"""
+import asyncio
+import logging
+import os
+import shutil
+import time
+from pathlib import Path
+
+from app.agent.event_stream import EventStream
+
+logger = logging.getLogger("skills_api")
+
+STEERING_DIR = Path("/tmp/agent_steering")
+
+
+def write_steering_message(trace_id: str, message: str) -> None:
+    """Write a steering message to the filesystem queue (atomic)."""
+    trace_dir = STEERING_DIR / trace_id
+    trace_dir.mkdir(parents=True, exist_ok=True)
+    # Use time_ns + pid + random bytes to avoid filename collision across workers
+    unique = f"{time.time_ns()}_{os.getpid()}_{os.urandom(4).hex()}"
+    tmp_file = trace_dir / f"{unique}.tmp"
+    tmp_file.write_text(message, encoding="utf-8")
+    # Atomic rename: polling only reads .msg files, so this is safe
+    tmp_file.rename(trace_dir / f"{unique}.msg")
+
+
+def cleanup_steering_dir(trace_id: str) -> None:
+    """Remove steering directory for a trace."""
+    trace_dir = STEERING_DIR / trace_id
+    if trace_dir.exists():
+        shutil.rmtree(trace_dir, ignore_errors=True)
+
+
+async def poll_steering_messages(
+    trace_id: str,
+    event_stream: EventStream,
+    poll_interval: float = 0.3,
+) -> None:
+    """Poll filesystem for steering messages and inject into EventStream.
+
+    Runs until event_stream is closed or the task is cancelled.
+    Only reads .msg files (fully written), ignoring .tmp files in flight.
+    """
+    trace_dir = STEERING_DIR / trace_id
+    while not event_stream.closed:
+        try:
+            if trace_dir.exists():
+                for msg_file in sorted(trace_dir.glob("*.msg")):
+                    try:
+                        message = msg_file.read_text(encoding="utf-8")
+                        await event_stream.inject(message)
+                        msg_file.unlink()
+                    except Exception:
+                        pass
+        except Exception:
+            pass
+        await asyncio.sleep(poll_interval)

--- a/app/api/v1/registry.py
+++ b/app/api/v1/registry.py
@@ -381,7 +381,7 @@ Important constraints:
 - Delete unnecessary example files
 """
 
-        agent_result = agent.run(agent_request)
+        agent_result = agent.run_sync(agent_request)
         duration_ms = int((time.time() - start_time) * 1000)
 
         # Update trace in database (sync)
@@ -1224,7 +1224,7 @@ Important constraints:
 - Maintain the SKILL.md format specification
 """
 
-        agent_result = agent.run(agent_request)
+        agent_result = agent.run_sync(agent_request)
         duration_ms = int((time.time() - start_time) * 1000)
 
         # Update trace in database (sync)
@@ -1326,7 +1326,7 @@ Important constraints:
 - Maintain the SKILL.md format specification
 """
 
-        agent_result = agent.run(agent_request)
+        agent_result = agent.run_sync(agent_request)
         duration_ms = int((time.time() - start_time) * 1000)
 
         # Update trace in database (sync)

--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -89,12 +89,17 @@ Increase **Max Turns** in the agent configuration. Default is 60. For complex mu
 2. **Reduce skills** — fewer skills means less context to process
 3. **Be specific** — vague requests require more agent rounds
 
+### Can I redirect the agent while it's running?
+
+Yes. While the agent is executing, the input field stays active. Type a message and press Enter to send a **steering message**. The agent picks it up at the next tool boundary and adjusts its behavior — no need to stop and restart. See [Agents — Steering](/concepts/agents#steering-mid-execution-intervention).
+
 ### Agent stuck in a loop
 
-1. Click **Stop** to halt execution
-2. Rephrase your request more specifically
-3. Try a different model
-4. Review traces for the repeated pattern
+1. Send a steering message to redirect it (e.g., "Stop repeating and try a different approach")
+2. Click **Stop** to halt execution
+3. Rephrase your request more specifically
+4. Try a different model
+5. Review traces for the repeated pattern
 
 ---
 

--- a/docs/docs/how-to/publish-agent.md
+++ b/docs/docs/how-to/publish-agent.md
@@ -148,12 +148,26 @@ curl -N -X POST http://localhost:62610/api/v1/published/{agent_id}/chat \
 | `tool_call` | Tool call started |
 | `tool_result` | Tool call result |
 | `output_file` | Auto-detected output file |
+| `steering_received` | Steering message was injected by the user |
 | `complete` | Agent finished (contains `answer`, `success`, `total_turns`) |
 | `context_compressed` | History was compressed (long conversations) |
 | `trace_saved` | Trace record saved to database |
 | `error` | Error occurred |
 
 Text arrives incrementally via `text_delta` events as the LLM generates tokens. Accumulate them to build the full response. If the stream connection drops, the system retries automatically.
+
+#### Steering a Running Agent
+
+While the agent is processing, you can inject a steering message to redirect its behavior:
+
+```bash
+# trace_id is returned in the run_started event
+curl -X POST http://localhost:62610/api/v1/published/{agent_id}/chat/{trace_id}/steer \
+  -H "Content-Type: application/json" \
+  -d '{"message": "Try a different approach"}'
+```
+
+The agent picks up the message at its next tool boundary. See [Agents — Steering](/concepts/agents#steering-mid-execution-intervention) for details.
 
 ### Non-Streaming Chat
 

--- a/docs/docs/how-to/run-tests.md
+++ b/docs/docs/how-to/run-tests.md
@@ -28,7 +28,7 @@ Do not run multiple test suites in parallel — they share the same test databas
 
 ## Test Categories
 
-### Unit Tests (~340 tests, ~45s)
+### Unit Tests (~390 tests, ~55s)
 
 Test individual API endpoints and services using a per-test isolated database. No API keys required.
 
@@ -42,7 +42,7 @@ Or run directly:
 pytest tests/test_api/ tests/test_core/ tests/test_services/ -v
 ```
 
-### E2E Workflow Tests (~160 tests, ~15s)
+### E2E Workflow Tests (~170 tests, ~15s)
 
 End-to-end API workflows using mocked LLM responses. Covers skills lifecycle, agents, traces, file upload, code execution, MCP, and more.
 

--- a/tests/test_api/test_agent_run.py
+++ b/tests/test_api/test_agent_run.py
@@ -10,7 +10,7 @@ Covers:
 
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from httpx import AsyncClient
@@ -65,7 +65,7 @@ class MockAgentResult:
 def _make_mock_agent(result: Optional[MockAgentResult] = None):
     """Return a MagicMock that behaves like SkillsAgent."""
     instance = MagicMock()
-    instance.run.return_value = result or MockAgentResult()
+    instance.run = AsyncMock(return_value=result or MockAgentResult())
     instance.model = "kimi-k2.5"
     instance.model_provider = "kimi"
     return instance

--- a/tests/test_api/test_agent_stream.py
+++ b/tests/test_api/test_agent_stream.py
@@ -4,15 +4,20 @@ Tests for Agent streaming endpoint: POST /api/v1/agent/run/stream
 Uses mocked SkillsAgent to avoid real LLM calls.
 The stream endpoint uses AsyncSessionLocal directly (not get_db),
 so we also need to mock that for trace saving.
+
+Also tests:
+- POST /api/v1/agent/run/stream/{trace_id}/steer
 """
 import json
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
-from types import SimpleNamespace
 from unittest.mock import patch, MagicMock, AsyncMock
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.agent.agent import StreamEvent
+from app.agent.event_stream import EventStream
 
 
 @dataclass
@@ -40,15 +45,15 @@ class MockLLMCall:
 
 
 def _make_stream_events():
-    """Create a list of mock stream events."""
+    """Create a list of StreamEvent objects for mock agent."""
     return [
-        SimpleNamespace(event_type="turn_start", turn=1, data={"turn": 1}),
-        SimpleNamespace(
+        StreamEvent(event_type="turn_start", turn=1, data={"turn": 1}),
+        StreamEvent(
             event_type="assistant",
             turn=1,
             data={"content": "Hello from mock", "turn": 1},
         ),
-        SimpleNamespace(
+        StreamEvent(
             event_type="complete",
             turn=1,
             data={
@@ -57,9 +62,49 @@ def _make_stream_events():
                 "total_turns": 1,
                 "total_input_tokens": 100,
                 "total_output_tokens": 50,
+                "skills_used": [],
+                "output_files": [],
+                "final_messages": [],
             },
         ),
     ]
+
+
+def _make_mock_agent_instance(events=None):
+    """Create a mock SkillsAgent whose run() pushes events to event_stream."""
+    from app.agent.agent import AgentResult
+
+    if events is None:
+        events = _make_stream_events()
+
+    # Extract result from complete event
+    complete_event = next((e for e in events if e.event_type == "complete"), None)
+    result = AgentResult(
+        success=complete_event.data.get("success", True) if complete_event else True,
+        answer=complete_event.data.get("answer", "Done") if complete_event else "Done",
+        total_turns=complete_event.data.get("total_turns", 1) if complete_event else 1,
+        total_input_tokens=complete_event.data.get("total_input_tokens", 100) if complete_event else 100,
+        total_output_tokens=complete_event.data.get("total_output_tokens", 50) if complete_event else 50,
+        skills_used=complete_event.data.get("skills_used", []) if complete_event else [],
+        output_files=complete_event.data.get("output_files", []) if complete_event else [],
+        final_messages=complete_event.data.get("final_messages", []) if complete_event else [],
+    )
+
+    mock_instance = MagicMock()
+    mock_instance.model = "claude-sonnet-4-5-20250929"
+    mock_instance.model_provider = "anthropic"
+    mock_instance.cleanup = MagicMock()
+
+    async def mock_run(request, conversation_history=None, image_contents=None,
+                       event_stream=None, cancellation_event=None):
+        if event_stream:
+            for event in events:
+                await event_stream.push(event)
+            await event_stream.close()
+        return result
+
+    mock_instance.run = AsyncMock(side_effect=mock_run)
+    return mock_instance
 
 
 def _mock_session_local(db_session: AsyncSession):
@@ -83,10 +128,7 @@ def _mock_session_local(db_session: AsyncSession):
 @pytest.mark.asyncio
 @patch("app.api.v1.agent.SkillsAgent")
 async def test_stream_returns_event_stream(MockAgent, client):
-    mock_instance = MagicMock()
-    mock_instance.run_stream.return_value = iter(_make_stream_events())
-    mock_instance.model = "claude-sonnet-4-5-20250929"
-    MockAgent.return_value = mock_instance
+    MockAgent.return_value = _make_mock_agent_instance()
 
     response = await client.post(
         "/api/v1/agent/run/stream",
@@ -100,10 +142,7 @@ async def test_stream_returns_event_stream(MockAgent, client):
 @patch("app.api.v1.agent.AsyncSessionLocal")
 @patch("app.api.v1.agent.SkillsAgent")
 async def test_stream_sends_run_started(MockAgent, MockSessionLocal, client, db_session):
-    mock_instance = MagicMock()
-    mock_instance.run_stream.return_value = iter(_make_stream_events())
-    mock_instance.model = "claude-sonnet-4-5-20250929"
-    MockAgent.return_value = mock_instance
+    MockAgent.return_value = _make_mock_agent_instance()
     MockSessionLocal.side_effect = lambda: _mock_session_local(db_session)()
 
     response = await client.post(
@@ -124,10 +163,7 @@ async def test_stream_sends_run_started(MockAgent, MockSessionLocal, client, db_
 @patch("app.api.v1.agent.AsyncSessionLocal")
 @patch("app.api.v1.agent.SkillsAgent")
 async def test_stream_sends_trace_saved(MockAgent, MockSessionLocal, client, db_session):
-    mock_instance = MagicMock()
-    mock_instance.run_stream.return_value = iter(_make_stream_events())
-    mock_instance.model = "claude-sonnet-4-5-20250929"
-    MockAgent.return_value = mock_instance
+    MockAgent.return_value = _make_mock_agent_instance()
     MockSessionLocal.side_effect = lambda: _mock_session_local(db_session)()
 
     response = await client.post(
@@ -145,10 +181,7 @@ async def test_stream_sends_trace_saved(MockAgent, MockSessionLocal, client, db_
 @patch("app.api.v1.agent.AsyncSessionLocal")
 @patch("app.api.v1.agent.SkillsAgent")
 async def test_stream_with_skills(MockAgent, MockSessionLocal, client, db_session):
-    mock_instance = MagicMock()
-    mock_instance.run_stream.return_value = iter(_make_stream_events())
-    mock_instance.model = "claude-sonnet-4-5-20250929"
-    MockAgent.return_value = mock_instance
+    MockAgent.return_value = _make_mock_agent_instance()
     MockSessionLocal.side_effect = lambda: _mock_session_local(db_session)()
 
     response = await client.post(
@@ -165,10 +198,7 @@ async def test_stream_with_skills(MockAgent, MockSessionLocal, client, db_sessio
 @patch("app.api.v1.agent.AsyncSessionLocal")
 @patch("app.api.v1.agent.SkillsAgent")
 async def test_stream_with_mcp_servers(MockAgent, MockSessionLocal, client, db_session):
-    mock_instance = MagicMock()
-    mock_instance.run_stream.return_value = iter(_make_stream_events())
-    mock_instance.model = "claude-sonnet-4-5-20250929"
-    MockAgent.return_value = mock_instance
+    MockAgent.return_value = _make_mock_agent_instance()
     MockSessionLocal.side_effect = lambda: _mock_session_local(db_session)()
 
     response = await client.post(
@@ -185,10 +215,28 @@ async def test_stream_with_mcp_servers(MockAgent, MockSessionLocal, client, db_s
 @patch("app.api.v1.agent.AsyncSessionLocal")
 @patch("app.api.v1.agent.SkillsAgent")
 async def test_stream_error_handling(MockAgent, MockSessionLocal, client, db_session):
-    mock_instance = MagicMock()
-    mock_instance.run_stream.side_effect = RuntimeError("Mock error")
-    mock_instance.model = "claude-sonnet-4-5-20250929"
-    MockAgent.return_value = mock_instance
+    """When agent encounters error, it pushes error complete event and stream includes it."""
+    # In the async architecture, agent.run() catches errors internally
+    # and pushes a complete event with success=False
+    error_events = [
+        StreamEvent(event_type="turn_start", turn=1, data={"turn": 1}),
+        StreamEvent(
+            event_type="complete",
+            turn=1,
+            data={
+                "success": False,
+                "answer": "Error: Mock error",
+                "error": "Mock error",
+                "total_turns": 1,
+                "total_input_tokens": 0,
+                "total_output_tokens": 0,
+                "skills_used": [],
+                "output_files": [],
+                "final_messages": [],
+            },
+        ),
+    ]
+    MockAgent.return_value = _make_mock_agent_instance(events=error_events)
     MockSessionLocal.side_effect = lambda: _mock_session_local(db_session)()
 
     response = await client.post(
@@ -198,5 +246,158 @@ async def test_stream_error_handling(MockAgent, MockSessionLocal, client, db_ses
     assert response.status_code == 200
     text = response.text
     lines = [l for l in text.strip().split("\n") if l.startswith("data: ")]
-    # Should have at least run_started and an error event
-    assert len(lines) >= 1
+    # Should have run_started + events + trace_saved
+    assert len(lines) >= 2
+    # Check for error complete event
+    events = [json.loads(l.replace("data: ", "")) for l in lines]
+    complete_events = [e for e in events if e.get("event_type") == "complete"]
+    assert len(complete_events) == 1
+    assert complete_events[0]["success"] is False
+
+
+# ---------------------------------------------------------------------------
+# Steer endpoint tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_steer_no_active_run_404(client):
+    """Steering a non-existent trace returns 404."""
+    resp = await client.post(
+        "/api/v1/agent/run/stream/nonexistent-trace-id/steer",
+        json={"message": "do something else"},
+    )
+    assert resp.status_code == 404
+    assert "No active run" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_steer_completed_run_409(client):
+    """Steering a completed (closed) stream returns 409."""
+    from app.api.v1.agent import _active_streams
+
+    # Register a closed event stream
+    es = EventStream()
+    await es.close()
+    _active_streams["test-trace-closed"] = es
+
+    try:
+        resp = await client.post(
+            "/api/v1/agent/run/stream/test-trace-closed/steer",
+            json={"message": "too late"},
+        )
+        assert resp.status_code == 409
+        assert "already completed" in resp.json()["detail"]
+    finally:
+        _active_streams.pop("test-trace-closed", None)
+
+
+@pytest.mark.asyncio
+async def test_steer_endpoint_injects_message(client):
+    """Steering an active stream injects the message into its injection queue."""
+    from app.api.v1.agent import _active_streams
+
+    es = EventStream()
+    _active_streams["test-trace-active"] = es
+
+    try:
+        resp = await client.post(
+            "/api/v1/agent/run/stream/test-trace-active/steer",
+            json={"message": "focus on validation"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "injected"
+        assert body["trace_id"] == "test-trace-active"
+
+        # Verify the message is in the injection queue
+        assert es.has_injection() is True
+        msg = es.get_injection_nowait()
+        assert msg == "focus on validation"
+    finally:
+        _active_streams.pop("test-trace-active", None)
+
+
+@pytest.mark.asyncio
+async def test_steer_empty_message_rejected(client):
+    """Empty steering message is rejected by validation."""
+    resp = await client.post(
+        "/api/v1/agent/run/stream/some-trace/steer",
+        json={"message": ""},
+    )
+    assert resp.status_code == 422  # Pydantic validation error
+
+
+@pytest.mark.asyncio
+async def test_steer_cross_worker_via_filesystem(client, db_session):
+    """Cross-worker steering: trace in DB + filesystem queue (no _active_streams entry)."""
+    from app.db.models import AgentTraceDB
+    from app.agent.steering import STEERING_DIR, cleanup_steering_dir
+
+    # Create a running trace in the DB (simulating another worker)
+    trace = AgentTraceDB(
+        request="test",
+        skills_used=[],
+        model="test",
+        model_provider="test",
+        status="running",
+        success=False,
+        answer="",
+        total_turns=0,
+        total_input_tokens=0,
+        total_output_tokens=0,
+        steps=[],
+        llm_calls=[],
+        duration_ms=0,
+    )
+    db_session.add(trace)
+    await db_session.commit()
+
+    try:
+        # Steer should hit the cross-worker path (no _active_streams entry)
+        resp = await client.post(
+            f"/api/v1/agent/run/stream/{trace.id}/steer",
+            json={"message": "cross-worker steer"},
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "injected"
+
+        # Verify the message was written to filesystem
+        trace_dir = STEERING_DIR / trace.id
+        msg_files = list(trace_dir.glob("*.msg"))
+        assert len(msg_files) == 1
+        assert msg_files[0].read_text(encoding="utf-8") == "cross-worker steer"
+    finally:
+        cleanup_steering_dir(trace.id)
+
+
+@pytest.mark.asyncio
+async def test_steer_cross_worker_completed_trace_409(client, db_session):
+    """Cross-worker steering: completed trace returns 409."""
+    from app.db.models import AgentTraceDB
+
+    # Create a completed trace
+    trace = AgentTraceDB(
+        request="test",
+        skills_used=[],
+        model="test",
+        model_provider="test",
+        status="completed",
+        success=True,
+        answer="done",
+        total_turns=1,
+        total_input_tokens=100,
+        total_output_tokens=50,
+        steps=[],
+        llm_calls=[],
+        duration_ms=1000,
+    )
+    db_session.add(trace)
+    await db_session.commit()
+
+    resp = await client.post(
+        f"/api/v1/agent/run/stream/{trace.id}/steer",
+        json={"message": "too late"},
+    )
+    assert resp.status_code == 409
+    assert "already completed" in resp.json()["detail"]

--- a/tests/test_core/test_event_stream.py
+++ b/tests/test_core/test_event_stream.py
@@ -1,0 +1,87 @@
+"""
+Tests for EventStream — async event channel with bidirectional steering support.
+
+Tests:
+- Basic inject/get_injection functionality
+- has_injection when empty
+- Multiple injections in FIFO order
+- Injection after stream is closed
+"""
+import asyncio
+
+import pytest
+
+from app.agent.agent import StreamEvent
+from app.agent.event_stream import EventStream
+
+
+@pytest.mark.asyncio
+async def test_inject_and_get():
+    """inject() puts a message, get_injection_nowait() retrieves it."""
+    es = EventStream()
+    await es.inject("fix the bug")
+    assert es.has_injection() is True
+    msg = es.get_injection_nowait()
+    assert msg == "fix the bug"
+    assert es.has_injection() is False
+
+
+@pytest.mark.asyncio
+async def test_has_injection_empty():
+    """Empty injection queue returns False."""
+    es = EventStream()
+    assert es.has_injection() is False
+    assert es.get_injection_nowait() is None
+
+
+@pytest.mark.asyncio
+async def test_multiple_injections_fifo():
+    """Multiple injected messages are consumed in FIFO order."""
+    es = EventStream()
+    await es.inject("first")
+    await es.inject("second")
+    await es.inject("third")
+
+    assert es.get_injection_nowait() == "first"
+    assert es.get_injection_nowait() == "second"
+    assert es.get_injection_nowait() == "third"
+    assert es.get_injection_nowait() is None
+
+
+@pytest.mark.asyncio
+async def test_inject_after_close():
+    """Injection still works even after the event stream is closed.
+
+    This is by design: the injection queue is separate from the event queue.
+    The agent may still check injections before exiting its loop.
+    """
+    es = EventStream()
+    await es.close()
+    assert es.closed is True
+
+    await es.inject("late steering")
+    assert es.has_injection() is True
+    msg = es.get_injection_nowait()
+    assert msg == "late steering"
+
+
+@pytest.mark.asyncio
+async def test_push_and_iterate():
+    """Basic push/iterate still works alongside injection."""
+    es = EventStream()
+    event = StreamEvent(event_type="turn_start", turn=1, data={"turn": 1})
+
+    await es.push(event)
+    await es.inject("steer me")
+    await es.close()
+
+    collected = []
+    async for e in es:
+        collected.append(e)
+
+    assert len(collected) == 1
+    assert collected[0].event_type == "turn_start"
+
+    # Injection queue is independent
+    assert es.has_injection() is True
+    assert es.get_injection_nowait() == "steer me"

--- a/tests/test_core/test_steering.py
+++ b/tests/test_core/test_steering.py
@@ -1,0 +1,126 @@
+"""
+Tests for filesystem-based cross-worker steering queue.
+
+Tests:
+- write_steering_message creates .msg files
+- poll_steering_messages picks up files and injects into EventStream
+- cleanup_steering_dir removes the trace directory
+- Multiple messages are consumed in order
+"""
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from app.agent.event_stream import EventStream
+from app.agent.steering import (
+    STEERING_DIR,
+    write_steering_message,
+    poll_steering_messages,
+    cleanup_steering_dir,
+)
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_steering_dir():
+    """Ensure steering directory is clean before and after each test."""
+    import shutil
+    test_dir = STEERING_DIR / "test-trace"
+    if test_dir.exists():
+        shutil.rmtree(test_dir)
+    yield
+    if test_dir.exists():
+        shutil.rmtree(test_dir)
+
+
+def test_write_creates_msg_file():
+    """write_steering_message creates a .msg file in the trace directory."""
+    write_steering_message("test-trace", "hello")
+    trace_dir = STEERING_DIR / "test-trace"
+    assert trace_dir.exists()
+    files = list(trace_dir.glob("*.msg"))
+    assert len(files) == 1
+    assert files[0].read_text(encoding="utf-8") == "hello"
+
+
+def test_write_multiple_messages():
+    """Multiple writes create multiple .msg files in order."""
+    write_steering_message("test-trace", "first")
+    write_steering_message("test-trace", "second")
+    write_steering_message("test-trace", "third")
+    trace_dir = STEERING_DIR / "test-trace"
+    files = sorted(trace_dir.glob("*.msg"))
+    assert len(files) == 3
+    assert files[0].read_text(encoding="utf-8") == "first"
+    assert files[1].read_text(encoding="utf-8") == "second"
+    assert files[2].read_text(encoding="utf-8") == "third"
+
+
+def test_cleanup_removes_directory():
+    """cleanup_steering_dir removes the trace directory entirely."""
+    write_steering_message("test-trace", "msg")
+    assert (STEERING_DIR / "test-trace").exists()
+    cleanup_steering_dir("test-trace")
+    assert not (STEERING_DIR / "test-trace").exists()
+
+
+def test_cleanup_nonexistent_is_noop():
+    """cleanup_steering_dir on nonexistent trace is a no-op."""
+    cleanup_steering_dir("test-trace-does-not-exist")
+
+
+@pytest.mark.asyncio
+async def test_poll_picks_up_messages():
+    """poll_steering_messages reads .msg files and injects into EventStream."""
+    es = EventStream()
+
+    # Write messages before polling starts
+    write_steering_message("test-trace", "steer-1")
+    write_steering_message("test-trace", "steer-2")
+
+    # Start polling with short interval
+    poll_task = asyncio.create_task(
+        poll_steering_messages("test-trace", es, poll_interval=0.05)
+    )
+
+    # Wait for polling to pick up messages
+    await asyncio.sleep(0.2)
+
+    # Close stream to stop polling
+    await es.close()
+    poll_task.cancel()
+    try:
+        await poll_task
+    except asyncio.CancelledError:
+        pass
+
+    # Verify messages were injected
+    assert es.get_injection_nowait() == "steer-1"
+    assert es.get_injection_nowait() == "steer-2"
+    assert es.get_injection_nowait() is None
+
+    # Verify files were consumed (deleted)
+    trace_dir = STEERING_DIR / "test-trace"
+    remaining = list(trace_dir.glob("*.msg")) if trace_dir.exists() else []
+    assert len(remaining) == 0
+
+
+@pytest.mark.asyncio
+async def test_poll_stops_when_stream_closed():
+    """poll_steering_messages exits when event_stream is closed."""
+    es = EventStream()
+    await es.close()
+
+    # Should exit quickly since stream is already closed
+    poll_task = asyncio.create_task(
+        poll_steering_messages("test-trace", es, poll_interval=0.05)
+    )
+
+    # Should complete within a short time
+    await asyncio.sleep(0.15)
+    assert poll_task.done() or poll_task.cancelled()
+    poll_task.cancel()
+    try:
+        await poll_task
+    except asyncio.CancelledError:
+        pass

--- a/tests/test_core/test_stream_retry.py
+++ b/tests/test_core/test_stream_retry.py
@@ -2,15 +2,17 @@
 
 Tests cover:
 1. _is_retryable_error() classification of transient vs permanent errors
-2. run_stream() retry with non-streaming fallback when stream fails
+2. run() streaming retry with non-streaming fallback when stream fails
 3. Proper error propagation when both stream and retry fail
 4. Non-retryable errors skip retry
 5. SSE endpoint properly relays stream error/retry events
 """
 
+import asyncio
 import pytest
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, AsyncMock
 from app.agent.agent import SkillsAgent, StreamEvent
+from app.agent.event_stream import EventStream
 from app.llm.provider import LLMResponse, LLMTextBlock, LLMToolCall, LLMUsage
 
 
@@ -56,14 +58,18 @@ def _make_delta(text):
     )
 
 
-def _collect_events(gen):
-    """Collect all StreamEvents from a run_stream() generator."""
+async def _collect_stream_events(agent, request, **kwargs):
+    """Run agent.run() with an EventStream and collect all events."""
+    event_stream = EventStream()
     events = []
-    try:
-        for event in gen:
+
+    async def collector():
+        async for event in event_stream:
             events.append(event)
-    except StopIteration:
-        pass
+
+    collector_task = asyncio.create_task(collector())
+    await agent.run(request, event_stream=event_stream, **kwargs)
+    await collector_task
     return events
 
 
@@ -143,21 +149,23 @@ class TestIsRetryableError:
 # Class 2: Stream success (no retry needed)
 # ===================================================================
 
+@pytest.mark.asyncio
 class TestStreamSuccessNoRetry:
     """Verify normal streaming works without triggering retry."""
 
-    @patch("time.sleep")  # Don't actually sleep in tests
-    def test_normal_stream_yields_deltas_and_complete(self, mock_sleep):
+    async def test_normal_stream_yields_deltas_and_complete(self):
         """Normal stream: text_delta events emitted, complete event at end."""
         mock_client = MagicMock()
-        mock_client.create_stream.return_value = iter([
-            _make_delta("Hello "),
-            _make_delta("world"),
-            _make_final_response("Hello world"),
-        ])
+
+        async def mock_stream(*args, **kwargs):
+            yield _make_delta("Hello ")
+            yield _make_delta("world")
+            yield _make_final_response("Hello world")
+
+        mock_client.acreate_stream = MagicMock(return_value=mock_stream())
 
         agent = _make_test_agent(mock_client)
-        events = _collect_events(agent.run_stream("test request"))
+        events = await _collect_stream_events(agent, "test request")
 
         # Verify text_delta events
         text_deltas = [e for e in events if e.event_type == "text_delta"]
@@ -171,11 +179,10 @@ class TestStreamSuccessNoRetry:
         assert complete_events[0].data["success"] is True
         assert complete_events[0].data["answer"] == "Hello world"
 
-        # Non-streaming create() should NOT have been called
-        mock_client.create.assert_not_called()
+        # Non-streaming acreate() should NOT have been called
+        mock_client.acreate.assert_not_called()
 
-    @patch("time.sleep")
-    def test_stream_with_tool_calls(self, mock_sleep):
+    async def test_stream_with_tool_calls(self):
         """Stream with tool calls: deltas + tool_call events, no retry."""
         mock_client = MagicMock()
 
@@ -189,24 +196,27 @@ class TestStreamSuccessNoRetry:
             usage=LLMUsage(input_tokens=100, output_tokens=50),
             model="test-model",
         )
-        mock_client.create_stream.side_effect = [
-            iter([
-                _make_delta("Let me check that."),
-                first_response,
-            ]),
-            iter([
-                _make_delta("Here's what I found."),
-                _make_final_response("Here's what I found."),
-            ]),
-        ]
 
-        # Mock tool execution
+        call_count = {"n": 0}
+
+        async def mock_stream(*args, **kwargs):
+            if call_count["n"] == 0:
+                call_count["n"] += 1
+                yield _make_delta("Let me check that.")
+                yield first_response
+            else:
+                yield _make_delta("Here's what I found.")
+                yield _make_final_response("Here's what I found.")
+
+        mock_client.acreate_stream = MagicMock(side_effect=lambda *a, **kw: mock_stream())
+
         agent = _make_test_agent(mock_client)
         agent.tool_functions = {
             "web_search": lambda **kwargs: '{"results": []}',
         }
 
-        events = _collect_events(agent.run_stream("search for test"))
+        with patch("app.agent.agent.acall_tool", new_callable=AsyncMock, return_value='{"results": []}'):
+            events = await _collect_stream_events(agent, "search for test")
 
         # Verify events sequence
         event_types = [e.event_type for e in events]
@@ -216,37 +226,37 @@ class TestStreamSuccessNoRetry:
         assert "tool_result" in event_types
         assert "complete" in event_types
 
-        # create() should NOT have been called
-        mock_client.create.assert_not_called()
+        # acreate() should NOT have been called
+        mock_client.acreate.assert_not_called()
 
 
 # ===================================================================
 # Class 3: Stream failure with successful retry
 # ===================================================================
 
+@pytest.mark.asyncio
 class TestStreamFailRetrySuccess:
-    """Stream fails with retryable error, non-streaming create() fallback succeeds."""
+    """Stream fails with retryable error, non-streaming acreate() fallback succeeds."""
 
-    @patch("time.sleep")
-    def test_partial_deltas_then_retry(self, mock_sleep):
-        """Stream yields partial deltas, then fails. Retry with create() succeeds."""
+    async def test_partial_deltas_then_retry(self):
+        """Stream yields partial deltas, then fails. Retry with acreate() succeeds."""
         mock_client = MagicMock()
 
-        # create_stream yields some deltas then raises connection error
-        def failing_stream(*args, **kwargs):
+        # acreate_stream yields some deltas then raises connection error
+        async def failing_stream(*args, **kwargs):
             yield _make_delta("I'll analyze ")
             yield _make_delta("the data")
             raise Exception("peer closed connection without sending complete message body (incomplete chunked read)")
 
-        mock_client.create_stream.side_effect = failing_stream
+        mock_client.acreate_stream = MagicMock(return_value=failing_stream())
 
-        # Non-streaming create() fallback succeeds
-        mock_client.create.return_value = _make_final_response(
+        # Non-streaming acreate() fallback succeeds
+        mock_client.acreate = AsyncMock(return_value=_make_final_response(
             "I'll analyze the data and create a report."
-        )
+        ))
 
         agent = _make_test_agent(mock_client)
-        events = _collect_events(agent.run_stream("analyze data"))
+        events = await _collect_stream_events(agent, "analyze data")
 
         # Verify partial text_delta events were emitted before failure
         text_deltas = [e for e in events if e.event_type == "text_delta"]
@@ -254,34 +264,29 @@ class TestStreamFailRetrySuccess:
         assert text_deltas[0].data["text"] == "I'll analyze "
         assert text_deltas[1].data["text"] == "the data"
 
-        # Verify retry was attempted (create() called once)
-        mock_client.create.assert_called_once()
+        # Verify retry was attempted (acreate() called once)
+        mock_client.acreate.assert_called_once()
 
         # Verify complete event from successful retry
         complete_events = [e for e in events if e.event_type == "complete"]
         assert len(complete_events) == 1
         assert complete_events[0].data["success"] is True
 
-        # Verify sleep was called for retry delay
-        mock_sleep.assert_called()
-
-    @patch("time.sleep")
-    def test_no_deltas_then_retry(self, mock_sleep):
+    async def test_no_deltas_then_retry(self):
         """Stream fails immediately (no deltas). Retry succeeds."""
         mock_client = MagicMock()
 
-        # create_stream fails immediately
-        def failing_stream(*args, **kwargs):
+        async def failing_stream(*args, **kwargs):
             raise Exception("Connection timeout")
-            yield  # make it a generator
+            yield  # make it an async generator
 
-        mock_client.create_stream.side_effect = failing_stream
+        mock_client.acreate_stream = MagicMock(return_value=failing_stream())
 
         # Retry succeeds
-        mock_client.create.return_value = _make_final_response("Response from retry")
+        mock_client.acreate = AsyncMock(return_value=_make_final_response("Response from retry"))
 
         agent = _make_test_agent(mock_client)
-        events = _collect_events(agent.run_stream("test"))
+        events = await _collect_stream_events(agent, "test")
 
         # No text_delta events (stream failed immediately)
         text_deltas = [e for e in events if e.event_type == "text_delta"]
@@ -293,22 +298,21 @@ class TestStreamFailRetrySuccess:
         assert complete_events[0].data["success"] is True
         assert complete_events[0].data["answer"] == "Response from retry"
 
-    @patch("time.sleep")
-    def test_retry_preserves_token_counts(self, mock_sleep):
+    async def test_retry_preserves_token_counts(self):
         """Verify token usage is correctly tracked from the retry response."""
         mock_client = MagicMock()
 
-        def failing_stream(*args, **kwargs):
+        async def failing_stream(*args, **kwargs):
             raise Exception("502 Bad Gateway")
             yield
 
-        mock_client.create_stream.side_effect = failing_stream
-        mock_client.create.return_value = _make_final_response(
+        mock_client.acreate_stream = MagicMock(return_value=failing_stream())
+        mock_client.acreate = AsyncMock(return_value=_make_final_response(
             "OK", input_tokens=200, output_tokens=80
-        )
+        ))
 
         agent = _make_test_agent(mock_client)
-        events = _collect_events(agent.run_stream("test"))
+        events = await _collect_stream_events(agent, "test")
 
         complete = [e for e in events if e.event_type == "complete"][0]
         assert complete.data["total_input_tokens"] == 200
@@ -319,23 +323,23 @@ class TestStreamFailRetrySuccess:
 # Class 4: Stream failure, retry also fails
 # ===================================================================
 
+@pytest.mark.asyncio
 class TestStreamFailRetryFail:
     """Both stream and retry fail — proper error propagation."""
 
-    @patch("time.sleep")
-    def test_both_fail_emits_error_complete(self, mock_sleep):
+    async def test_both_fail_emits_error_complete(self):
         """Stream fails, retry fails → complete event with success=False."""
         mock_client = MagicMock()
 
-        def failing_stream(*args, **kwargs):
+        async def failing_stream(*args, **kwargs):
             raise Exception("peer closed connection (incomplete chunked read)")
             yield
 
-        mock_client.create_stream.side_effect = failing_stream
-        mock_client.create.side_effect = Exception("Still failing: connection refused")
+        mock_client.acreate_stream = MagicMock(return_value=failing_stream())
+        mock_client.acreate = AsyncMock(side_effect=Exception("Still failing: connection refused"))
 
         agent = _make_test_agent(mock_client)
-        events = _collect_events(agent.run_stream("test"))
+        events = await _collect_stream_events(agent, "test")
 
         # Verify error complete event
         complete_events = [e for e in events if e.event_type == "complete"]
@@ -344,21 +348,20 @@ class TestStreamFailRetryFail:
         assert "failed" in complete_events[0].data["answer"].lower() or \
                "unsuccessful" in complete_events[0].data["answer"].lower()
 
-    @patch("time.sleep")
-    def test_both_fail_no_crash(self, mock_sleep):
-        """Even when both fail, run_stream() returns cleanly (no exception)."""
+    async def test_both_fail_no_crash(self):
+        """Even when both fail, run() returns cleanly (no exception)."""
         mock_client = MagicMock()
 
-        def failing_stream(*args, **kwargs):
+        async def failing_stream(*args, **kwargs):
             yield _make_delta("partial")
             raise Exception("503 Service Unavailable")
 
-        mock_client.create_stream.side_effect = failing_stream
-        mock_client.create.side_effect = Exception("503 Service Unavailable")
+        mock_client.acreate_stream = MagicMock(return_value=failing_stream())
+        mock_client.acreate = AsyncMock(side_effect=Exception("503 Service Unavailable"))
 
         agent = _make_test_agent(mock_client)
         # Should not raise — errors are channeled through events
-        events = _collect_events(agent.run_stream("test"))
+        events = await _collect_stream_events(agent, "test")
 
         # Partial delta still present
         text_deltas = [e for e in events if e.event_type == "text_delta"]
@@ -370,22 +373,21 @@ class TestStreamFailRetryFail:
         assert len(complete_events) == 1
         assert complete_events[0].data["success"] is False
 
-    @patch("time.sleep")
-    def test_partial_deltas_preserved_on_total_failure(self, mock_sleep):
+    async def test_partial_deltas_preserved_on_total_failure(self):
         """Verify that text_delta events already sent are not lost when everything fails."""
         mock_client = MagicMock()
 
-        def failing_stream(*args, **kwargs):
+        async def failing_stream(*args, **kwargs):
             yield _make_delta("Step 1: ")
             yield _make_delta("Download the file. ")
             yield _make_delta("Step 2: ")
             raise Exception("Connection reset by peer")
 
-        mock_client.create_stream.side_effect = failing_stream
-        mock_client.create.side_effect = Exception("Connection reset by peer")
+        mock_client.acreate_stream = MagicMock(return_value=failing_stream())
+        mock_client.acreate = AsyncMock(side_effect=Exception("Connection reset by peer"))
 
         agent = _make_test_agent(mock_client)
-        events = _collect_events(agent.run_stream("test"))
+        events = await _collect_stream_events(agent, "test")
 
         # All 3 partial deltas should be present in the events
         text_deltas = [e for e in events if e.event_type == "text_delta"]
@@ -398,46 +400,45 @@ class TestStreamFailRetryFail:
 # Class 5: Non-retryable error (no retry attempted)
 # ===================================================================
 
+@pytest.mark.asyncio
 class TestNonRetryableErrorNoRetry:
     """Non-retryable errors should skip retry and return error immediately."""
 
-    @patch("time.sleep")
-    def test_auth_error_no_retry(self, mock_sleep):
+    async def test_auth_error_no_retry(self):
         """Authentication error: no retry, immediate error."""
         mock_client = MagicMock()
 
-        def failing_stream(*args, **kwargs):
+        async def failing_stream(*args, **kwargs):
             raise Exception("Invalid API key: authentication failed")
             yield
 
-        mock_client.create_stream.side_effect = failing_stream
+        mock_client.acreate_stream = MagicMock(return_value=failing_stream())
 
         agent = _make_test_agent(mock_client)
-        events = _collect_events(agent.run_stream("test"))
+        events = await _collect_stream_events(agent, "test")
 
-        # create() should NOT have been called (non-retryable)
-        mock_client.create.assert_not_called()
+        # acreate() should NOT have been called (non-retryable)
+        mock_client.acreate.assert_not_called()
 
         # Error complete event
         complete_events = [e for e in events if e.event_type == "complete"]
         assert len(complete_events) == 1
         assert complete_events[0].data["success"] is False
 
-    @patch("time.sleep")
-    def test_validation_error_no_retry(self, mock_sleep):
+    async def test_validation_error_no_retry(self):
         """Validation error: no retry."""
         mock_client = MagicMock()
 
-        def failing_stream(*args, **kwargs):
+        async def failing_stream(*args, **kwargs):
             raise Exception("Invalid request body: tool schema mismatch")
             yield
 
-        mock_client.create_stream.side_effect = failing_stream
+        mock_client.acreate_stream = MagicMock(return_value=failing_stream())
 
         agent = _make_test_agent(mock_client)
-        events = _collect_events(agent.run_stream("test"))
+        events = await _collect_stream_events(agent, "test")
 
-        mock_client.create.assert_not_called()
+        mock_client.acreate.assert_not_called()
 
         complete_events = [e for e in events if e.event_type == "complete"]
         assert len(complete_events) == 1
@@ -445,7 +446,7 @@ class TestNonRetryableErrorNoRetry:
 
 
 # ===================================================================
-# Class 6: SSE endpoint with stream error events
+# Class 6: SSE endpoint with stream events
 # ===================================================================
 
 def _parse_sse_events(text: str):
@@ -465,7 +466,6 @@ def _parse_sse_events(text: str):
 def _mock_async_session():
     """Return a callable that produces async-context-manager sessions (no-op DB)."""
     from contextlib import asynccontextmanager
-    from unittest.mock import AsyncMock
 
     @asynccontextmanager
     async def _ctx():
@@ -479,6 +479,46 @@ def _mock_async_session():
     return _ctx
 
 
+def _make_mock_agent_with_events(events_to_push):
+    """Create a mock SkillsAgent whose run() pushes events to event_stream.
+
+    events_to_push: list of StreamEvent objects to push into the event_stream.
+    """
+    from app.agent.agent import AgentResult
+
+    mock_instance = MagicMock()
+
+    # Extract result data from complete event
+    complete_event = next((e for e in events_to_push if e.event_type == "complete"), None)
+    if complete_event:
+        result = AgentResult(
+            success=complete_event.data.get("success", False),
+            answer=complete_event.data.get("answer", ""),
+            total_turns=complete_event.data.get("total_turns", 0),
+            total_input_tokens=complete_event.data.get("total_input_tokens", 0),
+            total_output_tokens=complete_event.data.get("total_output_tokens", 0),
+            skills_used=complete_event.data.get("skills_used", []),
+            output_files=complete_event.data.get("output_files", []),
+            final_messages=complete_event.data.get("final_messages", []),
+        )
+    else:
+        result = AgentResult(success=False, answer="No complete event")
+
+    async def mock_run(request, conversation_history=None, image_contents=None,
+                       event_stream=None, cancellation_event=None):
+        if event_stream:
+            for event in events_to_push:
+                await event_stream.push(event)
+            await event_stream.close()
+        return result
+
+    mock_instance.run = AsyncMock(side_effect=mock_run)
+    mock_instance.cleanup = MagicMock()
+    mock_instance.model = "test-model"
+    mock_instance.model_provider = "test"
+    return mock_instance
+
+
 @pytest.mark.asyncio
 class TestStreamRetrySSE:
     """Test that the SSE endpoint properly handles text_delta + error from stream retry scenarios."""
@@ -487,14 +527,11 @@ class TestStreamRetrySSE:
     @patch("app.api.v1.agent.SkillsAgent")
     async def test_sse_with_text_deltas(self, MockAgent, MockSessionLocal, client):
         """SSE stream carries text_delta events from normal streaming."""
-        from types import SimpleNamespace
-
-        mock_instance = MagicMock()
-        mock_instance.run_stream.return_value = iter([
-            SimpleNamespace(event_type="turn_start", turn=1, data={"max_turns": 60}),
-            SimpleNamespace(event_type="text_delta", turn=1, data={"text": "Hello "}),
-            SimpleNamespace(event_type="text_delta", turn=1, data={"text": "world!"}),
-            SimpleNamespace(
+        mock_instance = _make_mock_agent_with_events([
+            StreamEvent(event_type="turn_start", turn=1, data={"max_turns": 60}),
+            StreamEvent(event_type="text_delta", turn=1, data={"text": "Hello "}),
+            StreamEvent(event_type="text_delta", turn=1, data={"text": "world!"}),
+            StreamEvent(
                 event_type="complete", turn=1,
                 data={
                     "success": True,
@@ -507,8 +544,6 @@ class TestStreamRetrySSE:
                 },
             ),
         ])
-        mock_instance.model = "test-model"
-        mock_instance.model_provider = "test"
         MockAgent.return_value = mock_instance
         MockSessionLocal.side_effect = lambda: _mock_async_session()()
 
@@ -532,13 +567,10 @@ class TestStreamRetrySSE:
     @patch("app.api.v1.agent.SkillsAgent")
     async def test_sse_with_error_after_deltas(self, MockAgent, MockSessionLocal, client):
         """SSE stream: text_deltas followed by error complete (simulates failed retry)."""
-        from types import SimpleNamespace
-
-        mock_instance = MagicMock()
-        mock_instance.run_stream.return_value = iter([
-            SimpleNamespace(event_type="turn_start", turn=1, data={"max_turns": 60}),
-            SimpleNamespace(event_type="text_delta", turn=1, data={"text": "partial output "}),
-            SimpleNamespace(
+        mock_instance = _make_mock_agent_with_events([
+            StreamEvent(event_type="turn_start", turn=1, data={"max_turns": 60}),
+            StreamEvent(event_type="text_delta", turn=1, data={"text": "partial output "}),
+            StreamEvent(
                 event_type="complete", turn=1,
                 data={
                     "success": False,
@@ -551,8 +583,6 @@ class TestStreamRetrySSE:
                 },
             ),
         ])
-        mock_instance.model = "test-model"
-        mock_instance.model_provider = "test"
         MockAgent.return_value = mock_instance
         MockSessionLocal.side_effect = lambda: _mock_async_session()()
 
@@ -580,23 +610,20 @@ class TestStreamRetrySSE:
         self, MockAgent, MockSessionLocal, client
     ):
         """Verify text_delta events are relayed and ordered correctly in SSE output."""
-        from types import SimpleNamespace
-
-        mock_instance = MagicMock()
-        mock_instance.run_stream.return_value = iter([
-            SimpleNamespace(event_type="turn_start", turn=1, data={"max_turns": 60}),
-            SimpleNamespace(event_type="text_delta", turn=1, data={"text": "Part 1. "}),
-            SimpleNamespace(event_type="text_delta", turn=1, data={"text": "Part 2. "}),
-            SimpleNamespace(
+        mock_instance = _make_mock_agent_with_events([
+            StreamEvent(event_type="turn_start", turn=1, data={"max_turns": 60}),
+            StreamEvent(event_type="text_delta", turn=1, data={"text": "Part 1. "}),
+            StreamEvent(event_type="text_delta", turn=1, data={"text": "Part 2. "}),
+            StreamEvent(
                 event_type="tool_call", turn=1,
                 data={"tool_name": "execute_code", "tool_input": {"code": "print(1)"}},
             ),
-            SimpleNamespace(
+            StreamEvent(
                 event_type="tool_result", turn=1,
                 data={"tool_name": "execute_code", "tool_result": "1", "tool_input": {"code": "print(1)"}},
             ),
-            SimpleNamespace(event_type="text_delta", turn=1, data={"text": "Done."}),
-            SimpleNamespace(
+            StreamEvent(event_type="text_delta", turn=1, data={"text": "Done."}),
+            StreamEvent(
                 event_type="complete", turn=1,
                 data={
                     "success": True,
@@ -609,8 +636,6 @@ class TestStreamRetrySSE:
                 },
             ),
         ])
-        mock_instance.model = "test-model"
-        mock_instance.model_provider = "test"
         MockAgent.return_value = mock_instance
         MockSessionLocal.side_effect = lambda: _mock_async_session()()
 

--- a/web/src/components/chat/chat-panel.tsx
+++ b/web/src/components/chat/chat-panel.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import { flushSync } from "react-dom";
 import Link from "next/link";
 import { useQuery } from "@tanstack/react-query";
-import { RotateCcw, Paperclip, X, Wrench, Plug, ChevronDown, ChevronUp, Square, Bot, Cpu, Maximize2, Server } from "lucide-react";
+import { RotateCcw, Paperclip, X, Wrench, Plug, ChevronDown, ChevronUp, Square, Bot, Cpu, Maximize2, Server, Navigation } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Input } from "@/components/ui/input";
@@ -181,9 +181,28 @@ export function ChatPanel({ isOpen, onClose, defaultSkills = [] }: ChatPanelProp
     }
   }, [agentPresets, selectedAgentPreset, systemPrompt, setSystemPrompt]);
 
+  const handleSteer = async (message: string) => {
+    const traceId = currentTraceIdRef.current;
+    if (!traceId) return;
+    try {
+      await agentApi.steerAgent(traceId, message);
+      setInput("");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to send steering message");
+    }
+  };
+
   const handleSubmit = async () => {
-    // Use store.getState() to avoid stale closure - prevents concurrent runs from double-clicks
-    if (!input.trim() || useChatStore.getState().isRunning) return;
+    if (!input.trim()) return;
+
+    // Steering mode: inject message into running agent
+    if (useChatStore.getState().isRunning && currentTraceIdRef.current) {
+      await handleSteer(input.trim());
+      return;
+    }
+
+    // Normal mode: prevent concurrent runs
+    if (useChatStore.getState().isRunning) return;
 
     // Create abort controller for this request
     const abortController = new AbortController();
@@ -826,9 +845,8 @@ export function ChatPanel({ isOpen, onClose, defaultSkills = [] }: ChatPanelProp
             value={input}
             onChange={(e) => setInput(e.target.value)}
             onKeyDown={handleKeyDown}
-            placeholder="Type your request..."
+            placeholder={isRunning ? "Steer the agent..." : "Type your request..."}
             className="min-h-[80px] resize-none"
-            disabled={isRunning}
           />
         </div>
         <div className="flex justify-between items-center mt-2">
@@ -856,10 +874,16 @@ export function ChatPanel({ isOpen, onClose, defaultSkills = [] }: ChatPanelProp
             </span>
           </div>
           {isRunning ? (
-            <Button onClick={handleStop} variant="destructive">
-              <Square className="h-4 w-4 mr-1" />
-              Stop
-            </Button>
+            <div className="flex items-center gap-2">
+              <Button onClick={handleStop} variant="destructive" size="sm">
+                <Square className="h-4 w-4 mr-1" />
+                Stop
+              </Button>
+              <Button onClick={handleSubmit} disabled={!input.trim()} size="sm">
+                <Navigation className="h-4 w-4 mr-1" />
+                Steer
+              </Button>
+            </div>
           ) : (
             <Button onClick={handleSubmit} disabled={!input.trim()}>
               Send

--- a/web/src/components/chat/stream-events/index.tsx
+++ b/web/src/components/chat/stream-events/index.tsx
@@ -8,6 +8,7 @@ import { ToolResultItem } from "./tool-result-item";
 import { OutputFileCard } from "./output-file-card";
 import { CompleteBanner } from "./complete-banner";
 import { ErrorBanner } from "./error-banner";
+import { SteeringMessage } from "./steering-message";
 
 interface StreamEventsRendererProps {
   events: StreamEventRecord[];
@@ -57,6 +58,9 @@ export function StreamEventsRenderer({ events, expandAll = false, isStreaming = 
           case 'error':
             return <ErrorBanner key={event.id} data={event.data} />;
 
+          case 'steering_received':
+            return <SteeringMessage key={event.id} data={event.data} />;
+
           // run_started and trace_saved don't have visible UI
           case 'run_started':
           case 'trace_saved':
@@ -78,3 +82,4 @@ export { ToolResultItem } from "./tool-result-item";
 export { OutputFileCard } from "./output-file-card";
 export { CompleteBanner } from "./complete-banner";
 export { ErrorBanner } from "./error-banner";
+export { SteeringMessage } from "./steering-message";

--- a/web/src/components/chat/stream-events/steering-message.tsx
+++ b/web/src/components/chat/stream-events/steering-message.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { Navigation } from "lucide-react";
+import type { SteeringReceivedData } from "@/types/stream-events";
+
+interface SteeringMessageProps {
+  data: SteeringReceivedData;
+}
+
+/**
+ * Renders a steering message injected by the user during agent execution.
+ * Displayed as a compact right-aligned bubble with a steering icon.
+ */
+export function SteeringMessage({ data }: SteeringMessageProps) {
+  return (
+    <div className="flex justify-end my-2">
+      <div className="inline-flex items-start gap-2 max-w-[80%] rounded-lg bg-blue-50 dark:bg-blue-950/40 border border-blue-200 dark:border-blue-800 px-3 py-2 text-sm">
+        <Navigation className="h-4 w-4 text-blue-500 mt-0.5 shrink-0" />
+        <div>
+          <span className="text-xs font-medium text-blue-600 dark:text-blue-400">Steering</span>
+          <p className="text-foreground mt-0.5">{data.message}</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/i18n/locales/en-US/chat.json
+++ b/web/src/i18n/locales/en-US/chat.json
@@ -78,5 +78,10 @@
     "user": "You",
     "assistant": "Assistant",
     "system": "System"
+  },
+  "steering": {
+    "placeholder": "Steer the agent...",
+    "button": "Steer",
+    "label": "Steering"
   }
 }

--- a/web/src/i18n/locales/es/chat.json
+++ b/web/src/i18n/locales/es/chat.json
@@ -78,5 +78,10 @@
     "user": "Tú",
     "assistant": "Asistente",
     "system": "Sistema"
+  },
+  "steering": {
+    "placeholder": "Dirigir al agente...",
+    "button": "Dirigir",
+    "label": "Dirección"
   }
 }

--- a/web/src/i18n/locales/ja/chat.json
+++ b/web/src/i18n/locales/ja/chat.json
@@ -78,5 +78,10 @@
     "user": "あなた",
     "assistant": "アシスタント",
     "system": "システム"
+  },
+  "steering": {
+    "placeholder": "エージェントを操舵...",
+    "button": "操舵",
+    "label": "ステアリング"
   }
 }

--- a/web/src/i18n/locales/pt-BR/chat.json
+++ b/web/src/i18n/locales/pt-BR/chat.json
@@ -78,5 +78,10 @@
     "user": "Você",
     "assistant": "Assistente",
     "system": "Sistema"
+  },
+  "steering": {
+    "placeholder": "Direcionar o agente...",
+    "button": "Direcionar",
+    "label": "Direcionamento"
   }
 }

--- a/web/src/i18n/locales/zh-CN/chat.json
+++ b/web/src/i18n/locales/zh-CN/chat.json
@@ -78,5 +78,10 @@
     "user": "你",
     "assistant": "助手",
     "system": "系统"
+  },
+  "steering": {
+    "placeholder": "引导 Agent...",
+    "button": "引导",
+    "label": "引导消息"
   }
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -710,7 +710,7 @@ const AGENT_API_BASE = BACKEND_API_BASE;
 
 // Stream event types
 export interface StreamEvent {
-  event_type: 'run_started' | 'turn_start' | 'text_delta' | 'assistant' | 'tool_call' | 'tool_result' | 'output_file' | 'complete' | 'error' | 'trace_saved';
+  event_type: 'run_started' | 'turn_start' | 'text_delta' | 'assistant' | 'tool_call' | 'tool_result' | 'output_file' | 'complete' | 'error' | 'trace_saved' | 'steering_received';
   turn: number;
   // For turn_start
   max_turns?: number;
@@ -832,6 +832,21 @@ export const agentApi = {
           }
         }
       }
+    }
+  },
+
+  steerAgent: async (traceId: string, message: string): Promise<void> => {
+    const response = await fetch(
+      `${AGENT_API_BASE}/agent/run/stream/${encodeURIComponent(traceId)}/steer`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message }),
+      }
+    );
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({}));
+      throw new Error(error.detail || `Steer failed: ${response.statusText}`);
     }
   },
 };
@@ -1359,6 +1374,21 @@ export const publishedAgentApi = {
           }
         }
       }
+    }
+  },
+
+  steerAgent: async (agentId: string, traceId: string, message: string): Promise<void> => {
+    const response = await fetch(
+      `${PUBLISHED_API_BASE}/published/${encodeURIComponent(agentId)}/chat/${encodeURIComponent(traceId)}/steer`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message }),
+      }
+    );
+    if (!response.ok) {
+      const error = await response.json().catch(() => ({}));
+      throw new Error(error.detail || `Steer failed: ${response.statusText}`);
     }
   },
 

--- a/web/src/lib/stream-utils.ts
+++ b/web/src/lib/stream-utils.ts
@@ -14,6 +14,7 @@ import type {
   ErrorRecord,
   RunStartedRecord,
   TraceSavedRecord,
+  SteeringReceivedRecord,
 } from '@/types/stream-events';
 
 let eventIdCounter = 0;
@@ -135,6 +136,15 @@ export function mapEventToRecord(event: StreamEvent): StreamEventRecord | null {
         },
       } as TraceSavedRecord;
 
+    case 'steering_received':
+      return {
+        ...base,
+        type: 'steering_received',
+        data: {
+          message: event.message || '',
+        },
+      } as SteeringReceivedRecord;
+
     default:
       return null;
   }
@@ -222,6 +232,10 @@ export function serializeEventsToText(events: StreamEventRecord[]): string {
 
       case 'error':
         result += `\n❌ Error: ${event.data.message}\n`;
+        break;
+
+      case 'steering_received':
+        result += `\n🎯 Steering: ${event.data.message}\n`;
         break;
 
       // run_started and trace_saved don't produce visible text

--- a/web/src/types/stream-events.ts
+++ b/web/src/types/stream-events.ts
@@ -115,6 +115,16 @@ export interface TraceSavedRecord extends StreamEventRecordBase {
   data: TraceSavedData;
 }
 
+// Steering received event data
+export interface SteeringReceivedData {
+  message: string;
+}
+
+export interface SteeringReceivedRecord extends StreamEventRecordBase {
+  type: 'steering_received';
+  data: SteeringReceivedData;
+}
+
 // Union type of all stream event records
 export type StreamEventRecord =
   | TurnStartRecord
@@ -125,7 +135,8 @@ export type StreamEventRecord =
   | CompleteRecord
   | ErrorRecord
   | RunStartedRecord
-  | TraceSavedRecord;
+  | TraceSavedRecord
+  | SteeringReceivedRecord;
 
 // Type guard functions
 export function isTurnStartRecord(record: StreamEventRecord): record is TurnStartRecord {


### PR DESCRIPTION
## Summary

- Allow users to inject steering messages into a running agent to redirect behavior at tool boundaries, without stopping the run
- Hybrid multi-worker support: same-worker in-memory fast path + cross-worker filesystem queue with atomic writes
- Frontend input stays active during agent runs with dedicated Steer mode and button

## Changes

**Backend:**
- `EventStream` bidirectional communication (push events + inject messages)
- Cross-worker filesystem queue (`/tmp/agent_steering/`) with atomic write-then-rename
- `POST /agent/run/stream/{trace_id}/steer` and `POST /published/{agent_id}/chat/{trace_id}/steer` endpoints
- Agent loop checks steering at tool boundaries and before `end_turn`

**Frontend:**
- Input unlocked during runs, Steer button replaces Send
- `steering_received` SSE event rendered as blue right-aligned bubble
- API client methods for both agent and published agent steering
- i18n support (5 languages)

**Docs:**
- Steering section in `concepts/agents.md`
- Steer endpoints in `reference/api.md`
- Updated `how-to/publish-agent.md`, `how-to/run-tests.md`, `faq.md`

## Test plan

- [x] 387 unit tests passing
- [x] 168 E2E tests passing
- [x] Docker deployed and all services healthy