### PR TITLE
feat: widen chat message bubbles

### DIFF
--- a/web/src/app/chat/page.tsx
+++ b/web/src/app/chat/page.tsx
@@ -795,7 +795,7 @@ export default function FullscreenChatPage() {
           </div>
         ) : (
           messages.map((message) => (
-            <div key={message.id} className="max-w-3xl mx-auto">
+            <div key={message.id} className="max-w-4xl mx-auto">
               <ChatMessageItem
                 message={message}
                 streamingContent={message.id === streamingMessageId ? streamingContent : null}
@@ -810,7 +810,7 @@ export default function FullscreenChatPage() {
 
       {/* Input */}
       <div className="border-t px-6 py-4 shrink-0">
-        <div className="max-w-3xl mx-auto">
+        <div className="max-w-4xl mx-auto">
           {/* Uploaded Files Display */}
           {uploadedFiles.length > 0 && (
             <div className="mb-3 flex flex-wrap gap-2">

--- a/web/src/app/published/[id]/page.tsx
+++ b/web/src/app/published/[id]/page.tsx
@@ -519,7 +519,7 @@ export default function PublishedChatPage() {
           </div>
         ) : (
           messages.map((message) => (
-            <div key={message.id} className="max-w-3xl mx-auto">
+            <div key={message.id} className="max-w-4xl mx-auto">
               <ChatMessageItem
                 message={message}
                 streamingContent={message.id === streamingMessageId ? streamingContent : null}
@@ -535,7 +535,7 @@ export default function PublishedChatPage() {
 
       {/* Input */}
       <div className="border-t px-6 py-4 shrink-0">
-        <div className="max-w-3xl mx-auto">
+        <div className="max-w-4xl mx-auto">
           {/* Uploaded Files Display */}
           {uploadedFiles.length > 0 && (
             <div className="mb-3 flex flex-wrap gap-2">

--- a/web/src/app/skills/evolve/page.tsx
+++ b/web/src/app/skills/evolve/page.tsx
@@ -680,7 +680,7 @@ export default function SkillEvolvePage() {
           </div>
         ) : (
           messages.map((message) => (
-            <div key={message.id} className="max-w-3xl mx-auto">
+            <div key={message.id} className="max-w-4xl mx-auto">
               <ChatMessageItem
                 message={message}
                 streamingContent={
@@ -707,7 +707,7 @@ export default function SkillEvolvePage() {
 
       {/* Input */}
       <div className="border-t px-6 py-4 shrink-0">
-        <div className="max-w-3xl mx-auto">
+        <div className="max-w-4xl mx-auto">
           <div className="flex gap-2">
             <Textarea
               value={input}

--- a/web/src/components/chat/chat-message.tsx
+++ b/web/src/components/chat/chat-message.tsx
@@ -45,7 +45,7 @@ export function ChatMessageItem({
   if (message.role === "user") {
     return (
       <div className="flex justify-end">
-        <Card className="max-w-[85%] p-3 bg-primary text-primary-foreground">
+        <Card className="max-w-[85%] p-3 px-4 bg-primary text-primary-foreground">
           <p className="text-sm whitespace-pre-wrap">{message.content}</p>
           {message.attachedFiles && message.attachedFiles.length > 0 && (
             <div className="flex flex-wrap gap-1.5 mt-2 pt-2 border-t border-primary-foreground/20">
@@ -67,7 +67,7 @@ export function ChatMessageItem({
 
   return (
     <div className="flex justify-start">
-      <Card className="max-w-[85%] p-3 w-full">
+      <Card className="p-4 w-full">
         {message.isLoading && !displayContent ? (
           <div className="flex items-center gap-2">
             <Spinner size="md" />


### PR DESCRIPTION
## Summary
- Widen message container from `max-w-3xl` (768px) to `max-w-4xl` (896px) on fullscreen chat, published agent, and skill evolve pages
- Assistant messages now use full container width instead of 85% cap
- User messages keep 85% bubble style with slightly more horizontal padding

## Test plan
- [ ] Verify fullscreen chat (`/chat`) message layout
- [ ] Verify published agent (`/published/[id]`) message layout
- [ ] Verify skill evolve (`/skills/evolve`) message layout
- [ ] Check dark mode rendering

Closes #9