### PR TITLE
feat: unify chat panel with server-side session management

### DIFF
--- a/app/api/v1/agent.py
+++ b/app/api/v1/agent.py
@@ -15,6 +15,7 @@ from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.agent import SkillsAgent, EventStream, write_steering_message, poll_steering_messages, cleanup_steering_dir
+from app.api.v1.sessions import load_or_create_session, save_session_messages, CHAT_SENTINEL_AGENT_ID
 from app.db.database import get_db, AsyncSessionLocal, SyncSessionLocal
 from app.db.models import AgentTraceDB, AgentPresetDB
 
@@ -64,12 +65,6 @@ async def _finalize_trace(trace_id: str, values: dict):
             logger.error(f"Sync trace update also failed for {trace_id}: {e2}")
 
 
-class ConversationMessage(BaseModel):
-    """A message in the conversation history"""
-    role: str = Field(..., description="Message role: 'user' or 'assistant'")
-    content: str = Field(..., description="Message content")
-
-
 class UploadedFile(BaseModel):
     """Info about an uploaded file"""
     file_id: str
@@ -91,9 +86,8 @@ class AgentRequest(BaseModel):
     skills: Optional[List[str]] = Field(None, description="List of skill names to activate (None = all available)")
     allowed_tools: Optional[List[str]] = Field(None, description="List of tool names to enable (None = all available)")
     max_turns: int = Field(60, description="Maximum turns before stopping", ge=1, le=60000)
-    conversation_history: Optional[List[ConversationMessage]] = Field(
-        None, description="Previous conversation messages for multi-turn dialogue"
-    )
+    session_id: str = Field(..., description="Session ID for server-side session management. "
+                                             "History is loaded from DB automatically.")
     uploaded_files: Optional[List[UploadedFile]] = Field(
         None, description="List of uploaded files available to the agent"
     )
@@ -337,10 +331,9 @@ async def run_agent(request: AgentRequest, db: AsyncSession = Depends(get_db)):
     agent = _create_agent(config)
 
     try:
-        # Convert conversation history to dict format for agent
-        history = None
-        if request.conversation_history:
-            history = [{"role": msg.role, "content": msg.content} for msg in request.conversation_history]
+        # Load session history from DB
+        agent_id = config.get("agent_id") or CHAT_SENTINEL_AGENT_ID
+        session_id, history = await load_or_create_session(request.session_id, agent_id)
 
         # Build the actual request with file info and image blocks
         actual_request, image_contents = _build_request_with_files(
@@ -373,6 +366,14 @@ async def run_agent(request: AgentRequest, db: AsyncSession = Depends(get_db)):
         )
         db.add(trace)
         await db.commit()
+
+        # Save session messages
+        await save_session_messages(
+            session_id,
+            result.answer,
+            request.request,
+            final_messages=getattr(result, "final_messages", None),
+        )
 
         return AgentResponse(
             success=result.success,
@@ -422,10 +423,9 @@ async def run_agent_stream(request: AgentRequest, db: AsyncSession = Depends(get
         model_name=config.get("model_name"),
     )
 
-    # Convert conversation history
-    history = None
-    if request.conversation_history:
-        history = [{"role": msg.role, "content": msg.content} for msg in request.conversation_history]
+    # Load session history from DB
+    agent_id_for_session = config.get("agent_id") or CHAT_SENTINEL_AGENT_ID
+    session_id, history = await load_or_create_session(request.session_id, agent_id_for_session)
 
     async def event_generator():
         start_time = time.time()
@@ -456,8 +456,8 @@ async def run_agent_stream(request: AgentRequest, db: AsyncSession = Depends(get
             await trace_db.commit()
             trace_id = trace.id
 
-        # Send run_started event with trace_id immediately
-        yield f"data: {json.dumps({'event_type': 'run_started', 'turn': 0, 'trace_id': trace_id})}\n\n"
+        # Send run_started event with trace_id and session_id immediately
+        yield f"data: {json.dumps({'event_type': 'run_started', 'turn': 0, 'trace_id': trace_id, 'session_id': session_id})}\n\n"
 
         # Create agent, event stream, and cancellation event
         agent = SkillsAgent(
@@ -595,6 +595,16 @@ async def run_agent_stream(request: AgentRequest, db: AsyncSession = Depends(get
                 "steps": collected_steps,
                 "duration_ms": duration_ms,
             })
+
+            # Save full conversation messages to session
+            if not was_cancelled and session_id and last_complete_event:
+                final_answer = last_complete_event.get("answer", "")
+                await save_session_messages(
+                    session_id,
+                    final_answer,
+                    request.request,
+                    final_messages=last_complete_event.get("final_messages"),
+                )
 
         if not was_cancelled:
             yield f"data: {json.dumps({'event_type': 'trace_saved', 'turn': 0, 'trace_id': trace_id})}\n\n"

--- a/app/api/v1/sessions.py
+++ b/app/api/v1/sessions.py
@@ -1,0 +1,97 @@
+"""Shared session management helpers.
+
+Used by both the agent (chat panel) and published agent endpoints
+to load/create/save server-side sessions via PublishedSessionDB.
+"""
+from datetime import datetime
+from typing import Optional, Tuple, List
+
+from sqlalchemy import select, update
+
+from app.db.database import AsyncSessionLocal
+from app.db.models import PublishedSessionDB
+
+# Sentinel agent_id for chat-panel sessions (not tied to a published agent)
+CHAT_SENTINEL_AGENT_ID = "__chat__"
+
+
+async def load_or_create_session(
+    session_id: str,
+    agent_id: str,
+) -> Tuple[str, Optional[List[dict]]]:
+    """Load existing session or create a new one.
+
+    Returns (session_id, history) where history is None for brand-new sessions.
+    """
+    history = None
+
+    async with AsyncSessionLocal() as db:
+        result = await db.execute(
+            select(PublishedSessionDB).where(
+                PublishedSessionDB.id == session_id,
+                PublishedSessionDB.agent_id == agent_id,
+            )
+        )
+        session_record = result.scalar_one_or_none()
+
+        if session_record:
+            history = session_record.messages or []
+        else:
+            # Create new session with caller-provided ID
+            new_session = PublishedSessionDB(
+                id=session_id,
+                agent_id=agent_id,
+                messages=[],
+            )
+            db.add(new_session)
+            await db.commit()
+
+    return session_id, history
+
+
+async def save_session_messages(
+    session_id: str,
+    final_answer: str,
+    request_text: str,
+    final_messages: Optional[list] = None,
+) -> None:
+    """Save full conversation messages to session.
+
+    If *final_messages* is provided (the full Anthropic message list from the
+    agent run), it replaces the session messages entirely.  Otherwise we
+    append a simple user/assistant pair.
+    """
+    try:
+        async with AsyncSessionLocal() as session_db:
+            result = await session_db.execute(
+                select(PublishedSessionDB).where(
+                    PublishedSessionDB.id == session_id,
+                )
+            )
+            session_record = result.scalar_one_or_none()
+            if session_record:
+                if final_messages:
+                    await session_db.execute(
+                        update(PublishedSessionDB)
+                        .where(PublishedSessionDB.id == session_id)
+                        .values(
+                            messages=final_messages,
+                            updated_at=datetime.utcnow(),
+                        )
+                    )
+                else:
+                    current_messages = session_record.messages or []
+                    current_messages.append({"role": "user", "content": request_text})
+                    if final_answer:
+                        current_messages.append({"role": "assistant", "content": final_answer})
+                    await session_db.execute(
+                        update(PublishedSessionDB)
+                        .where(PublishedSessionDB.id == session_id)
+                        .values(
+                            messages=current_messages,
+                            updated_at=datetime.utcnow(),
+                        )
+                    )
+                await session_db.commit()
+    except Exception:
+        pass  # Don't fail the response if session save fails

--- a/tests/TESTING_GUIDE.md
+++ b/tests/TESTING_GUIDE.md
@@ -321,7 +321,7 @@ async def test_something(MockAgent, client):
     mock_instance.model = "claude-sonnet-4-5-20250929"
     MockAgent.return_value = mock_instance
 
-    response = await client.post("/api/v1/agent/run", json={"request": "hello"})
+    response = await client.post("/api/v1/agent/run", json={"request": "hello", "session_id": "test-session-id"})
     assert response.status_code == 200
 ```
 

--- a/tests/test_api/test_agent_stream.py
+++ b/tests/test_api/test_agent_stream.py
@@ -132,7 +132,7 @@ async def test_stream_returns_event_stream(MockAgent, client):
 
     response = await client.post(
         "/api/v1/agent/run/stream",
-        json={"request": "hello"},
+        json={"request": "hello", "session_id": "test-session-id"},
     )
     assert response.status_code == 200
     assert "text/event-stream" in response.headers.get("content-type", "")
@@ -147,7 +147,7 @@ async def test_stream_sends_run_started(MockAgent, MockSessionLocal, client, db_
 
     response = await client.post(
         "/api/v1/agent/run/stream",
-        json={"request": "hello"},
+        json={"request": "hello", "session_id": "test-session-id"},
     )
     assert response.status_code == 200
     text = response.text
@@ -168,7 +168,7 @@ async def test_stream_sends_trace_saved(MockAgent, MockSessionLocal, client, db_
 
     response = await client.post(
         "/api/v1/agent/run/stream",
-        json={"request": "hello"},
+        json={"request": "hello", "session_id": "test-session-id"},
     )
     text = response.text
     lines = [l for l in text.strip().split("\n") if l.startswith("data: ")]
@@ -186,7 +186,7 @@ async def test_stream_with_skills(MockAgent, MockSessionLocal, client, db_sessio
 
     response = await client.post(
         "/api/v1/agent/run/stream",
-        json={"request": "hello", "skills": ["test-skill"]},
+        json={"request": "hello", "skills": ["test-skill"], "session_id": "test-session-id"},
     )
     assert response.status_code == 200
     MockAgent.assert_called_once()
@@ -203,7 +203,7 @@ async def test_stream_with_mcp_servers(MockAgent, MockSessionLocal, client, db_s
 
     response = await client.post(
         "/api/v1/agent/run/stream",
-        json={"request": "hello", "equipped_mcp_servers": ["fetch"]},
+        json={"request": "hello", "equipped_mcp_servers": ["fetch"], "session_id": "test-session-id"},
     )
     assert response.status_code == 200
     MockAgent.assert_called_once()
@@ -241,7 +241,7 @@ async def test_stream_error_handling(MockAgent, MockSessionLocal, client, db_ses
 
     response = await client.post(
         "/api/v1/agent/run/stream",
-        json={"request": "hello"},
+        json={"request": "hello", "session_id": "test-session-id"},
     )
     assert response.status_code == 200
     text = response.text

--- a/tests/test_core/test_stream_retry.py
+++ b/tests/test_core/test_stream_retry.py
@@ -549,7 +549,7 @@ class TestStreamRetrySSE:
 
         resp = await client.post(
             "/api/v1/agent/run/stream",
-            json={"request": "test stream with deltas"},
+            json={"request": "test stream with deltas", "session_id": "test-session-id"},
         )
         assert resp.status_code == 200
 
@@ -588,7 +588,7 @@ class TestStreamRetrySSE:
 
         resp = await client.post(
             "/api/v1/agent/run/stream",
-            json={"request": "test stream failure"},
+            json={"request": "test stream failure", "session_id": "test-session-id"},
         )
         assert resp.status_code == 200
 
@@ -641,7 +641,7 @@ class TestStreamRetrySSE:
 
         resp = await client.post(
             "/api/v1/agent/run/stream",
-            json={"request": "test delta buffer"},
+            json={"request": "test delta buffer", "session_id": "test-session-id"},
         )
         assert resp.status_code == 200
 

--- a/tests/test_e2e/test_e2e_agent_real.py
+++ b/tests/test_e2e/test_e2e_agent_real.py
@@ -63,6 +63,8 @@ class TestRealAgentE2E:
 
     async def test_02_first_message(self, e2e_client: AsyncClient):
         """Send a simple message and validate response structure."""
+        session_id = "e2e-real-session-001"
+        type(self)._state["session_id"] = session_id
         with _patch_api_key():
             resp = await e2e_client.post(
                 "/api/v1/agent/run",
@@ -71,6 +73,7 @@ class TestRealAgentE2E:
                     "max_turns": 3,
                     "model_provider": "kimi",
                     "model_name": "kimi-k2.5",
+                    "session_id": session_id,
                 },
             )
         assert resp.status_code == 200
@@ -83,18 +86,14 @@ class TestRealAgentE2E:
         type(self)._state["first_answer"] = body["answer"]
 
     async def test_03_follow_up(self, e2e_client: AsyncClient):
-        """Send a follow-up message with conversation history."""
-        first_answer = type(self)._state.get("first_answer", "")
-        history = [
-            {"role": "user", "content": "Hello, please respond with exactly one sentence."},
-            {"role": "assistant", "content": first_answer},
-        ]
+        """Send a follow-up message using the same session (history loaded from DB)."""
+        session_id = type(self)._state["session_id"]
         with _patch_api_key():
             resp = await e2e_client.post(
                 "/api/v1/agent/run",
                 json={
                     "request": "Summarize what you just said in one word.",
-                    "conversation_history": history,
+                    "session_id": session_id,
                     "max_turns": 3,
                     "model_provider": "kimi",
                     "model_name": "kimi-k2.5",
@@ -136,6 +135,7 @@ class TestRealAgentE2E:
                     "max_turns": 3,
                     "model_provider": "kimi",
                     "model_name": "kimi-k2.5",
+                    "session_id": "e2e-real-stream-session",
                 },
             )
         assert resp.status_code == 200
@@ -268,6 +268,7 @@ class TestRealEvolveE2E:
                     "max_turns": 5,
                     "model_provider": "kimi",
                     "model_name": "kimi-k2.5",
+                    "session_id": "e2e-evolve-session",
                 },
                 timeout=120,
             )
@@ -438,6 +439,7 @@ class TestRealImportLifecycleE2E:
                     "max_turns": 5,
                     "model_provider": "kimi",
                     "model_name": "kimi-k2.5",
+                    "session_id": "e2e-import-session",
                 },
                 timeout=120,
             )

--- a/tests/test_e2e/test_e2e_data_analysis.py
+++ b/tests/test_e2e/test_e2e_data_analysis.py
@@ -349,6 +349,7 @@ class FullDataAnalysisTestBase:
                     "model_provider": config["model_provider"],
                     "model_name": config["model_name"],
                     "max_turns": 30,
+                    "session_id": "e2e-data-analysis-stream-session",
                 },
                 timeout=300,  # 5 min timeout for multi-turn analysis
             )
@@ -573,6 +574,7 @@ class TestDataAnalysisLightE2E:
                     "max_turns": 10,
                     "model_provider": "kimi",
                     "model_name": "kimi-k2.5",
+                    "session_id": "e2e-data-analysis-sync-session",
                 },
                 timeout=120,
             )

--- a/tests/test_e2e/test_e2e_workflows.py
+++ b/tests/test_e2e/test_e2e_workflows.py
@@ -532,7 +532,7 @@ class TestAgentPresetLifecycleE2E:
         MockAgent.return_value = _make_mock_agent()
         resp = await e2e_client.post(
             "/api/v1/agent/run",
-            json={"request": "E2E test request"},
+            json={"request": "E2E test request", "session_id": "test-session-id"},
         )
         assert resp.status_code == 200
         body = resp.json()
@@ -635,7 +635,7 @@ class TestAgentRunAndTraceE2E:
         MockAgent.return_value = _make_mock_agent()
         resp = await e2e_client.post(
             "/api/v1/agent/run",
-            json={"request": "E2E simple run"},
+            json={"request": "E2E simple run", "session_id": "test-session-id"},
         )
         assert resp.status_code == 200
         body = resp.json()
@@ -667,20 +667,16 @@ class TestAgentRunAndTraceE2E:
             assert t["success"] is True
 
     @patch("app.api.v1.agent.SkillsAgent")
-    async def test_05_run_with_skills_and_history(
+    async def test_05_run_with_skills_and_session(
         self, MockAgent, e2e_client: AsyncClient
     ):
         MockAgent.return_value = _make_mock_agent()
-        history = [
-            {"role": "user", "content": "Hi"},
-            {"role": "assistant", "content": "Hello!"},
-        ]
         resp = await e2e_client.post(
             "/api/v1/agent/run",
             json={
                 "request": "Continue our conversation",
                 "skills": ["test-skill"],
-                "conversation_history": history,
+                "session_id": "test-session-id",
             },
         )
         assert resp.status_code == 200
@@ -698,7 +694,7 @@ class TestAgentRunAndTraceE2E:
 
         resp = await e2e_client.post(
             "/api/v1/agent/run/stream",
-            json={"request": "E2E stream test"},
+            json={"request": "E2E stream test", "session_id": "test-session-id"},
         )
         assert resp.status_code == 200
         assert "text/event-stream" in resp.headers.get("content-type", "")
@@ -770,7 +766,7 @@ class TestFileUploadE2E:
         ]
         resp = await e2e_client.post(
             "/api/v1/agent/run",
-            json={"request": "Process this file", "uploaded_files": files},
+            json={"request": "Process this file", "uploaded_files": files, "session_id": "test-session-id"},
         )
         assert resp.status_code == 200
         assert resp.json()["success"] is True
@@ -2326,7 +2322,7 @@ class TestAutoDetectOutputFilesE2E:
 
         resp = await e2e_client.post(
             "/api/v1/agent/run",
-            json={"request": "Generate a chart"},
+            json={"request": "Generate a chart", "session_id": "test-session-id"},
         )
         assert resp.status_code == 200
         body = resp.json()
@@ -2346,7 +2342,7 @@ class TestAutoDetectOutputFilesE2E:
 
         resp = await e2e_client.post(
             "/api/v1/agent/run",
-            json={"request": "Just talk, no files"},
+            json={"request": "Just talk, no files", "session_id": "test-session-id"},
         )
         assert resp.status_code == 200
         body = resp.json()
@@ -2409,7 +2405,7 @@ class TestAutoDetectOutputFilesE2E:
 
         resp = await e2e_client.post(
             "/api/v1/agent/run/stream",
-            json={"request": "Create CSV data"},
+            json={"request": "Create CSV data", "session_id": "test-session-id"},
         )
         assert resp.status_code == 200
 
@@ -2438,7 +2434,7 @@ class TestAutoDetectOutputFilesE2E:
 
         resp = await e2e_client.post(
             "/api/v1/agent/run/stream",
-            json={"request": "No files needed"},
+            json={"request": "No files needed", "session_id": "test-session-id"},
         )
         assert resp.status_code == 200
 

--- a/web/src/app/chat/page.tsx
+++ b/web/src/app/chat/page.tsx
@@ -20,6 +20,7 @@ import {
   Home,
   Settings,
   Navigation,
+  Plus,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
@@ -37,7 +38,8 @@ import {
 import { MultiSelect } from "@/components/ui/multi-select";
 import { skillsApi, agentApi, filesApi, mcpApi, toolsApi, agentPresetsApi, modelsApi, executorsApi } from "@/lib/api";
 import type { StreamEvent, OutputFileInfo } from "@/lib/api";
-import { useChatStore, getConversationHistory, REQUIRED_TOOLS, type ChatMessage } from "@/stores/chat-store";
+import { useChatStore, REQUIRED_TOOLS, type ChatMessage } from "@/stores/chat-store";
+import { useChatSessionRestore } from "@/hooks/use-chat-session";
 import { ChatMessageItem } from "@/components/chat/chat-message";
 import type { StreamEventRecord } from "@/types/stream-events";
 import { handleStreamEvent, serializeEventsToText } from "@/lib/stream-utils";
@@ -55,6 +57,7 @@ export default function FullscreenChatPage() {
   // Use zustand store for persistence (shared with chat panel via localStorage)
   const {
     messages,
+    sessionId,
     selectedSkills,
     selectedTools,
     selectedMcpServers,
@@ -67,7 +70,9 @@ export default function FullscreenChatPage() {
     updateMessage,
     removeMessages,
     clearMessages,
+    newSession,
     resetAll,
+    setSessionId,
     setSelectedSkills,
     setSelectedTools,
     setSelectedMcpServers,
@@ -84,6 +89,9 @@ export default function FullscreenChatPage() {
     selectedExecutorId,
     setSelectedExecutorId,
   } = useChatStore();
+
+  // Restore session messages from server on mount
+  useChatSessionRestore();
 
   const [showToolsPanel, setShowToolsPanel] = React.useState(false);
   const [showResetDialog, setShowResetDialog] = React.useState(false);
@@ -250,8 +258,12 @@ export default function FullscreenChatPage() {
       const currentSkills = useChatStore.getState().selectedSkills;
       const skillsList = currentSkills.length > 0 ? currentSkills : undefined;
 
-      const previousMessages = [...messages, userMessage];
-      const conversationHistory = getConversationHistory(previousMessages);
+      // Generate session_id if none exists (deferred creation)
+      let currentSessionId = useChatStore.getState().sessionId;
+      if (!currentSessionId) {
+        currentSessionId = crypto.randomUUID();
+        setSessionId(currentSessionId);
+      }
 
       const events: StreamEventRecord[] = [];
       let finalAnswer = "";
@@ -275,8 +287,8 @@ export default function FullscreenChatPage() {
       if (currentAgentPreset) {
         agentRequest = {
           request: userMessage.content,
+          session_id: currentSessionId,
           agent_id: currentAgentPreset,
-          conversation_history: conversationHistory.length > 1 ? conversationHistory.slice(0, -1) : undefined,
           uploaded_files: agentFiles,
           model_provider: currentModelProvider || undefined,
           model_name: currentModelName || undefined,
@@ -290,10 +302,10 @@ export default function FullscreenChatPage() {
 
         agentRequest = {
           request: userMessage.content,
+          session_id: currentSessionId,
           skills: skillsList,
           allowed_tools: toolsList,
           max_turns: maxTurns,
-          conversation_history: conversationHistory.length > 1 ? conversationHistory.slice(0, -1) : undefined,
           uploaded_files: agentFiles,
           equipped_mcp_servers: mcpServersList,
           system_prompt: currentSystemPrompt || undefined,
@@ -314,6 +326,9 @@ export default function FullscreenChatPage() {
             case "run_started":
               traceId = event.trace_id;
               currentTraceIdRef.current = traceId || null;
+              if (event.session_id) {
+                setSessionId(event.session_id);
+              }
               flushSync(() => {
                 updateMessage(loadingMessageId, { traceId: traceId });
               });
@@ -479,12 +494,22 @@ export default function FullscreenChatPage() {
         <Button
           variant="outline"
           size="sm"
-          onClick={handleReset}
+          onClick={() => newSession()}
           disabled={messages.length === 0 || isRunning}
-          title="Reset conversation"
+          title="New Chat"
+        >
+          <Plus className="h-4 w-4 mr-1" />
+          New Chat
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handleReset}
+          disabled={isRunning}
+          title="Reset everything"
         >
           <RotateCcw className="h-4 w-4 mr-1" />
-          Reset
+          Reset All
         </Button>
         <Link href="/">
           <Button variant="outline" size="sm" title="Back to home">

--- a/web/src/app/sessions/[id]/page.tsx
+++ b/web/src/app/sessions/[id]/page.tsx
@@ -25,152 +25,11 @@ import { useQuery } from '@tanstack/react-query';
 import { agentPresetsApi } from '@/lib/api';
 import { ChatMessageItem } from '@/components/chat/chat-message';
 import type { ChatMessage } from '@/stores/chat-store';
-import type { StreamEventRecord } from '@/types/stream-events';
+import { sessionMessagesToChatMessages } from '@/lib/session-utils';
 import { useTranslation } from '@/i18n/client';
 import { formatDateTime } from '@/lib/formatters';
 
-// ---------- convert raw session messages → ChatMessage[] with streamEvents ----------
-
-interface RawMessage {
-  role: string;
-  content: string | Array<Record<string, unknown>>;
-}
-
-function sessionMessagesToChatMessages(raw: RawMessage[]): ChatMessage[] {
-  const result: ChatMessage[] = [];
-  let events: StreamEventRecord[] = [];
-  let pendingAssistantId: string | null = null;
-  let toolIdToName: Record<string, string> = {};
-  let eventCounter = 0;
-
-  const nextId = () => `evt-${eventCounter++}`;
-  const now = Date.now();
-
-  const flushAssistant = () => {
-    if (pendingAssistantId !== null) {
-      result.push({
-        id: pendingAssistantId,
-        role: 'assistant',
-        content: '',
-        timestamp: now,
-        streamEvents: events.length > 0 ? [...events] : undefined,
-      });
-      events = [];
-      toolIdToName = {};
-      pendingAssistantId = null;
-    }
-  };
-
-  for (let i = 0; i < raw.length; i++) {
-    const msg = raw[i];
-
-    if (msg.role === 'user') {
-      // Check if this is a tool_result message (sent back by the system)
-      if (Array.isArray(msg.content)) {
-        const hasToolResult = msg.content.some(
-          (b) => typeof b === 'object' && b !== null && b.type === 'tool_result'
-        );
-        if (hasToolResult) {
-          for (const block of msg.content) {
-            if (typeof block === 'object' && block !== null && block.type === 'tool_result') {
-              const toolUseId = typeof block.tool_use_id === 'string' ? block.tool_use_id : '';
-              const toolName = toolIdToName[toolUseId] || 'tool';
-              const resultContent = typeof block.content === 'string'
-                ? block.content
-                : JSON.stringify(block.content);
-              events.push({
-                id: nextId(),
-                timestamp: now,
-                type: 'tool_result',
-                data: {
-                  toolName,
-                  toolResult: resultContent,
-                  success: !block.is_error,
-                },
-              });
-            }
-          }
-          continue;
-        }
-      }
-
-      // Regular user message — flush any pending assistant first
-      flushAssistant();
-
-      let userText = '';
-      if (typeof msg.content === 'string') {
-        userText = msg.content;
-      } else if (Array.isArray(msg.content)) {
-        const texts: string[] = [];
-        for (const block of msg.content) {
-          if (typeof block === 'object' && block !== null && block.type === 'text' && typeof block.text === 'string') {
-            texts.push(block.text);
-          }
-        }
-        userText = texts.join('\n');
-      }
-
-      result.push({
-        id: `msg-${i}`,
-        role: 'user',
-        content: userText,
-        timestamp: now,
-      });
-      continue;
-    }
-
-    if (msg.role === 'assistant') {
-      flushAssistant();
-      pendingAssistantId = `msg-${i}`;
-
-      if (typeof msg.content === 'string') {
-        if (msg.content) {
-          events.push({
-            id: nextId(),
-            timestamp: now,
-            type: 'assistant',
-            data: { content: msg.content },
-          });
-        }
-      } else if (Array.isArray(msg.content)) {
-        for (const block of msg.content) {
-          if (typeof block !== 'object' || block === null) continue;
-
-          if (block.type === 'text' && typeof block.text === 'string') {
-            if (block.text) {
-              events.push({
-                id: nextId(),
-                timestamp: now,
-                type: 'assistant',
-                data: { content: block.text },
-              });
-            }
-          } else if (block.type === 'tool_use') {
-            const toolName = typeof block.name === 'string' ? block.name : 'tool';
-            const toolId = typeof block.id === 'string' ? block.id : '';
-            if (toolId) toolIdToName[toolId] = toolName;
-
-            events.push({
-              id: nextId(),
-              timestamp: now,
-              type: 'tool_call',
-              data: {
-                toolName,
-                toolInput: (typeof block.input === 'object' && block.input !== null)
-                  ? block.input as Record<string, unknown>
-                  : undefined,
-              },
-            });
-          }
-        }
-      }
-      continue;
-    }
-  }
-
-  flushAssistant();
-  return result;
-}
+const CHAT_SENTINEL = '__chat__';
 
 // ---------- main page ----------
 export default function SessionDetailPage() {
@@ -183,10 +42,12 @@ export default function SessionDetailPage() {
   const { data: session, isLoading, error } = usePublishedSessionDetail(sessionId);
   const deleteMutation = useDeletePublishedSession();
 
+  const isChat = session?.agent_id === CHAT_SENTINEL;
+
   const { data: agent } = useQuery({
     queryKey: ['agent', session?.agent_id],
     queryFn: () => agentPresetsApi.get(session!.agent_id),
-    enabled: !!session?.agent_id,
+    enabled: !!session?.agent_id && !isChat,
   });
 
   const handleDelete = async () => {
@@ -200,7 +61,9 @@ export default function SessionDetailPage() {
   };
 
   const chatMessages = React.useMemo(
-    () => sessionMessagesToChatMessages((session?.messages || []) as RawMessage[]),
+    () => sessionMessagesToChatMessages(
+      (session?.messages || []) as Array<{ role: string; content: string | Array<Record<string, unknown>> }>
+    ),
     [session?.messages]
   );
 
@@ -233,7 +96,11 @@ export default function SessionDetailPage() {
                   {t('detail.title')}
                 </h1>
                 <div className="flex flex-wrap items-center gap-3 mt-2 text-sm text-muted-foreground">
-                  {agent && <Badge variant="outline">{agent.name}</Badge>}
+                  {isChat ? (
+                    <Badge variant="secondary">{t('detail.chatBadge')}</Badge>
+                  ) : agent ? (
+                    <Badge variant="outline">{agent.name}</Badge>
+                  ) : null}
                   <span className="flex items-center gap-1">
                     <Clock className="h-3 w-3" />
                     {formatDateTime(session.created_at)}

--- a/web/src/app/sessions/page.tsx
+++ b/web/src/app/sessions/page.tsx
@@ -57,6 +57,8 @@ export default function SessionsPage() {
     },
   });
 
+  const CHAT_SENTINEL = '__chat__';
+
   const deleteMutation = useDeletePublishedSession();
   const totalPages = data ? Math.ceil(data.total / PAGE_SIZE) : 0;
 
@@ -98,6 +100,7 @@ export default function SessionsPage() {
             </SelectTrigger>
             <SelectContent>
               <SelectItem value="all">{t('filters.allAgents')}</SelectItem>
+              <SelectItem value={CHAT_SENTINEL}>{t('filters.chatSessions')}</SelectItem>
               {agentsData?.map((agent) => (
                 <SelectItem key={agent.id} value={agent.id}>
                   {agent.name}
@@ -138,9 +141,11 @@ export default function SessionsPage() {
                             </span>
                           </div>
                           <div className="flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
-                            {session.agent_name && (
+                            {session.agent_id === CHAT_SENTINEL ? (
+                              <Badge variant="secondary">{t('filters.chatBadge')}</Badge>
+                            ) : session.agent_name ? (
                               <Badge variant="outline">{session.agent_name}</Badge>
-                            )}
+                            ) : null}
                             <span>{t('card.messageCount', { count: session.message_count })}</span>
                             <span className="flex items-center gap-1">
                               <Clock className="h-3 w-3" />

--- a/web/src/hooks/use-chat-session.ts
+++ b/web/src/hooks/use-chat-session.ts
@@ -1,0 +1,42 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { agentApi } from '@/lib/api';
+import { useChatStore } from '@/stores/chat-store';
+import { sessionMessagesToChatMessages } from '@/lib/session-utils';
+
+/**
+ * On mount, if the store has a sessionId but no messages,
+ * fetch the session from the server and populate the message list.
+ */
+export function useChatSessionRestore() {
+  const sessionId = useChatStore((s) => s.sessionId);
+  const messages = useChatStore((s) => s.messages);
+  const isRunning = useChatStore((s) => s.isRunning);
+  const attempted = useRef(false);
+
+  useEffect(() => {
+    if (attempted.current) return;
+    if (!sessionId || messages.length > 0 || isRunning) return;
+
+    attempted.current = true;
+
+    (async () => {
+      try {
+        const session = await agentApi.getSession(sessionId);
+        if (session && session.messages && session.messages.length > 0) {
+          const chatMessages = sessionMessagesToChatMessages(
+            session.messages as Array<{ role: string; content: string | Array<Record<string, unknown>> }>
+          );
+          // Populate store
+          const store = useChatStore.getState();
+          for (const msg of chatMessages) {
+            store.addMessage(msg);
+          }
+        }
+      } catch {
+        // 404 or network error — start fresh, no messages to restore
+      }
+    })();
+  }, [sessionId, messages.length, isRunning]);
+}

--- a/web/src/i18n/locales/en-US/sessions.json
+++ b/web/src/i18n/locales/en-US/sessions.json
@@ -5,7 +5,9 @@
   "emptyDescription": "Chat with a published agent to create sessions",
   "filters": {
     "allAgents": "All Agents",
-    "byAgent": "Filter by agent"
+    "byAgent": "Filter by agent",
+    "chatSessions": "Chat",
+    "chatBadge": "Chat"
   },
   "card": {
     "messageCount": "{{count}} messages",
@@ -30,7 +32,8 @@
     "title": "Session Detail",
     "user": "User",
     "assistant": "Assistant",
-    "noMessages": "No messages in this session"
+    "noMessages": "No messages in this session",
+    "chatBadge": "Chat"
   },
   "pagination": {
     "showing": "Showing {{from}}–{{to}} of {{total}} sessions",

--- a/web/src/i18n/locales/es/sessions.json
+++ b/web/src/i18n/locales/es/sessions.json
@@ -5,7 +5,9 @@
   "emptyDescription": "Chatea con un agente publicado para crear sesiones",
   "filters": {
     "allAgents": "Todos los agentes",
-    "byAgent": "Filtrar por agente"
+    "byAgent": "Filtrar por agente",
+    "chatSessions": "Chat",
+    "chatBadge": "Chat"
   },
   "card": {
     "messageCount": "{{count}} mensajes",
@@ -30,7 +32,8 @@
     "title": "Detalle de la sesión",
     "user": "Usuario",
     "assistant": "Asistente",
-    "noMessages": "No hay mensajes en esta sesión"
+    "noMessages": "No hay mensajes en esta sesión",
+    "chatBadge": "Chat"
   },
   "pagination": {
     "showing": "Mostrando {{from}}–{{to}} de {{total}} sesiones",

--- a/web/src/i18n/locales/ja/sessions.json
+++ b/web/src/i18n/locales/ja/sessions.json
@@ -5,7 +5,9 @@
   "emptyDescription": "公開エージェントとチャットしてセッションを作成してください",
   "filters": {
     "allAgents": "すべてのエージェント",
-    "byAgent": "エージェントでフィルター"
+    "byAgent": "エージェントでフィルター",
+    "chatSessions": "チャット",
+    "chatBadge": "チャット"
   },
   "card": {
     "messageCount": "{{count}} メッセージ",
@@ -30,7 +32,8 @@
     "title": "セッション詳細",
     "user": "ユーザー",
     "assistant": "アシスタント",
-    "noMessages": "このセッションにはメッセージがありません"
+    "noMessages": "このセッションにはメッセージがありません",
+    "chatBadge": "チャット"
   },
   "pagination": {
     "showing": "{{total}} 件中 {{from}}–{{to}} を表示",

--- a/web/src/i18n/locales/pt-BR/sessions.json
+++ b/web/src/i18n/locales/pt-BR/sessions.json
@@ -5,7 +5,9 @@
   "emptyDescription": "Converse com um agente publicado para criar sessões",
   "filters": {
     "allAgents": "Todos os agentes",
-    "byAgent": "Filtrar por agente"
+    "byAgent": "Filtrar por agente",
+    "chatSessions": "Chat",
+    "chatBadge": "Chat"
   },
   "card": {
     "messageCount": "{{count}} mensagens",
@@ -30,7 +32,8 @@
     "title": "Detalhe da sessão",
     "user": "Usuário",
     "assistant": "Assistente",
-    "noMessages": "Nenhuma mensagem nesta sessão"
+    "noMessages": "Nenhuma mensagem nesta sessão",
+    "chatBadge": "Chat"
   },
   "pagination": {
     "showing": "Mostrando {{from}}–{{to}} de {{total}} sessões",

--- a/web/src/i18n/locales/zh-CN/sessions.json
+++ b/web/src/i18n/locales/zh-CN/sessions.json
@@ -5,7 +5,9 @@
   "emptyDescription": "与已发布的代理聊天以创建会话",
   "filters": {
     "allAgents": "所有代理",
-    "byAgent": "按代理筛选"
+    "byAgent": "按代理筛选",
+    "chatSessions": "聊天",
+    "chatBadge": "聊天"
   },
   "card": {
     "messageCount": "{{count}} 条消息",
@@ -30,7 +32,8 @@
     "title": "会话详情",
     "user": "用户",
     "assistant": "助手",
-    "noMessages": "此会话暂无消息"
+    "noMessages": "此会话暂无消息",
+    "chatBadge": "聊天"
   },
   "pagination": {
     "showing": "显示第 {{from}}–{{to}} 条，共 {{total}} 条会话",

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -662,11 +662,6 @@ export const filesApi = {
 };
 
 // Agent API
-export interface ConversationMessage {
-  role: 'user' | 'assistant';
-  content: string;
-}
-
 export interface AgentUploadedFile {
   file_id: string;
   filename: string;
@@ -676,13 +671,13 @@ export interface AgentUploadedFile {
 
 export interface AgentRequest {
   request: string;
+  session_id: string;  // Session ID for server-side session management
   agent_id?: string;  // Agent preset ID. When set, uses preset config and ignores individual config fields.
   model_provider?: string;  // LLM provider: anthropic, openrouter, openai, google
   model_name?: string;  // Model name/ID for the provider
   skills?: string[];  // Optional list of skills to activate (undefined = all)
   allowed_tools?: string[];  // Optional list of tools to enable (undefined = all)
   max_turns?: number;
-  conversation_history?: ConversationMessage[];  // Previous messages for multi-turn dialogue
   uploaded_files?: AgentUploadedFile[];  // Uploaded files available to the agent
   equipped_mcp_servers?: string[];  // Optional list of MCP servers to enable (undefined = all)
   system_prompt?: string;  // Custom system prompt to append to base prompt
@@ -848,6 +843,16 @@ export const agentApi = {
       const error = await response.json().catch(() => ({}));
       throw new Error(error.detail || `Steer failed: ${response.statusText}`);
     }
+  },
+
+  getSession: async (sessionId: string): Promise<SessionMessages> => {
+    const response = await fetch(
+      `${AGENT_API_BASE}/published/sessions/${encodeURIComponent(sessionId)}/detail`
+    );
+    if (!response.ok) {
+      throw new ApiError(response.status, 'Session not found');
+    }
+    return response.json();
   },
 };
 

--- a/web/src/lib/session-utils.ts
+++ b/web/src/lib/session-utils.ts
@@ -1,0 +1,147 @@
+/**
+ * Shared utilities for converting raw session messages (Anthropic format)
+ * into ChatMessage[] with StreamEventRecords for the chat UI.
+ */
+import type { ChatMessage } from '@/stores/chat-store';
+import type { StreamEventRecord } from '@/types/stream-events';
+
+interface RawMessage {
+  role: string;
+  content: string | Array<Record<string, unknown>>;
+}
+
+export function sessionMessagesToChatMessages(raw: RawMessage[]): ChatMessage[] {
+  const result: ChatMessage[] = [];
+  let events: StreamEventRecord[] = [];
+  let pendingAssistantId: string | null = null;
+  let toolIdToName: Record<string, string> = {};
+  let eventCounter = 0;
+
+  const nextId = () => `evt-${eventCounter++}`;
+  const now = Date.now();
+
+  const flushAssistant = () => {
+    if (pendingAssistantId !== null) {
+      result.push({
+        id: pendingAssistantId,
+        role: 'assistant',
+        content: '',
+        timestamp: now,
+        streamEvents: events.length > 0 ? [...events] : undefined,
+      });
+      events = [];
+      toolIdToName = {};
+      pendingAssistantId = null;
+    }
+  };
+
+  for (let i = 0; i < raw.length; i++) {
+    const msg = raw[i];
+
+    if (msg.role === 'user') {
+      // Check if this is a tool_result message (sent back by the system)
+      if (Array.isArray(msg.content)) {
+        const hasToolResult = msg.content.some(
+          (b) => typeof b === 'object' && b !== null && b.type === 'tool_result'
+        );
+        if (hasToolResult) {
+          for (const block of msg.content) {
+            if (typeof block === 'object' && block !== null && block.type === 'tool_result') {
+              const toolUseId = typeof block.tool_use_id === 'string' ? block.tool_use_id : '';
+              const toolName = toolIdToName[toolUseId] || 'tool';
+              const resultContent = typeof block.content === 'string'
+                ? block.content
+                : JSON.stringify(block.content);
+              events.push({
+                id: nextId(),
+                timestamp: now,
+                type: 'tool_result',
+                data: {
+                  toolName,
+                  toolResult: resultContent,
+                  success: !block.is_error,
+                },
+              });
+            }
+          }
+          continue;
+        }
+      }
+
+      // Regular user message — flush any pending assistant first
+      flushAssistant();
+
+      let userText = '';
+      if (typeof msg.content === 'string') {
+        userText = msg.content;
+      } else if (Array.isArray(msg.content)) {
+        const texts: string[] = [];
+        for (const block of msg.content) {
+          if (typeof block === 'object' && block !== null && block.type === 'text' && typeof block.text === 'string') {
+            texts.push(block.text);
+          }
+        }
+        userText = texts.join('\n');
+      }
+
+      result.push({
+        id: `msg-${i}`,
+        role: 'user',
+        content: userText,
+        timestamp: now,
+      });
+      continue;
+    }
+
+    if (msg.role === 'assistant') {
+      flushAssistant();
+      pendingAssistantId = `msg-${i}`;
+
+      if (typeof msg.content === 'string') {
+        if (msg.content) {
+          events.push({
+            id: nextId(),
+            timestamp: now,
+            type: 'assistant',
+            data: { content: msg.content },
+          });
+        }
+      } else if (Array.isArray(msg.content)) {
+        for (const block of msg.content) {
+          if (typeof block !== 'object' || block === null) continue;
+
+          if (block.type === 'text' && typeof block.text === 'string') {
+            if (block.text) {
+              events.push({
+                id: nextId(),
+                timestamp: now,
+                type: 'assistant',
+                data: { content: block.text },
+              });
+            }
+          } else if (block.type === 'tool_use') {
+            const toolName = typeof block.name === 'string' ? block.name : 'tool';
+            const toolId = typeof block.id === 'string' ? block.id : '';
+            if (toolId) toolIdToName[toolId] = toolName;
+
+            events.push({
+              id: nextId(),
+              timestamp: now,
+              type: 'tool_call',
+              data: {
+                toolName,
+                toolInput: (typeof block.input === 'object' && block.input !== null)
+                  ? block.input as Record<string, unknown>
+                  : undefined,
+              },
+            });
+          }
+        }
+      }
+      continue;
+    }
+  }
+
+  flushAssistant();
+  return result;
+}


### PR DESCRIPTION
## Summary
- Unify chat panel and fullscreen chat page to use server-side session management
- Add dedicated `/api/v1/sessions` API for session CRUD operations
- Refactor chat store and components to use shared session utilities (`session-utils.ts`, `use-chat-session.ts`)
- Simplify published agent chat by reusing the unified session logic
- Update i18n translations for sessions across all 5 languages

## Test plan
- [ ] Verify chat panel creates and persists sessions correctly
- [ ] Verify fullscreen chat page loads session history on refresh
- [ ] Verify published agent chat still works with session management
- [ ] Verify session list page displays all sessions
- [ ] Run unit and E2E tests: `./scripts/run-tests.sh`