### PR TITLE
feat: deduplicate chat surfaces, add i18n, fix responsive grid

### DIFF
--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -59,7 +59,7 @@ export default function Home() {
             </div>
             <div className="flex flex-col items-stretch gap-4 text-center w-full">
               {/* Primary Actions - 4 equal width buttons */}
-              <div className="grid grid-cols-4 gap-3">
+              <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-3">
                 <Link
                   href="/agents"
                   className="inline-flex items-center justify-center rounded-md bg-primary px-6 py-3 text-sm font-medium text-primary-foreground shadow transition-colors hover:bg-primary/90"
@@ -104,7 +104,7 @@ export default function Home() {
                 </Link>
               </div>
               {/* Secondary Navigation - Executors, Tools, MCP, Traces, Sessions */}
-              <div className="grid grid-cols-5 gap-3">
+              <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-3">
                 <Link
                   href="/executors"
                   className="inline-flex items-center justify-center rounded-md border border-input bg-background px-6 py-2.5 text-sm font-medium shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground"
@@ -142,7 +142,7 @@ export default function Home() {
                 </Link>
               </div>
               {/* Tertiary Navigation - Files, Terminal, Settings, Backup */}
-              <div className="grid grid-cols-4 gap-3">
+              <div className="grid grid-cols-2 sm:grid-cols-2 md:grid-cols-4 gap-3">
                 <Link
                   href="/files"
                   className="inline-flex items-center justify-center rounded-md border border-input bg-background px-6 py-2.5 text-sm font-medium shadow-sm transition-colors hover:bg-accent hover:text-accent-foreground"

--- a/web/src/app/published/[id]/page.tsx
+++ b/web/src/app/published/[id]/page.tsx
@@ -2,17 +2,15 @@
 
 import React, { useState, useRef, useEffect, useCallback } from "react";
 import { useParams } from "next/navigation";
-import { flushSync } from "react-dom";
 import { Paperclip, X, Square, Bot, Loader2, MessageSquarePlus, Navigation } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
-import { publishedAgentApi, filesApi } from "@/lib/api";
-import type { StreamEvent, OutputFileInfo, UploadedFile } from "@/lib/api";
+import { publishedAgentApi } from "@/lib/api";
+import type { StreamEvent, UploadedFile } from "@/lib/api";
 import type { ChatMessage } from "@/stores/chat-store";
 import { ChatMessageItem } from "@/components/chat/chat-message";
-import type { StreamEventRecord } from "@/types/stream-events";
-import { handleStreamEvent, serializeEventsToText } from "@/lib/stream-utils";
-import { toast } from "sonner";
+import { useChatEngine } from "@/hooks/use-chat-engine";
+import { useTranslation } from "@/i18n/client";
 
 type LocalMessage = ChatMessage;
 
@@ -20,22 +18,18 @@ function getSessionStorageKey(agentId: string): string {
   return `published-session-${agentId}`;
 }
 
-function generateUUID(): string {
-  return crypto.randomUUID();
-}
-
-/** Read or create a session ID for this agent tab */
 function getOrCreateSessionId(agentId: string): string {
-  if (typeof window === 'undefined') return generateUUID();
+  if (typeof window === 'undefined') return crypto.randomUUID();
   const key = getSessionStorageKey(agentId);
   const existing = sessionStorage.getItem(key);
   if (existing) return existing;
-  const id = generateUUID();
+  const id = crypto.randomUUID();
   sessionStorage.setItem(key, id);
   return id;
 }
 
 export default function PublishedChatPage() {
+  const { t } = useTranslation('chat');
   const params = useParams();
   const agentId = params.id as string;
 
@@ -46,28 +40,73 @@ export default function PublishedChatPage() {
   const [loadingInfo, setLoadingInfo] = useState(true);
   const [infoError, setInfoError] = useState<string | null>(null);
 
-  // Session state — always has a value (read or generated on mount)
+  // Session
   const [sessionId, setSessionId] = useState<string>(() => getOrCreateSessionId(agentId));
   const [restoringSession, setRestoringSession] = useState(false);
 
-  // Chat state (local, not Zustand)
+  // Chat state (local)
   const [messages, setMessages] = useState<LocalMessage[]>([]);
-  const [input, setInput] = useState("");
   const [isRunning, setIsRunning] = useState(false);
-  const [streamingContent, setStreamingContent] = useState<string | null>(null);
-  const [streamingEvents, setStreamingEvents] = useState<StreamEventRecord[]>([]);
-  const [streamingMessageId, setStreamingMessageId] = useState<string | null>(null);
-  const [currentOutputFiles, setCurrentOutputFiles] = useState<OutputFileInfo[]>([]);
-
-  // File upload state
   const [uploadedFiles, setUploadedFiles] = useState<UploadedFile[]>([]);
-  const [isUploading, setIsUploading] = useState(false);
-  const fileInputRef = useRef<HTMLInputElement>(null);
 
-  // Refs
-  const messagesEndRef = useRef<HTMLDivElement>(null);
-  const abortControllerRef = useRef<AbortController | null>(null);
-  const currentTraceIdRef = useRef<string | null>(null);
+  // Stable refs for sessionId and apiResponseMode (used in adapters)
+  const sessionIdRef = useRef(sessionId);
+  sessionIdRef.current = sessionId;
+  const apiResponseModeRef = useRef(apiResponseMode);
+  apiResponseModeRef.current = apiResponseMode;
+  const isRunningRef = useRef(isRunning);
+  isRunningRef.current = isRunning;
+  const uploadedFilesRef = useRef(uploadedFiles);
+  uploadedFilesRef.current = uploadedFiles;
+  const messagesRef = useRef(messages);
+  messagesRef.current = messages;
+
+  const addMessage = useCallback((msg: LocalMessage) => {
+    setMessages((prev) => [...prev, msg]);
+  }, []);
+
+  const updateMessage = useCallback((id: string, updates: Partial<LocalMessage>) => {
+    setMessages((prev) => prev.map((m) => (m.id === id ? { ...m, ...updates } : m)));
+  }, []);
+
+  const removeMessages = useCallback((ids: string[]) => {
+    setMessages((prev) => prev.filter((m) => !ids.includes(m.id)));
+  }, []);
+
+  // ── Shared chat engine ──
+  const engine = useChatEngine({
+    messageAdapter: {
+      getMessages: () => messagesRef.current,
+      addMessage,
+      updateMessage,
+      removeMessages,
+      getIsRunning: () => isRunningRef.current,
+      setIsRunning,
+      getUploadedFiles: () => uploadedFilesRef.current,
+      clearUploadedFiles: () => setUploadedFiles([]),
+      addUploadedFile: (file) => setUploadedFiles((prev) => [...prev, file]),
+      removeUploadedFile: (fileId) => setUploadedFiles((prev) => prev.filter((f) => f.file_id !== fileId)),
+    },
+    streamAdapter: {
+      runStream: async (request, agentFiles, onEvent, signal) => {
+        await publishedAgentApi.chatStream(
+          agentId,
+          { request, session_id: sessionIdRef.current, uploaded_files: agentFiles },
+          (event: StreamEvent) => onEvent(event),
+          signal
+        );
+      },
+      runSync: async (request, agentFiles) => {
+        return await publishedAgentApi.chatSync(agentId, {
+          request, session_id: sessionIdRef.current, uploaded_files: agentFiles,
+        });
+      },
+      steer: async (traceId, message) => {
+        await publishedAgentApi.steerAgent(agentId, traceId, message);
+      },
+    },
+    responseMode: (apiResponseMode === 'non_streaming') ? 'non_streaming' : 'streaming',
+  });
 
   // Load agent info + restore session
   useEffect(() => {
@@ -78,22 +117,18 @@ export default function PublishedChatPage() {
         setAgentDescription(info.description);
         setApiResponseMode(info.api_response_mode);
       } catch {
-        setInfoError("This agent is not available.");
+        setInfoError(t('published.notAvailable'));
         setLoadingInfo(false);
         return;
       }
 
-      // Try to restore session messages from server
       setRestoringSession(true);
       try {
         const sessionData = await publishedAgentApi.getSession(agentId, sessionId);
         if (sessionData.messages.length > 0) {
-          // Filter and extract displayable messages from full conversation
-          // (which may include tool_use/tool_result blocks)
           const restoredMessages: LocalMessage[] = [];
           for (const msg of sessionData.messages) {
             if (msg.role === "user") {
-              // Only show user messages with string content (skip tool_result arrays)
               if (typeof msg.content === "string") {
                 restoredMessages.push({
                   id: `restored-${restoredMessages.length}`,
@@ -103,7 +138,6 @@ export default function PublishedChatPage() {
                 });
               }
             } else if (msg.role === "assistant") {
-              // Extract text from assistant messages (may be string or content blocks array)
               let text = "";
               if (typeof msg.content === "string") {
                 text = msg.content;
@@ -113,7 +147,6 @@ export default function PublishedChatPage() {
                   .map((b: Record<string, unknown>) => b.text as string)
                   .join("\n");
               }
-              // Only add if there's actual text (skip tool-only assistant turns)
               if (text.trim()) {
                 restoredMessages.push({
                   id: `restored-${restoredMessages.length}`,
@@ -128,7 +161,7 @@ export default function PublishedChatPage() {
           setMessages(restoredMessages);
         }
       } catch {
-        // Session not found on server (first visit) — that's fine, nothing to restore
+        // Session not found — first visit
       } finally {
         setRestoringSession(false);
       }
@@ -140,330 +173,15 @@ export default function PublishedChatPage() {
 
   // Auto-scroll
   useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [messages, streamingContent]);
-
-  const addMessage = useCallback((msg: LocalMessage) => {
-    setMessages((prev) => [...prev, msg]);
-  }, []);
-
-  const updateMessage = useCallback((id: string, updates: Partial<LocalMessage>) => {
-    setMessages((prev) =>
-      prev.map((msg) => (msg.id === id ? { ...msg, ...updates } : msg))
-    );
-  }, []);
+    engine.messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages, engine.streamingContent]);
 
   const handleNewChat = () => {
-    const newId = generateUUID();
+    const newId = crypto.randomUUID();
     sessionStorage.setItem(getSessionStorageKey(agentId), newId);
     setSessionId(newId);
     setMessages([]);
-    setInput("");
-    setStreamingContent(null);
-    setStreamingEvents([]);
-    setStreamingMessageId(null);
-    setCurrentOutputFiles([]);
     setUploadedFiles([]);
-  };
-
-  const handleSteer = async (message: string) => {
-    const traceId = currentTraceIdRef.current;
-    if (!traceId) return;
-    try {
-      await publishedAgentApi.steerAgent(agentId, traceId, message);
-      setInput("");
-    } catch (err) {
-      toast.error(err instanceof Error ? err.message : "Failed to send steering message");
-    }
-  };
-
-  const handleSubmit = async () => {
-    if (!input.trim()) return;
-
-    // Steering mode
-    if (isRunning && currentTraceIdRef.current) {
-      await handleSteer(input.trim());
-      return;
-    }
-
-    if (isRunning) return;
-
-    const abortController = new AbortController();
-    abortControllerRef.current = abortController;
-
-    // Capture uploaded files before clearing
-    const agentFiles = uploadedFiles.length > 0
-      ? uploadedFiles.map((f) => ({
-          file_id: f.file_id,
-          filename: f.filename,
-          path: f.path,
-          content_type: f.content_type,
-        }))
-      : undefined;
-
-    const userMessage: LocalMessage = {
-      id: Date.now().toString(),
-      role: "user",
-      content: input.trim(),
-      timestamp: Date.now(),
-      attachedFiles: uploadedFiles.length > 0
-        ? uploadedFiles.map((f) => ({ file_id: f.file_id, filename: f.filename }))
-        : undefined,
-    };
-
-    const loadingMessageId = (Date.now() + 1).toString();
-    const loadingMessage: LocalMessage = {
-      id: loadingMessageId,
-      role: "assistant",
-      content: "",
-      timestamp: Date.now(),
-      isLoading: true,
-    };
-
-    addMessage(userMessage);
-    addMessage(loadingMessage);
-    setInput("");
-    setUploadedFiles([]);
-    setIsRunning(true);
-    setStreamingMessageId(loadingMessageId);
-    setStreamingContent("");
-    setStreamingEvents([]);
-    setCurrentOutputFiles([]);
-
-    try {
-
-      // Non-streaming mode: use sync endpoint
-      if (apiResponseMode === 'non_streaming') {
-        const result = await publishedAgentApi.chatSync(agentId, {
-          request: userMessage.content,
-          session_id: sessionId,
-          uploaded_files: agentFiles,
-        });
-
-        // Build structured events from steps
-        const events: StreamEventRecord[] = [];
-        let eventId = 0;
-        const now = Date.now();
-
-        if (result.steps && result.steps.length > 0) {
-          for (const step of result.steps) {
-            if (step.tool_name) {
-              // Tool call event
-              events.push({
-                id: `sync-${eventId++}`,
-                type: 'tool_call',
-                timestamp: now,
-                data: {
-                  toolName: step.tool_name,
-                  toolInput: step.tool_input as Record<string, unknown> | undefined,
-                },
-              });
-              // Tool result event (content is the result)
-              if (step.content) {
-                events.push({
-                  id: `sync-${eventId++}`,
-                  type: 'tool_result',
-                  timestamp: now,
-                  data: {
-                    toolName: step.tool_name,
-                    toolResult: step.content,
-                    success: true,
-                  },
-                });
-              }
-            } else if (step.content) {
-              // Assistant thinking
-              events.push({
-                id: `sync-${eventId++}`,
-                type: 'assistant',
-                timestamp: now,
-                data: {
-                  content: step.content,
-                },
-              });
-            }
-          }
-        }
-
-        // Complete event
-        events.push({
-          id: `sync-${eventId++}`,
-          type: 'complete',
-          timestamp: now,
-          data: {
-            success: result.success,
-            answer: result.answer,
-            totalTurns: result.total_turns,
-          },
-        });
-
-        // Error event if there was an error
-        if (result.error) {
-          events.push({
-            id: `sync-${eventId++}`,
-            type: 'error',
-            timestamp: now,
-            data: {
-              message: result.error,
-            },
-          });
-        }
-
-        updateMessage(loadingMessageId, {
-          content: serializeEventsToText(events),
-          streamEvents: events,
-          rawAnswer: result.answer || undefined,
-          isLoading: false,
-          traceId: result.trace_id,
-          error: result.error,
-        });
-      } else {
-        // Streaming mode: use SSE endpoint
-        const events: StreamEventRecord[] = [];
-        let finalAnswer = "";
-        let traceId: string | undefined;
-        let hasError = false;
-        let errorMessage = "";
-        let isComplete = false;
-        const outputFiles: OutputFileInfo[] = [];
-
-        await publishedAgentApi.chatStream(
-          agentId,
-          {
-            request: userMessage.content,
-            session_id: sessionId,
-            uploaded_files: agentFiles,
-          },
-          (event: StreamEvent) => {
-            // Accumulate text_delta into assistant records, or map other events
-            handleStreamEvent(event, events);
-
-            // Handle special cases
-            switch (event.event_type) {
-              case "run_started":
-                traceId = event.trace_id;
-                currentTraceIdRef.current = traceId || null;
-                flushSync(() => {
-                  updateMessage(loadingMessageId, { traceId });
-                });
-                break;
-              case "complete":
-                if (isComplete) break;
-                isComplete = true;
-                finalAnswer = event.answer || "";
-                break;
-              case "error":
-                hasError = true;
-                errorMessage = event.message || event.error || "Unknown error";
-                break;
-              case "trace_saved":
-                traceId = event.trace_id;
-                break;
-              case "output_file":
-                if (event.file_id && event.filename && event.download_url) {
-                  const fileInfo: OutputFileInfo = {
-                    file_id: event.file_id,
-                    filename: event.filename,
-                    size: event.size || 0,
-                    content_type: event.content_type || "application/octet-stream",
-                    download_url: event.download_url,
-                    description: event.description,
-                  };
-                  outputFiles.push(fileInfo);
-                  flushSync(() => {
-                    setCurrentOutputFiles([...outputFiles]);
-                  });
-                }
-                break;
-            }
-
-            flushSync(() => {
-              setStreamingEvents([...events]);
-              setStreamingContent(serializeEventsToText(events));
-            });
-          },
-          abortController.signal
-        );
-
-        updateMessage(loadingMessageId, {
-          content: serializeEventsToText(events),
-          streamEvents: events,
-          rawAnswer: finalAnswer || undefined,
-          isLoading: false,
-          traceId,
-          error: hasError ? errorMessage : undefined,
-          outputFiles: outputFiles.length > 0 ? outputFiles : undefined,
-        });
-      }
-    } catch (err) {
-      if (err instanceof Error && err.name === "AbortError") {
-        return;
-      }
-      updateMessage(loadingMessageId, {
-        content: "Failed to run agent",
-        isLoading: false,
-        error: err instanceof Error ? err.message : "Unknown error",
-      });
-    } finally {
-      setIsRunning(false);
-      setStreamingMessageId(null);
-      setStreamingContent(null);
-      setStreamingEvents([]);
-      setCurrentOutputFiles([]);
-      abortControllerRef.current = null;
-      currentTraceIdRef.current = null;
-    }
-  };
-
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === "Enter" && !e.shiftKey) {
-      e.preventDefault();
-      handleSubmit();
-    }
-  };
-
-  const handleStop = () => {
-    if (!isRunning || !abortControllerRef.current) return;
-    abortControllerRef.current.abort();
-    // Remove last two messages (user + loading)
-    setMessages((prev) => prev.slice(0, -2));
-    setIsRunning(false);
-    setStreamingMessageId(null);
-    setStreamingContent(null);
-    setStreamingEvents([]);
-    setCurrentOutputFiles([]);
-    abortControllerRef.current = null;
-    currentTraceIdRef.current = null;
-  };
-
-  const handleFileUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const files = e.target.files;
-    if (!files || files.length === 0) return;
-
-    setIsUploading(true);
-    try {
-      for (const file of Array.from(files)) {
-        const uploaded = await filesApi.upload(file);
-        setUploadedFiles((prev) => [...prev, uploaded]);
-      }
-    } catch (err) {
-      console.error("File upload failed:", err);
-      toast.error(err instanceof Error ? err.message : "File upload failed");
-    } finally {
-      setIsUploading(false);
-      if (fileInputRef.current) {
-        fileInputRef.current.value = "";
-      }
-    }
-  };
-
-  const handleRemoveFile = async (fileId: string) => {
-    try {
-      await filesApi.delete(fileId);
-    } catch {
-      // Ignore server delete errors
-    }
-    setUploadedFiles((prev) => prev.filter((f) => f.file_id !== fileId));
   };
 
   if (loadingInfo || restoringSession) {
@@ -479,7 +197,7 @@ export default function PublishedChatPage() {
       <div className="flex items-center justify-center min-h-screen">
         <div className="text-center">
           <Bot className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
-          <h1 className="text-xl font-semibold mb-2">Agent Not Available</h1>
+          <h1 className="text-xl font-semibold mb-2">{t('agentNotAvailable')}</h1>
           <p className="text-muted-foreground">{infoError}</p>
         </div>
       </div>
@@ -493,19 +211,11 @@ export default function PublishedChatPage() {
         <Bot className="h-6 w-6 text-primary" />
         <div className="flex-1">
           <h1 className="font-semibold text-lg">{agentName}</h1>
-          {agentDescription && (
-            <p className="text-sm text-muted-foreground">{agentDescription}</p>
-          )}
+          {agentDescription && <p className="text-sm text-muted-foreground">{agentDescription}</p>}
         </div>
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={handleNewChat}
-          disabled={isRunning}
-          title="Start new chat"
-        >
+        <Button variant="outline" size="sm" onClick={handleNewChat} disabled={isRunning} title={t('newChat')}>
           <MessageSquarePlus className="h-4 w-4 mr-1" />
-          New Chat
+          {t('newChat')}
         </Button>
       </div>
 
@@ -514,100 +224,70 @@ export default function PublishedChatPage() {
         {messages.length === 0 ? (
           <div className="text-center text-muted-foreground py-16">
             <Bot className="h-12 w-12 mx-auto mb-4 opacity-50" />
-            <p className="text-lg">Start a conversation</p>
-            <p className="text-sm mt-2">Type a message below to begin.</p>
+            <p className="text-lg">{t('startConversation')}</p>
+            <p className="text-sm mt-2">{t('published.typeToBegin')}</p>
           </div>
         ) : (
           messages.map((message) => (
             <div key={message.id} className="max-w-4xl mx-auto">
               <ChatMessageItem
                 message={message}
-                streamingContent={message.id === streamingMessageId ? streamingContent : null}
-                streamingEvents={message.id === streamingMessageId ? streamingEvents : undefined}
-                streamingOutputFiles={message.id === streamingMessageId ? currentOutputFiles : undefined}
+                streamingContent={message.id === engine.streamingMessageId ? engine.streamingContent : null}
+                streamingEvents={message.id === engine.streamingMessageId ? engine.streamingEvents : undefined}
+                streamingOutputFiles={message.id === engine.streamingMessageId ? engine.currentOutputFiles : undefined}
                 hideTraceLink
               />
             </div>
           ))
         )}
-        <div ref={messagesEndRef} />
+        <div ref={engine.messagesEndRef} />
       </div>
 
       {/* Input */}
       <div className="border-t px-6 py-4 shrink-0">
         <div className="max-w-4xl mx-auto">
-          {/* Uploaded Files Display */}
           {uploadedFiles.length > 0 && (
             <div className="mb-3 flex flex-wrap gap-2">
               {uploadedFiles.map((file) => (
-                <div
-                  key={file.file_id}
-                  className="flex items-center gap-1 bg-muted rounded px-2 py-1 text-xs"
-                >
+                <div key={file.file_id} className="flex items-center gap-1 bg-muted rounded px-2 py-1 text-xs">
                   <Paperclip className="h-3 w-3" />
-                  <span className="max-w-[150px] truncate" title={file.filename}>
-                    {file.filename}
-                  </span>
-                  <button
-                    onClick={() => handleRemoveFile(file.file_id)}
-                    className="hover:text-destructive ml-1"
-                    title="Remove file"
-                  >
+                  <span className="max-w-[150px] truncate" title={file.filename}>{file.filename}</span>
+                  <button onClick={() => engine.handleRemoveFile(file.file_id)} className="hover:text-destructive ml-1" title={t('files.remove')}>
                     <X className="h-3 w-3" />
                   </button>
                 </div>
               ))}
             </div>
           )}
-
           <div className="flex gap-2">
             <Textarea
-              value={input}
-              onChange={(e) => setInput(e.target.value)}
-              onKeyDown={handleKeyDown}
-              placeholder={isRunning ? "Steer the agent..." : "Type your message..."}
+              value={engine.input}
+              onChange={(e) => engine.setInput(e.target.value)}
+              onKeyDown={engine.handleKeyDown}
+              placeholder={isRunning ? t('steering.placeholder') : t('placeholder')}
               className="min-h-[80px] resize-none"
             />
           </div>
           <div className="flex justify-between items-center mt-2">
             <div className="flex items-center gap-2">
-              <input
-                ref={fileInputRef}
-                type="file"
-                multiple
-                onChange={handleFileUpload}
-                className="hidden"
-                disabled={isRunning || isUploading}
-              />
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => fileInputRef.current?.click()}
-                disabled={isRunning || isUploading}
-                title="Upload files"
-              >
+              <input ref={engine.fileInputRef} type="file" multiple onChange={engine.handleFileUpload} className="hidden" disabled={isRunning || engine.isUploading} />
+              <Button variant="outline" size="sm" onClick={() => engine.fileInputRef.current?.click()} disabled={isRunning || engine.isUploading} title={t('files.upload')}>
                 <Paperclip className="h-4 w-4 mr-1" />
-                {isUploading ? "Uploading..." : "Attach"}
+                {engine.isUploading ? t('files.uploading') : t('attach')}
               </Button>
-              <span className="text-xs text-muted-foreground">
-                Enter to send
-              </span>
+              <span className="text-xs text-muted-foreground">{t('enterToSend')}</span>
             </div>
             {isRunning ? (
               <div className="flex items-center gap-2">
-                <Button onClick={handleStop} variant="destructive" size="sm">
-                  <Square className="h-4 w-4 mr-1" />
-                  Stop
+                <Button onClick={engine.handleStop} variant="destructive" size="sm">
+                  <Square className="h-4 w-4 mr-1" />{t('stop')}
                 </Button>
-                <Button onClick={handleSubmit} disabled={!input.trim()} size="sm">
-                  <Navigation className="h-4 w-4 mr-1" />
-                  Steer
+                <Button onClick={engine.handleSubmit} disabled={!engine.input.trim()} size="sm">
+                  <Navigation className="h-4 w-4 mr-1" />{t('steering.button')}
                 </Button>
               </div>
             ) : (
-              <Button onClick={handleSubmit} disabled={!input.trim()}>
-                Send
-              </Button>
+              <Button onClick={engine.handleSubmit} disabled={!engine.input.trim()}>{t('send')}</Button>
             )}
           </div>
         </div>

--- a/web/src/components/chat/chat-panel.tsx
+++ b/web/src/components/chat/chat-panel.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import React from "react";
-import { flushSync } from "react-dom";
 import Link from "next/link";
 import { useQuery } from "@tanstack/react-query";
 import { RotateCcw, Paperclip, X, Wrench, Plug, ChevronDown, ChevronUp, Square, Bot, Cpu, Maximize2, Server, Navigation, Plus } from "lucide-react";
@@ -19,14 +18,13 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { MultiSelect } from "@/components/ui/multi-select";
-import { skillsApi, agentApi, filesApi, mcpApi, toolsApi, agentPresetsApi, modelsApi, executorsApi } from "@/lib/api";
-import type { StreamEvent, OutputFileInfo } from "@/lib/api";
-import { useChatStore, REQUIRED_TOOLS, type ChatMessage } from "@/stores/chat-store";
+import { skillsApi, agentApi, mcpApi, toolsApi, agentPresetsApi, modelsApi, executorsApi } from "@/lib/api";
+import type { StreamEvent } from "@/lib/api";
+import { useChatStore, REQUIRED_TOOLS } from "@/stores/chat-store";
 import { useChatSessionRestore } from "@/hooks/use-chat-session";
+import { useChatEngine } from "@/hooks/use-chat-engine";
 import { ChatMessageItem } from "./chat-message";
-import type { StreamEventRecord } from "@/types/stream-events";
-import { handleStreamEvent, serializeEventsToText } from "@/lib/stream-utils";
-import { toast } from "sonner";
+import { useTranslation } from "@/i18n/client";
 
 interface ChatPanelProps {
   isOpen: boolean;
@@ -35,17 +33,12 @@ interface ChatPanelProps {
 }
 
 export function ChatPanel({ isOpen, onClose, defaultSkills = [] }: ChatPanelProps) {
-  const [input, setInput] = React.useState("");
-  const [streamingContent, setStreamingContent] = React.useState<string | null>(null);
-  const [streamingEvents, setStreamingEvents] = React.useState<StreamEventRecord[]>([]);
-  const [streamingMessageId, setStreamingMessageId] = React.useState<string | null>(null);
-  const [currentOutputFiles, setCurrentOutputFiles] = React.useState<OutputFileInfo[]>([]);
-  const messagesEndRef = React.useRef<HTMLDivElement>(null);
+  const { t } = useTranslation('chat');
+  const { t: tc } = useTranslation('common');
 
   // Use zustand store for persistence
   const {
     messages,
-    sessionId,
     selectedSkills,
     selectedTools,
     selectedMcpServers,
@@ -84,66 +77,101 @@ export function ChatPanel({ isOpen, onClose, defaultSkills = [] }: ChatPanelProp
   const [showToolsPanel, setShowToolsPanel] = React.useState(false);
   const [showResetDialog, setShowResetDialog] = React.useState(false);
 
-  const fileInputRef = React.useRef<HTMLInputElement>(null);
-  const [isUploading, setIsUploading] = React.useState(false);
+  // ── Shared chat engine ──
+  const engine = useChatEngine({
+    messageAdapter: {
+      getMessages: () => useChatStore.getState().messages,
+      addMessage,
+      updateMessage,
+      removeMessages,
+      getIsRunning: () => useChatStore.getState().isRunning,
+      setIsRunning,
+      getUploadedFiles: () => useChatStore.getState().uploadedFiles,
+      clearUploadedFiles,
+      addUploadedFile,
+      removeUploadedFile,
+    },
+    streamAdapter: {
+      runStream: async (request, agentFiles, onEvent, signal) => {
+        const state = useChatStore.getState();
+        let currentSessionId = state.sessionId;
+        if (!currentSessionId) {
+          currentSessionId = crypto.randomUUID();
+          setSessionId(currentSessionId);
+        }
 
-  // For stop functionality
-  const abortControllerRef = React.useRef<AbortController | null>(null);
-  const currentRequestMessagesRef = React.useRef<string[]>([]);
-  const currentTraceIdRef = React.useRef<string | null>(null);
+        const currentAgentPreset = state.selectedAgentPreset;
+        const currentModelProvider = state.selectedModelProvider;
+        const currentModelName = state.selectedModelName;
 
-  // Fetch available skills from registry database
-  const { data: skillsData } = useQuery({
-    queryKey: ["registry-skills-list"],
-    queryFn: () => skillsApi.list(),
+        let agentRequest: import("@/lib/api").AgentRequest;
+
+        if (currentAgentPreset) {
+          agentRequest = {
+            request,
+            session_id: currentSessionId,
+            agent_id: currentAgentPreset,
+            uploaded_files: agentFiles,
+            model_provider: currentModelProvider || undefined,
+            model_name: currentModelName || undefined,
+          };
+        } else {
+          const currentSkills = state.selectedSkills;
+          const currentMcpServers = state.selectedMcpServers;
+          const currentTools = state.selectedTools;
+          const currentSystemPrompt = state.systemPrompt;
+          const currentExecutorId = state.selectedExecutorId;
+
+          const skillsList = currentSkills.length > 0 ? currentSkills : undefined;
+          const mcpServersList = (currentMcpServers === null || currentMcpServers.length === 0) ? undefined : currentMcpServers;
+          const toolsList = currentTools && currentTools.length > 0 ? currentTools : undefined;
+
+          agentRequest = {
+            request,
+            session_id: currentSessionId,
+            skills: skillsList,
+            allowed_tools: toolsList,
+            max_turns: state.maxTurns,
+            uploaded_files: agentFiles,
+            equipped_mcp_servers: mcpServersList,
+            system_prompt: currentSystemPrompt || undefined,
+            model_provider: currentModelProvider || undefined,
+            model_name: currentModelName || undefined,
+            executor_id: currentExecutorId || undefined,
+          };
+        }
+
+        await agentApi.runStream(agentRequest, (event: StreamEvent) => onEvent(event), signal);
+      },
+      steer: async (traceId, message) => {
+        await agentApi.steerAgent(traceId, message);
+      },
+    },
+    onSessionId: (id) => setSessionId(id),
   });
 
-  // Filter to user skills only (exclude meta skills)
+  // Fetch available data
+  const { data: skillsData } = useQuery({ queryKey: ["registry-skills-list"], queryFn: () => skillsApi.list() });
   const skills = (skillsData?.skills || []).filter(s => s.skill_type === 'user');
 
-  // Fetch available tools
-  const { data: toolsData } = useQuery({
-    queryKey: ["tools-list"],
-    queryFn: () => toolsApi.list(),
-  });
-
+  const { data: toolsData } = useQuery({ queryKey: ["tools-list"], queryFn: () => toolsApi.list() });
   const tools = toolsData?.tools || [];
 
-  // Fetch available MCP servers
-  const { data: mcpData } = useQuery({
-    queryKey: ["mcp-servers"],
-    queryFn: () => mcpApi.listServers(),
-  });
-
+  const { data: mcpData } = useQuery({ queryKey: ["mcp-servers"], queryFn: () => mcpApi.listServers() });
   const mcpServers = mcpData?.servers || [];
 
-  // Fetch available agents (only user-created, not system)
-  const { data: agentPresetsData } = useQuery({
-    queryKey: ["agent-presets-user"],
-    queryFn: () => agentPresetsApi.list({ is_system: false }),
-  });
-
+  const { data: agentPresetsData } = useQuery({ queryKey: ["agent-presets-user"], queryFn: () => agentPresetsApi.list({ is_system: false }) });
   const agentPresets = agentPresetsData?.presets || [];
 
-  // Fetch available models grouped by provider
-  const { data: modelsData } = useQuery({
-    queryKey: ["models-providers"],
-    queryFn: () => modelsApi.listProviders(),
-  });
-
+  const { data: modelsData } = useQuery({ queryKey: ["models-providers"], queryFn: () => modelsApi.listProviders() });
   const modelProviders = modelsData?.providers || [];
 
-  // Fetch executors
-  const { data: executorsData } = useQuery({
-    queryKey: ["executors-list"],
-    queryFn: () => executorsApi.list(),
-  });
-
+  const { data: executorsData } = useQuery({ queryKey: ["executors-list"], queryFn: () => executorsApi.list() });
   const onlineExecutors = (executorsData?.executors || []).filter(e => e.status === 'online');
 
   // Auto-scroll to bottom
   React.useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+    engine.messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages]);
 
   // Update selected skills when defaultSkills changes (from skill detail page)
@@ -154,31 +182,20 @@ export function ChatPanel({ isOpen, onClose, defaultSkills = [] }: ChatPanelProp
   }, [defaultSkills, setSelectedSkills]);
 
   // Initialize selected tools with all tools selected by default
-  // Note: null means not initialized, empty array means user explicitly deselected all
-  // We only auto-select when null (first time) or when tools list changes and current selection is invalid
   React.useEffect(() => {
-    if (tools.length > 0) {
-      if (selectedTools === null) {
-        // First time initialization - select all tools
-        const allToolNames = tools.map((tool) => tool.name);
-        setSelectedTools(allToolNames);
-      }
+    if (tools.length > 0 && selectedTools === null) {
+      setSelectedTools(tools.map((tool) => tool.name));
     }
   }, [tools, selectedTools, setSelectedTools]);
 
   // Initialize selected MCP servers - default_enabled servers are auto-selected
-  // Only auto-select on first load (null), NOT when user explicitly deselects all (empty array)
   React.useEffect(() => {
     if (mcpServers.length > 0 && selectedMcpServers === null) {
-      const defaultEnabledServers = mcpServers
-        .filter((server) => server.default_enabled)
-        .map((server) => server.name);
-      setSelectedMcpServers(defaultEnabledServers);
+      setSelectedMcpServers(mcpServers.filter((s) => s.default_enabled).map((s) => s.name));
     }
   }, [mcpServers, selectedMcpServers, setSelectedMcpServers]);
 
   // Sync systemPrompt from selected preset on page load
-  // This handles the case where preset ID is restored from localStorage but systemPrompt wasn't set
   React.useEffect(() => {
     if (agentPresets.length > 0 && selectedAgentPreset) {
       const preset = agentPresets.find((p) => p.id === selectedAgentPreset);
@@ -188,323 +205,27 @@ export function ChatPanel({ isOpen, onClose, defaultSkills = [] }: ChatPanelProp
     }
   }, [agentPresets, selectedAgentPreset, systemPrompt, setSystemPrompt]);
 
-  const handleSteer = async (message: string) => {
-    const traceId = currentTraceIdRef.current;
-    if (!traceId) return;
-    try {
-      await agentApi.steerAgent(traceId, message);
-      setInput("");
-    } catch (err) {
-      toast.error(err instanceof Error ? err.message : "Failed to send steering message");
-    }
-  };
-
-  const handleSubmit = async () => {
-    if (!input.trim()) return;
-
-    // Steering mode: inject message into running agent
-    if (useChatStore.getState().isRunning && currentTraceIdRef.current) {
-      await handleSteer(input.trim());
-      return;
-    }
-
-    // Normal mode: prevent concurrent runs
-    if (useChatStore.getState().isRunning) return;
-
-    // Create abort controller for this request
-    const abortController = new AbortController();
-    abortControllerRef.current = abortController;
-
-    // Capture uploaded files before clearing
-    const agentFiles = uploadedFiles.length > 0
-      ? uploadedFiles.map((f) => ({
-          file_id: f.file_id,
-          filename: f.filename,
-          path: f.path,
-          content_type: f.content_type,
-        }))
-      : undefined;
-
-    const userMessage: ChatMessage = {
-      id: Date.now().toString(),
-      role: "user",
-      content: input.trim(),
-      timestamp: Date.now(),
-      attachedFiles: uploadedFiles.length > 0
-        ? uploadedFiles.map((f) => ({ file_id: f.file_id, filename: f.filename }))
-        : undefined,
-    };
-
-    const loadingMessageId = (Date.now() + 1).toString();
-    const loadingMessage: ChatMessage = {
-      id: loadingMessageId,
-      role: "assistant",
-      content: "",
-      timestamp: Date.now(),
-      isLoading: true,
-    };
-
-    // Track message IDs for this request (for stop functionality)
-    currentRequestMessagesRef.current = [userMessage.id, loadingMessageId];
-
-    addMessage(userMessage);
-    addMessage(loadingMessage);
-    setInput("");
-    clearUploadedFiles();
-    setIsRunning(true);
-    setStreamingMessageId(loadingMessageId);
-    setStreamingContent("");
-    setStreamingEvents([]);
-    setCurrentOutputFiles([]);
-
-    try {
-      // Read skills from current store state to avoid stale closures
-      const currentSkills = useChatStore.getState().selectedSkills;
-      const skillsList = currentSkills.length > 0 ? currentSkills : undefined;
-
-      // Generate session_id if none exists (deferred creation)
-      let currentSessionId = useChatStore.getState().sessionId;
-      if (!currentSessionId) {
-        currentSessionId = crypto.randomUUID();
-        setSessionId(currentSessionId);
-      }
-
-      // Accumulate streaming events using ref to avoid closure issues
-      const events: StreamEventRecord[] = [];
-      let finalAnswer = "";
-      let traceId: string | undefined;
-      let hasError = false;
-      let errorMessage = "";
-      let isComplete = false;
-      const outputFiles: OutputFileInfo[] = [];
-
-      // Read current values directly from store to avoid stale closures
-      // This ensures we always get the latest value, not a potentially stale render closure
-      const currentState = useChatStore.getState();
-      const currentMcpServers = currentState.selectedMcpServers;
-      const currentTools = currentState.selectedTools;
-      const currentSystemPrompt = currentState.systemPrompt;
-      const currentAgentPreset = currentState.selectedAgentPreset;
-      const currentModelProvider = currentState.selectedModelProvider;
-      const currentModelName = currentState.selectedModelName;
-      const currentExecutorId = currentState.selectedExecutorId;
-
-      // Build request: if agent is selected, send agent_id and let backend handle config
-      let agentRequest: import("@/lib/api").AgentRequest;
-
-      if (currentAgentPreset) {
-        // Agent preset selected: backend resolves config from preset
-        // But if user manually selected a model, override preset's model
-        agentRequest = {
-          request: userMessage.content,
-          session_id: currentSessionId,
-          agent_id: currentAgentPreset,
-          uploaded_files: agentFiles,
-          model_provider: currentModelProvider || undefined,
-          model_name: currentModelName || undefined,
-        };
-      } else {
-        // Custom config: send individual fields
-        // MCP servers list:
-        // - null or empty array = use backend defaults (default_enabled servers)
-        // - non-empty array = use specified servers
-        const mcpServersList = (currentMcpServers === null || currentMcpServers.length === 0)
-          ? undefined
-          : currentMcpServers;
-
-        // Tools list: pass selected tools (required tools always included by backend)
-        // null means not initialized, undefined tells backend to use all tools
-        const toolsList = currentTools && currentTools.length > 0 ? currentTools : undefined;
-
-        agentRequest = {
-          request: userMessage.content,
-          session_id: currentSessionId,
-          skills: skillsList,
-          allowed_tools: toolsList,
-          max_turns: maxTurns,
-          uploaded_files: agentFiles,
-          equipped_mcp_servers: mcpServersList,
-          system_prompt: currentSystemPrompt || undefined,
-          model_provider: currentModelProvider || undefined,
-          model_name: currentModelName || undefined,
-          executor_id: currentExecutorId || undefined,
-        };
-      }
-
-      await agentApi.runStream(
-        agentRequest,
-        (event: StreamEvent) => {
-          // Accumulate text_delta into assistant records, or map other events
-          handleStreamEvent(event, events);
-
-          // Handle special cases
-          switch (event.event_type) {
-            case "run_started":
-              // Capture trace_id and session_id immediately when run starts
-              traceId = event.trace_id;
-              currentTraceIdRef.current = traceId || null;
-              if (event.session_id) {
-                setSessionId(event.session_id);
-              }
-              // Update message with trace_id right away
-              flushSync(() => {
-                updateMessage(loadingMessageId, { traceId: traceId });
-              });
-              break;
-            case "complete":
-              if (isComplete) break; // Guard against duplicate complete events
-              isComplete = true;
-              finalAnswer = event.answer || "";
-              // Capture error from complete event with success=false
-              if (event.success === false && !hasError) {
-                hasError = true;
-                errorMessage = event.error || event.answer || "Agent run failed";
-              }
-              break;
-            case "error":
-              hasError = true;
-              errorMessage = event.message || event.error || "Unknown error";
-              break;
-            case "trace_saved":
-              traceId = event.trace_id;
-              break;
-            case "output_file":
-              if (event.file_id && event.filename && event.download_url) {
-                const fileInfo: OutputFileInfo = {
-                  file_id: event.file_id,
-                  filename: event.filename,
-                  size: event.size || 0,
-                  content_type: event.content_type || "application/octet-stream",
-                  download_url: event.download_url,
-                  description: event.description,
-                };
-                outputFiles.push(fileInfo);
-                // Update current output files for display
-                flushSync(() => {
-                  setCurrentOutputFiles([...outputFiles]);
-                });
-              }
-              break;
-          }
-
-          // Use flushSync to force immediate re-render
-          flushSync(() => {
-            setStreamingEvents([...events]);
-            // Also update text content for backward compatibility
-            setStreamingContent(serializeEventsToText(events));
-          });
-        },
-        abortController.signal
-      );
-
-      // Final update to store
-      updateMessage(loadingMessageId, {
-        content: serializeEventsToText(events),  // Text fallback for backward compatibility
-        streamEvents: events,  // Structured events for rich UI
-        rawAnswer: finalAnswer || undefined,  // Store clean answer for conversation history
-        isLoading: false,
-        traceId: traceId,
-        error: hasError ? errorMessage : undefined,
-        outputFiles: outputFiles.length > 0 ? outputFiles : undefined,
-      });
-    } catch (err) {
-      // Check if this was an abort (user clicked stop)
-      if (err instanceof Error && err.name === 'AbortError') {
-        // Request was stopped by user - messages already removed by handleStop
-        return;
-      }
-      updateMessage(loadingMessageId, {
-        content: "Failed to run agent",
-        isLoading: false,
-        error: err instanceof Error ? err.message : "Unknown error",
-      });
-    } finally {
-      setIsRunning(false);
-      setStreamingMessageId(null);
-      setStreamingContent(null);
-      setStreamingEvents([]);
-      setCurrentOutputFiles([]);
-      abortControllerRef.current = null;
-      currentRequestMessagesRef.current = [];
-      currentTraceIdRef.current = null;
-    }
-  };
-
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === "Enter" && !e.shiftKey) {
-      e.preventDefault();
-      handleSubmit();
-    }
-  };
-
-  const handleReset = () => {
-    if (!isRunning) {
-      setShowResetDialog(true);
-    }
-  };
-
-  const handleStop = async () => {
-    if (!isRunning || !abortControllerRef.current) return;
-
-    // Abort the fetch request
-    abortControllerRef.current.abort();
-
-    // Remove the messages from this request (user message + loading message)
-    if (currentRequestMessagesRef.current.length > 0) {
-      removeMessages(currentRequestMessagesRef.current);
-    }
-
-    // Note: Trace is preserved (not deleted) even when cancelled
-    // The backend will keep it with success=False state for debugging/history
-
-    // Reset state
-    setIsRunning(false);
-    setStreamingMessageId(null);
-    setStreamingContent(null);
-    setStreamingEvents([]);
-    setCurrentOutputFiles([]);
-    abortControllerRef.current = null;
-    currentRequestMessagesRef.current = [];
-    currentTraceIdRef.current = null;
-  };
-
-  const handleFileUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const files = e.target.files;
-    if (!files || files.length === 0) return;
-
-    setIsUploading(true);
-    try {
-      for (const file of Array.from(files)) {
-        const uploadedFile = await filesApi.upload(file);
-        addUploadedFile(uploadedFile);
-      }
-    } catch (err) {
-      console.error("File upload failed:", err);
-      toast.error(err instanceof Error ? err.message : "File upload failed");
-    } finally {
-      setIsUploading(false);
-      // Reset input so the same file can be uploaded again
-      if (fileInputRef.current) {
-        fileInputRef.current.value = "";
-      }
-    }
-  };
-
-  const handleRemoveFile = async (fileId: string) => {
-    try {
-      await filesApi.delete(fileId);
-      removeUploadedFile(fileId);
-    } catch (err) {
-      console.error("Failed to delete file:", err);
-      // Still remove from UI even if server delete fails
-      removeUploadedFile(fileId);
-    }
-  };
-
   const handleOpenFullscreen = () => {
-    // Open fullscreen chat in new window
-    // The chat state is persisted in localStorage via zustand, so the new window will share the same state
     window.open("/chat", "_blank", "noopener,noreferrer");
+  };
+
+  const applyPreset = (presetId: string) => {
+    const preset = agentPresets.find((p) => p.id === presetId);
+    if (!preset) return;
+    setSelectedAgentPreset(preset.id);
+    setSelectedSkills(preset.skill_ids || []);
+    setMaxTurns(preset.max_turns);
+    setSystemPrompt(preset.system_prompt || null);
+    if (preset.builtin_tools === null && tools.length > 0) {
+      setSelectedTools(tools.map(t => t.name));
+    } else if (preset.builtin_tools && preset.builtin_tools.length > 0) {
+      setSelectedTools(preset.builtin_tools);
+    } else {
+      setSelectedTools([]);
+    }
+    setSelectedMcpServers(preset.mcp_servers || []);
+    setSelectedModel(preset.model_provider || null, preset.model_name || null);
+    setSelectedExecutorId(preset.executor_id || null);
   };
 
   if (!isOpen) return null;
@@ -513,36 +234,19 @@ export function ChatPanel({ isOpen, onClose, defaultSkills = [] }: ChatPanelProp
     <div className="fixed right-0 top-0 h-full w-full sm:w-[480px] bg-background border-l shadow-lg flex flex-col z-50">
       {/* Header */}
       <div className="p-4 border-b flex items-center justify-between">
-        <h2 className="font-semibold">Chat Panel</h2>
+        <h2 className="font-semibold">{t('chatPanel')}</h2>
         <div className="flex items-center gap-2">
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => newSession()}
-            disabled={messages.length === 0 || isRunning}
-            title="New Chat"
-          >
+          <Button variant="ghost" size="sm" onClick={() => newSession()} disabled={messages.length === 0 || isRunning} title={t('newChat')}>
             <Plus className="h-4 w-4" />
           </Button>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={handleReset}
-            disabled={isRunning}
-            title="Reset everything"
-          >
+          <Button variant="ghost" size="sm" onClick={() => !isRunning && setShowResetDialog(true)} disabled={isRunning} title={t('resetEverything')}>
             <RotateCcw className="h-4 w-4" />
           </Button>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={handleOpenFullscreen}
-            title="Open in new window"
-          >
+          <Button variant="ghost" size="sm" onClick={handleOpenFullscreen} title={t('openFullscreen')}>
             <Maximize2 className="h-4 w-4" />
           </Button>
           <Button variant="ghost" size="sm" onClick={onClose}>
-            Close
+            {t('close')}
           </Button>
         </div>
       </div>
@@ -551,51 +255,22 @@ export function ChatPanel({ isOpen, onClose, defaultSkills = [] }: ChatPanelProp
       {agentPresets.length > 0 && (
         <div className="px-4 py-2 border-b bg-primary/5 flex items-center gap-2 text-xs">
           <Bot className="h-3.5 w-3.5 text-primary" />
-          <span className="text-muted-foreground">Agent:</span>
+          <span className="text-muted-foreground">{t('configuration.agent')}:</span>
           <select
             value={selectedAgentPreset || ""}
             onChange={(e) => {
               const presetId = e.target.value;
-              if (!presetId) {
-                // Clear preset selection, keep current config
-                setSelectedAgentPreset(null);
-                setSystemPrompt(null);
-              } else {
-                // Apply preset
-                const preset = agentPresets.find((p) => p.id === presetId);
-                if (preset) {
-                  setSelectedAgentPreset(preset.id);
-                  setSelectedSkills(preset.skill_ids || []);
-                  setMaxTurns(preset.max_turns);
-                  setSystemPrompt(preset.system_prompt || null);
-                  // null means all tools enabled, otherwise use the specified list
-                  if (preset.builtin_tools === null && tools.length > 0) {
-                    setSelectedTools(tools.map(t => t.name));
-                  } else if (preset.builtin_tools && preset.builtin_tools.length > 0) {
-                    setSelectedTools(preset.builtin_tools);
-                  } else {
-                    setSelectedTools([]);
-                  }
-                  setSelectedMcpServers(preset.mcp_servers || []);
-                  // Apply model from preset
-                  setSelectedModel(preset.model_provider || null, preset.model_name || null);
-                  // Apply executor from preset
-                  setSelectedExecutorId(preset.executor_id || null);
-                }
-              }
+              if (!presetId) { setSelectedAgentPreset(null); setSystemPrompt(null); }
+              else applyPreset(presetId);
             }}
             className="h-6 text-xs px-2 rounded border bg-background flex-1 max-w-[160px]"
           >
-            <option value="">Custom Config</option>
+            <option value="">{t('configuration.customConfig')}</option>
             {agentPresets.map((preset) => (
-              <option key={preset.id} value={preset.id}>
-                {preset.name}
-              </option>
+              <option key={preset.id} value={preset.id}>{preset.name}</option>
             ))}
           </select>
-          <Link href="/agents" className="text-primary hover:underline text-xs">
-            Manage
-          </Link>
+          <Link href="/agents" className="text-primary hover:underline text-xs">{t('manage')}</Link>
         </div>
       )}
 
@@ -603,29 +278,22 @@ export function ChatPanel({ isOpen, onClose, defaultSkills = [] }: ChatPanelProp
       {modelProviders.length > 0 && (
         <div className="px-4 py-2 border-b bg-muted/30 flex items-center gap-2 text-xs">
           <Cpu className="h-3.5 w-3.5 text-muted-foreground" />
-          <span className="text-muted-foreground">Model:</span>
+          <span className="text-muted-foreground">{t('configuration.model')}:</span>
           <select
             value={selectedModelProvider && selectedModelName ? `${selectedModelProvider}/${selectedModelName}` : ""}
             onChange={(e) => {
               const value = e.target.value;
-              if (!value) {
-                setSelectedModel(null, null);
-              } else {
-                const [provider, ...modelParts] = value.split('/');
-                const modelName = modelParts.join('/');
-                setSelectedModel(provider, modelName);
-              }
-              setSelectedAgentPreset(null); // Clear preset when manually changing model
+              if (!value) { setSelectedModel(null, null); }
+              else { const [provider, ...p] = value.split('/'); setSelectedModel(provider, p.join('/')); }
+              setSelectedAgentPreset(null);
             }}
             className="h-6 text-xs px-2 rounded border bg-background flex-1"
           >
-            <option value="">Default (Kimi K2.5)</option>
+            <option value="">{t('defaultModel')}</option>
             {modelProviders.map((provider) => (
               <optgroup key={provider.name} label={provider.name.charAt(0).toUpperCase() + provider.name.slice(1)}>
                 {provider.models.map((model) => (
-                  <option key={model.key} value={model.key}>
-                    {model.display_name}
-                  </option>
+                  <option key={model.key} value={model.key}>{model.display_name}</option>
                 ))}
               </optgroup>
             ))}
@@ -633,24 +301,19 @@ export function ChatPanel({ isOpen, onClose, defaultSkills = [] }: ChatPanelProp
         </div>
       )}
 
-      {/* Executor Selector - only show if there are online executors */}
+      {/* Executor Selector */}
       {onlineExecutors.length > 0 && (
         <div className="px-4 py-2 border-b bg-muted/30 flex items-center gap-2 text-xs">
           <Server className="h-3.5 w-3.5 text-muted-foreground" />
-          <span className="text-muted-foreground">Executor:</span>
+          <span className="text-muted-foreground">{t('configuration.executor')}:</span>
           <select
             value={selectedExecutorId || ""}
-            onChange={(e) => {
-              setSelectedExecutorId(e.target.value || null);
-              setSelectedAgentPreset(null); // Clear preset when manually changing
-            }}
+            onChange={(e) => { setSelectedExecutorId(e.target.value || null); setSelectedAgentPreset(null); }}
             className="h-6 text-xs px-2 rounded border bg-background flex-1"
           >
-            <option value="">Local</option>
+            <option value="">{t('configuration.executorLocal')}</option>
             {onlineExecutors.map((executor) => (
-              <option key={executor.id} value={executor.id}>
-                {executor.name}
-              </option>
+              <option key={executor.id} value={executor.id}>{executor.name}</option>
             ))}
           </select>
         </div>
@@ -660,57 +323,35 @@ export function ChatPanel({ isOpen, onClose, defaultSkills = [] }: ChatPanelProp
       <div className={`px-4 py-2 border-b bg-muted/50 text-xs ${selectedAgentPreset ? 'relative' : ''}`}>
         {selectedAgentPreset && (
           <div className="flex items-center justify-between mb-1.5">
-            <span className="text-muted-foreground text-[10px]">
-              Config managed by preset — edit to switch to custom
-            </span>
+            <span className="text-muted-foreground text-[10px]">{t('configManagedByPreset')}</span>
           </div>
         )}
         <div className={`flex items-center gap-4 ${selectedAgentPreset ? 'opacity-50' : ''}`}>
           <div className="flex items-center gap-1.5">
-            <span className="text-muted-foreground">Turns</span>
+            <span className="text-muted-foreground">{t('configuration.turns')}</span>
             <Input
-              type="number"
-              min={1}
-              max={60000}
-              value={maxTurns}
-              onChange={(e) => {
-                setMaxTurns(parseInt(e.target.value) || 60);
-                setSelectedAgentPreset(null); // Clear preset when manually changing
-              }}
+              type="number" min={1} max={60000} value={maxTurns}
+              onChange={(e) => { setMaxTurns(parseInt(e.target.value) || 60); setSelectedAgentPreset(null); }}
               className="w-14 h-6 text-xs px-2"
             />
           </div>
           <div className="flex items-center gap-1.5 flex-1">
-            <span className="text-muted-foreground">Skills</span>
+            <span className="text-muted-foreground">{t('configuration.skills')}</span>
             <MultiSelect
-              options={skills.map((skill) => ({
-                value: skill.name,
-                label: skill.name,
-                description: skill.description?.slice(0, 50),
-              }))}
+              options={skills.map((skill) => ({ value: skill.name, label: skill.name, description: skill.description?.slice(0, 50) }))}
               selected={selectedSkills}
-              onChange={(skills) => {
-                setSelectedSkills(skills);
-                setSelectedAgentPreset(null); // Clear preset when manually changing
-              }}
-              placeholder="Select..."
+              onChange={(s) => { setSelectedSkills(s); setSelectedAgentPreset(null); }}
+              placeholder={t('configuration.selectSkills')}
               emptyText="None"
               className="flex-1 max-w-[120px]"
               size="sm"
             />
           </div>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => setShowToolsPanel(!showToolsPanel)}
-            className="h-6 px-2 text-xs gap-1"
-          >
+          <Button variant="ghost" size="sm" onClick={() => setShowToolsPanel(!showToolsPanel)} className="h-6 px-2 text-xs gap-1">
             <Wrench className="h-3 w-3" />
-            Tools ({(selectedTools || []).length}/{tools.length})
+            {t('configuration.tools')} ({(selectedTools || []).length}/{tools.length})
             {mcpServers.length > 0 && (
-              <span className="text-muted-foreground">
-                + MCP ({(selectedMcpServers || []).length})
-              </span>
+              <span className="text-muted-foreground">+ MCP ({(selectedMcpServers || []).length})</span>
             )}
             {showToolsPanel ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}
           </Button>
@@ -720,14 +361,11 @@ export function ChatPanel({ isOpen, onClose, defaultSkills = [] }: ChatPanelProp
       {/* Tools/MCP Panel */}
       {showToolsPanel && (
         <div className={`px-4 py-3 border-b bg-muted/30 max-h-[300px] overflow-y-auto ${selectedAgentPreset ? 'opacity-50' : ''}`}>
-          {/* Built-in Tools */}
           <div className="mb-3">
             <div className="flex items-center gap-2 mb-2">
               <Wrench className="h-3.5 w-3.5 text-muted-foreground" />
-              <span className="text-xs font-medium">Built-in Tools</span>
-              <span className="text-xs text-muted-foreground">
-                ({(selectedTools || []).length}/{tools.length} selected)
-              </span>
+              <span className="text-xs font-medium">{t('builtinTools')}</span>
+              <span className="text-xs text-muted-foreground">({(selectedTools || []).length}/{tools.length} {t('selected')})</span>
             </div>
             <div className="flex flex-wrap gap-1.5">
               {tools.map((tool) => {
@@ -738,22 +376,12 @@ export function ChatPanel({ isOpen, onClose, defaultSkills = [] }: ChatPanelProp
                     key={tool.id}
                     onClick={() => {
                       if (isRequired) return;
-                      const currentTools = selectedTools || [];
-                      if (isSelected) {
-                        setSelectedTools(currentTools.filter((t) => t !== tool.name));
-                      } else {
-                        setSelectedTools([...currentTools, tool.name]);
-                      }
-                      setSelectedAgentPreset(null); // Clear preset when manually changing
+                      const cur = selectedTools || [];
+                      setSelectedTools(isSelected ? cur.filter((t) => t !== tool.name) : [...cur, tool.name]);
+                      setSelectedAgentPreset(null);
                     }}
                     disabled={isRequired}
-                    className={`px-2 py-1 text-xs rounded-md border transition-colors ${
-                      isRequired
-                        ? 'bg-primary/20 border-primary/50 text-primary cursor-not-allowed'
-                        : isSelected
-                          ? 'bg-primary/10 border-primary text-primary hover:bg-primary/20'
-                          : 'bg-background border-border text-muted-foreground hover:bg-muted'
-                    }`}
+                    className={`px-2 py-1 text-xs rounded-md border transition-colors ${isRequired ? 'bg-primary/20 border-primary/50 text-primary cursor-not-allowed' : isSelected ? 'bg-primary/10 border-primary text-primary hover:bg-primary/20' : 'bg-background border-border text-muted-foreground hover:bg-muted'}`}
                     title={isRequired ? `${tool.name} (required)` : tool.description}
                   >
                     {tool.name}
@@ -764,15 +392,12 @@ export function ChatPanel({ isOpen, onClose, defaultSkills = [] }: ChatPanelProp
             </div>
           </div>
 
-          {/* MCP Servers */}
           {mcpServers.length > 0 && (
             <div>
               <div className="flex items-center gap-2 mb-2">
                 <Plug className="h-3.5 w-3.5 text-muted-foreground" />
-                <span className="text-xs font-medium">MCP Servers</span>
-                <span className="text-xs text-muted-foreground">
-                  ({(selectedMcpServers || []).length}/{mcpServers.length} selected)
-                </span>
+                <span className="text-xs font-medium">{t('configuration.mcpServers')}</span>
+                <span className="text-xs text-muted-foreground">({(selectedMcpServers || []).length}/{mcpServers.length} {t('selected')})</span>
               </div>
               <div className="flex flex-wrap gap-1.5">
                 {mcpServers.map((server) => {
@@ -781,19 +406,11 @@ export function ChatPanel({ isOpen, onClose, defaultSkills = [] }: ChatPanelProp
                     <button
                       key={server.name}
                       onClick={() => {
-                        const currentServers = selectedMcpServers || [];
-                        if (isSelected) {
-                          setSelectedMcpServers(currentServers.filter((s) => s !== server.name));
-                        } else {
-                          setSelectedMcpServers([...currentServers, server.name]);
-                        }
-                        setSelectedAgentPreset(null); // Clear preset when manually changing
+                        const cur = selectedMcpServers || [];
+                        setSelectedMcpServers(isSelected ? cur.filter((s) => s !== server.name) : [...cur, server.name]);
+                        setSelectedAgentPreset(null);
                       }}
-                      className={`px-2 py-1 text-xs rounded-md border transition-colors ${
-                        isSelected
-                          ? 'bg-purple-500/10 border-purple-500 text-purple-600 hover:bg-purple-500/20'
-                          : 'bg-background border-border text-muted-foreground hover:bg-muted'
-                      }`}
+                      className={`px-2 py-1 text-xs rounded-md border transition-colors ${isSelected ? 'bg-purple-500/10 border-purple-500 text-purple-600 hover:bg-purple-500/20' : 'bg-background border-border text-muted-foreground hover:bg-muted'}`}
                       title={server.description}
                     >
                       {server.display_name}
@@ -805,7 +422,7 @@ export function ChatPanel({ isOpen, onClose, defaultSkills = [] }: ChatPanelProp
           )}
 
           <p className="text-[10px] text-muted-foreground mt-3">
-            * Required tools cannot be disabled. MCP servers are disabled by default.
+            {t('requiredToolsNote')} {t('mcpDefaultNote')}
           </p>
         </div>
       )}
@@ -814,47 +431,33 @@ export function ChatPanel({ isOpen, onClose, defaultSkills = [] }: ChatPanelProp
       <div className="flex-1 overflow-auto p-4 space-y-4">
         {messages.length === 0 ? (
           <div className="text-center text-muted-foreground py-8">
-            <p>Start a conversation with the agent.</p>
-            <p className="text-sm mt-2">
-              Select skills above to limit which skills the agent can use.
-            </p>
-            <p className="text-sm mt-1">
-              Conversations support multi-turn dialogue.
-            </p>
+            <p>{t('startConversation')}.</p>
+            <p className="text-sm mt-2">{t('selectSkillsHint')}</p>
+            <p className="text-sm mt-1">{t('multiTurnHint')}</p>
           </div>
         ) : (
           messages.map((message) => (
             <ChatMessageItem
               key={message.id}
               message={message}
-              streamingContent={message.id === streamingMessageId ? streamingContent : null}
-              streamingEvents={message.id === streamingMessageId ? streamingEvents : undefined}
-              streamingOutputFiles={message.id === streamingMessageId ? currentOutputFiles : undefined}
+              streamingContent={message.id === engine.streamingMessageId ? engine.streamingContent : null}
+              streamingEvents={message.id === engine.streamingMessageId ? engine.streamingEvents : undefined}
+              streamingOutputFiles={message.id === engine.streamingMessageId ? engine.currentOutputFiles : undefined}
             />
           ))
         )}
-        <div ref={messagesEndRef} />
+        <div ref={engine.messagesEndRef} />
       </div>
 
       {/* Input */}
       <div className="p-4 border-t">
-        {/* Uploaded Files Display */}
         {uploadedFiles.length > 0 && (
           <div className="mb-3 flex flex-wrap gap-2">
             {uploadedFiles.map((file) => (
-              <div
-                key={file.file_id}
-                className="flex items-center gap-1 bg-muted rounded px-2 py-1 text-xs"
-              >
+              <div key={file.file_id} className="flex items-center gap-1 bg-muted rounded px-2 py-1 text-xs">
                 <Paperclip className="h-3 w-3" />
-                <span className="max-w-[150px] truncate" title={file.filename}>
-                  {file.filename}
-                </span>
-                <button
-                  onClick={() => handleRemoveFile(file.file_id)}
-                  className="hover:text-destructive ml-1"
-                  title="Remove file"
-                >
+                <span className="max-w-[150px] truncate" title={file.filename}>{file.filename}</span>
+                <button onClick={() => engine.handleRemoveFile(file.file_id)} className="hover:text-destructive ml-1" title={t('files.remove')}>
                   <X className="h-3 w-3" />
                 </button>
               </div>
@@ -864,51 +467,36 @@ export function ChatPanel({ isOpen, onClose, defaultSkills = [] }: ChatPanelProp
 
         <div className="flex gap-2">
           <Textarea
-            value={input}
-            onChange={(e) => setInput(e.target.value)}
-            onKeyDown={handleKeyDown}
-            placeholder={isRunning ? "Steer the agent..." : "Type your request..."}
+            value={engine.input}
+            onChange={(e) => engine.setInput(e.target.value)}
+            onKeyDown={engine.handleKeyDown}
+            placeholder={isRunning ? t('steering.placeholder') : t('placeholder')}
             className="min-h-[80px] resize-none"
           />
         </div>
         <div className="flex justify-between items-center mt-2">
           <div className="flex items-center gap-2">
-            <input
-              ref={fileInputRef}
-              type="file"
-              multiple
-              onChange={handleFileUpload}
-              className="hidden"
-              disabled={isRunning || isUploading}
-            />
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => fileInputRef.current?.click()}
-              disabled={isRunning || isUploading}
-              title="Upload files"
-            >
+            <input ref={engine.fileInputRef} type="file" multiple onChange={engine.handleFileUpload} className="hidden" disabled={isRunning || engine.isUploading} />
+            <Button variant="outline" size="sm" onClick={() => engine.fileInputRef.current?.click()} disabled={isRunning || engine.isUploading} title={t('files.upload')}>
               <Paperclip className="h-4 w-4 mr-1" />
-              {isUploading ? "Uploading..." : "Attach"}
+              {engine.isUploading ? t('files.uploading') : t('attach')}
             </Button>
-            <span className="text-xs text-muted-foreground">
-              Enter to send
-            </span>
+            <span className="text-xs text-muted-foreground">{t('enterToSend')}</span>
           </div>
           {isRunning ? (
             <div className="flex items-center gap-2">
-              <Button onClick={handleStop} variant="destructive" size="sm">
+              <Button onClick={engine.handleStop} variant="destructive" size="sm">
                 <Square className="h-4 w-4 mr-1" />
-                Stop
+                {t('stop')}
               </Button>
-              <Button onClick={handleSubmit} disabled={!input.trim()} size="sm">
+              <Button onClick={engine.handleSubmit} disabled={!engine.input.trim()} size="sm">
                 <Navigation className="h-4 w-4 mr-1" />
-                Steer
+                {t('steering.button')}
               </Button>
             </div>
           ) : (
-            <Button onClick={handleSubmit} disabled={!input.trim()}>
-              Send
+            <Button onClick={engine.handleSubmit} disabled={!engine.input.trim()}>
+              {t('send')}
             </Button>
           )}
         </div>
@@ -918,21 +506,16 @@ export function ChatPanel({ isOpen, onClose, defaultSkills = [] }: ChatPanelProp
       <AlertDialog open={showResetDialog} onOpenChange={setShowResetDialog}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Reset Everything</AlertDialogTitle>
-            <AlertDialogDescription>
-              Reset everything (messages, files, skills, tools, MCP servers, max turns) and start fresh?
-            </AlertDialogDescription>
+            <AlertDialogTitle>{t('resetEverything')}</AlertDialogTitle>
+            <AlertDialogDescription>{t('resetDescription')}</AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogCancel>{tc('actions.cancel')}</AlertDialogCancel>
             <AlertDialogAction
-              onClick={() => {
-                resetAll();
-                setShowResetDialog(false);
-              }}
+              onClick={() => { resetAll(); setShowResetDialog(false); }}
               className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
             >
-              Reset
+              {t('reset')}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
@@ -940,4 +523,3 @@ export function ChatPanel({ isOpen, onClose, defaultSkills = [] }: ChatPanelProp
     </div>
   );
 }
-

--- a/web/src/hooks/use-chat-engine.ts
+++ b/web/src/hooks/use-chat-engine.ts
@@ -1,0 +1,403 @@
+"use client";
+
+import React from "react";
+import { flushSync } from "react-dom";
+import { filesApi } from "@/lib/api";
+import type { StreamEvent, OutputFileInfo, UploadedFile } from "@/lib/api";
+import type { ChatMessage } from "@/stores/chat-store";
+import type { StreamEventRecord } from "@/types/stream-events";
+import { handleStreamEvent, serializeEventsToText } from "@/lib/stream-utils";
+import { toast } from "sonner";
+
+// ── Adapter interfaces ────────────────────────────────────────────
+
+/** How to get/set messages and running state */
+export interface MessageAdapter {
+  getMessages: () => ChatMessage[];
+  addMessage: (msg: ChatMessage) => void;
+  updateMessage: (id: string, updates: Partial<ChatMessage>) => void;
+  removeMessages: (ids: string[]) => void;
+  getIsRunning: () => boolean;
+  setIsRunning: (running: boolean) => void;
+  getUploadedFiles: () => UploadedFile[];
+  clearUploadedFiles: () => void;
+  addUploadedFile: (file: UploadedFile) => void;
+  removeUploadedFile: (fileId: string) => void;
+}
+
+/** How to call the streaming / sync API */
+export interface StreamAdapter {
+  runStream: (
+    request: string,
+    agentFiles: { file_id: string; filename: string; path: string; content_type: string }[] | undefined,
+    onEvent: (event: StreamEvent) => void,
+    signal: AbortSignal
+  ) => Promise<void>;
+  runSync?: (
+    request: string,
+    agentFiles: { file_id: string; filename: string; path: string; content_type: string }[] | undefined,
+  ) => Promise<{
+    success: boolean;
+    answer: string;
+    total_turns: number;
+    steps: Array<{ role: string; content: string; tool_name?: string; tool_input?: unknown }>;
+    error?: string;
+    trace_id?: string;
+    session_id?: string;
+  }>;
+  steer: (traceId: string, message: string) => Promise<void>;
+}
+
+export interface ChatEngineOptions {
+  messageAdapter: MessageAdapter;
+  streamAdapter: StreamAdapter;
+  /** 'streaming' | 'non_streaming' — defaults to 'streaming' */
+  responseMode?: 'streaming' | 'non_streaming';
+  /** Called when session_id changes (e.g. from run_started event) */
+  onSessionId?: (id: string) => void;
+}
+
+export interface ChatEngineReturn {
+  input: string;
+  setInput: React.Dispatch<React.SetStateAction<string>>;
+  handleSubmit: () => Promise<void>;
+  handleStop: () => void;
+  handleKeyDown: (e: React.KeyboardEvent) => void;
+  handleFileUpload: (e: React.ChangeEvent<HTMLInputElement>) => Promise<void>;
+  handleRemoveFile: (fileId: string) => Promise<void>;
+  streamingContent: string | null;
+  streamingEvents: StreamEventRecord[];
+  streamingMessageId: string | null;
+  currentOutputFiles: OutputFileInfo[];
+  isUploading: boolean;
+  fileInputRef: React.RefObject<HTMLInputElement>;
+  messagesEndRef: React.RefObject<HTMLDivElement>;
+}
+
+// ── Hook implementation ───────────────────────────────────────────
+
+export function useChatEngine(options: ChatEngineOptions): ChatEngineReturn {
+  const { messageAdapter, streamAdapter, responseMode = 'streaming', onSessionId } = options;
+
+  const [input, setInput] = React.useState("");
+  const [streamingContent, setStreamingContent] = React.useState<string | null>(null);
+  const [streamingEvents, setStreamingEvents] = React.useState<StreamEventRecord[]>([]);
+  const [streamingMessageId, setStreamingMessageId] = React.useState<string | null>(null);
+  const [currentOutputFiles, setCurrentOutputFiles] = React.useState<OutputFileInfo[]>([]);
+  const [isUploading, setIsUploading] = React.useState(false);
+
+  const fileInputRef = React.useRef<HTMLInputElement>(null);
+  const messagesEndRef = React.useRef<HTMLDivElement>(null);
+  const abortControllerRef = React.useRef<AbortController | null>(null);
+  const currentRequestMessagesRef = React.useRef<string[]>([]);
+  const currentTraceIdRef = React.useRef<string | null>(null);
+
+  // Stable refs to avoid stale closures in callbacks
+  const adapterRef = React.useRef(options);
+  adapterRef.current = options;
+
+  const handleSteer = React.useCallback(async (message: string) => {
+    const traceId = currentTraceIdRef.current;
+    if (!traceId) return;
+    try {
+      await adapterRef.current.streamAdapter.steer(traceId, message);
+      setInput("");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to send steering message");
+    }
+  }, []);
+
+  const handleSubmit = React.useCallback(async () => {
+    if (!input.trim()) return;
+    const { messageAdapter: ma, streamAdapter: sa, responseMode: rm = 'streaming', onSessionId: onSid } = adapterRef.current;
+
+    // Steering mode: inject message into running agent
+    if (ma.getIsRunning() && currentTraceIdRef.current) {
+      await handleSteer(input.trim());
+      return;
+    }
+
+    // Prevent concurrent runs
+    if (ma.getIsRunning()) return;
+
+    const abortController = new AbortController();
+    abortControllerRef.current = abortController;
+
+    // Capture uploaded files before clearing
+    const uploadedFiles = ma.getUploadedFiles();
+    const agentFiles = uploadedFiles.length > 0
+      ? uploadedFiles.map((f) => ({
+          file_id: f.file_id,
+          filename: f.filename,
+          path: f.path,
+          content_type: f.content_type,
+        }))
+      : undefined;
+
+    const userMessage: ChatMessage = {
+      id: Date.now().toString(),
+      role: "user",
+      content: input.trim(),
+      timestamp: Date.now(),
+      attachedFiles: uploadedFiles.length > 0
+        ? uploadedFiles.map((f) => ({ file_id: f.file_id, filename: f.filename }))
+        : undefined,
+    };
+
+    const loadingMessageId = (Date.now() + 1).toString();
+    const loadingMessage: ChatMessage = {
+      id: loadingMessageId,
+      role: "assistant",
+      content: "",
+      timestamp: Date.now(),
+      isLoading: true,
+    };
+
+    currentRequestMessagesRef.current = [userMessage.id, loadingMessageId];
+
+    ma.addMessage(userMessage);
+    ma.addMessage(loadingMessage);
+    setInput("");
+    ma.clearUploadedFiles();
+    ma.setIsRunning(true);
+    setStreamingMessageId(loadingMessageId);
+    setStreamingContent("");
+    setStreamingEvents([]);
+    setCurrentOutputFiles([]);
+
+    try {
+      if (rm === 'non_streaming' && sa.runSync) {
+        // ── Non-streaming (sync) mode ──
+        const result = await sa.runSync(userMessage.content, agentFiles);
+
+        const events: StreamEventRecord[] = [];
+        let eventId = 0;
+        const now = Date.now();
+
+        if (result.steps && result.steps.length > 0) {
+          for (const step of result.steps) {
+            if (step.tool_name) {
+              events.push({
+                id: `sync-${eventId++}`,
+                type: 'tool_call',
+                timestamp: now,
+                data: { toolName: step.tool_name, toolInput: step.tool_input as Record<string, unknown> | undefined },
+              });
+              if (step.content) {
+                events.push({
+                  id: `sync-${eventId++}`,
+                  type: 'tool_result',
+                  timestamp: now,
+                  data: { toolName: step.tool_name, toolResult: step.content, success: true },
+                });
+              }
+            } else if (step.content) {
+              events.push({
+                id: `sync-${eventId++}`,
+                type: 'assistant',
+                timestamp: now,
+                data: { content: step.content },
+              });
+            }
+          }
+        }
+
+        events.push({
+          id: `sync-${eventId++}`,
+          type: 'complete',
+          timestamp: now,
+          data: { success: result.success, answer: result.answer, totalTurns: result.total_turns },
+        });
+
+        if (result.error) {
+          events.push({
+            id: `sync-${eventId++}`,
+            type: 'error',
+            timestamp: now,
+            data: { message: result.error },
+          });
+        }
+
+        ma.updateMessage(loadingMessageId, {
+          content: serializeEventsToText(events),
+          streamEvents: events,
+          rawAnswer: result.answer || undefined,
+          isLoading: false,
+          traceId: result.trace_id,
+          error: result.error,
+        });
+      } else {
+        // ── Streaming mode ──
+        const events: StreamEventRecord[] = [];
+        let finalAnswer = "";
+        let traceId: string | undefined;
+        let hasError = false;
+        let errorMessage = "";
+        let isComplete = false;
+        const outputFiles: OutputFileInfo[] = [];
+
+        await sa.runStream(
+          userMessage.content,
+          agentFiles,
+          (event: StreamEvent) => {
+            handleStreamEvent(event, events);
+
+            switch (event.event_type) {
+              case "run_started":
+                traceId = event.trace_id;
+                currentTraceIdRef.current = traceId || null;
+                if (event.session_id && onSid) {
+                  onSid(event.session_id);
+                }
+                flushSync(() => {
+                  ma.updateMessage(loadingMessageId, { traceId: traceId });
+                });
+                break;
+              case "complete":
+                if (isComplete) break;
+                isComplete = true;
+                finalAnswer = event.answer || "";
+                // Check success===false (fix for FullscreenChat bug)
+                if (event.success === false && !hasError) {
+                  hasError = true;
+                  errorMessage = event.error || event.answer || "Agent run failed";
+                }
+                break;
+              case "error":
+                hasError = true;
+                errorMessage = event.message || event.error || "Unknown error";
+                break;
+              case "trace_saved":
+                traceId = event.trace_id;
+                break;
+              case "output_file":
+                if (event.file_id && event.filename && event.download_url) {
+                  const fileInfo: OutputFileInfo = {
+                    file_id: event.file_id,
+                    filename: event.filename,
+                    size: event.size || 0,
+                    content_type: event.content_type || "application/octet-stream",
+                    download_url: event.download_url,
+                    description: event.description,
+                  };
+                  outputFiles.push(fileInfo);
+                  flushSync(() => {
+                    setCurrentOutputFiles([...outputFiles]);
+                  });
+                }
+                break;
+            }
+
+            flushSync(() => {
+              setStreamingEvents([...events]);
+              setStreamingContent(serializeEventsToText(events));
+            });
+          },
+          abortController.signal
+        );
+
+        ma.updateMessage(loadingMessageId, {
+          content: serializeEventsToText(events),
+          streamEvents: events,
+          rawAnswer: finalAnswer || undefined,
+          isLoading: false,
+          traceId: traceId,
+          error: hasError ? errorMessage : undefined,
+          outputFiles: outputFiles.length > 0 ? outputFiles : undefined,
+        });
+      }
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') {
+        return;
+      }
+      ma.updateMessage(loadingMessageId, {
+        content: "Failed to run agent",
+        isLoading: false,
+        error: err instanceof Error ? err.message : "Unknown error",
+      });
+    } finally {
+      ma.setIsRunning(false);
+      setStreamingMessageId(null);
+      setStreamingContent(null);
+      setStreamingEvents([]);
+      setCurrentOutputFiles([]);
+      abortControllerRef.current = null;
+      currentRequestMessagesRef.current = [];
+      currentTraceIdRef.current = null;
+    }
+  }, [input, handleSteer]);
+
+  const handleKeyDown = React.useCallback((e: React.KeyboardEvent) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSubmit();
+    }
+  }, [handleSubmit]);
+
+  const handleStop = React.useCallback(() => {
+    const ma = adapterRef.current.messageAdapter;
+    if (!ma.getIsRunning() || !abortControllerRef.current) return;
+
+    abortControllerRef.current.abort();
+
+    if (currentRequestMessagesRef.current.length > 0) {
+      ma.removeMessages(currentRequestMessagesRef.current);
+    }
+
+    ma.setIsRunning(false);
+    setStreamingMessageId(null);
+    setStreamingContent(null);
+    setStreamingEvents([]);
+    setCurrentOutputFiles([]);
+    abortControllerRef.current = null;
+    currentRequestMessagesRef.current = [];
+    currentTraceIdRef.current = null;
+  }, []);
+
+  const handleFileUpload = React.useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (!files || files.length === 0) return;
+
+    setIsUploading(true);
+    try {
+      for (const file of Array.from(files)) {
+        const uploadedFile = await filesApi.upload(file);
+        adapterRef.current.messageAdapter.addUploadedFile(uploadedFile);
+      }
+    } catch (err) {
+      console.error("File upload failed:", err);
+      toast.error(err instanceof Error ? err.message : "File upload failed");
+    } finally {
+      setIsUploading(false);
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
+    }
+  }, []);
+
+  const handleRemoveFile = React.useCallback(async (fileId: string) => {
+    try {
+      await filesApi.delete(fileId);
+    } catch {
+      // Ignore server delete errors
+    }
+    adapterRef.current.messageAdapter.removeUploadedFile(fileId);
+  }, []);
+
+  return {
+    input,
+    setInput,
+    handleSubmit,
+    handleStop,
+    handleKeyDown,
+    handleFileUpload,
+    handleRemoveFile,
+    streamingContent,
+    streamingEvents,
+    streamingMessageId,
+    currentOutputFiles,
+    isUploading,
+    fileInputRef,
+    messagesEndRef,
+  };
+}

--- a/web/src/i18n/locales/en-US/chat.json
+++ b/web/src/i18n/locales/en-US/chat.json
@@ -1,5 +1,6 @@
 {
   "title": "Chat",
+  "chatPanel": "Chat Panel",
   "placeholder": "Type a message...",
   "send": "Send",
   "stop": "Stop",
@@ -11,11 +12,27 @@
   "generating": "Generating...",
   "openFullscreen": "Open in new window",
   "reset": "Reset",
+  "resetAll": "Reset All",
+  "resetEverything": "Reset Everything",
+  "resetDescription": "Reset everything (messages, files, skills, tools, MCP servers, max turns) and start fresh?",
+  "close": "Close",
+  "manage": "Manage",
   "home": "Home",
   "config": "Config",
   "startConversation": "Start a conversation",
   "typeMessageToBegin": "Type a message below to begin chatting with the agent.",
   "clickConfigToCustomize": "Click Config above to customize settings.",
+  "selectSkillsHint": "Select skills above to limit which skills the agent can use.",
+  "multiTurnHint": "Conversations support multi-turn dialogue.",
+  "configManagedByPreset": "Config managed by preset — edit to switch to custom",
+  "requiredToolsNote": "* Required tools cannot be disabled.",
+  "mcpDefaultNote": "MCP servers are disabled by default.",
+  "enterToSend": "Enter to send",
+  "attach": "Attach",
+  "defaultModel": "Default (Kimi K2.5)",
+  "agentNotAvailable": "Agent Not Available",
+  "builtinTools": "Built-in Tools",
+  "selected": "selected",
   "configuration": {
     "title": "Configuration",
     "agent": "Agent",
@@ -29,6 +46,7 @@
     "mcpServers": "MCP Servers",
     "selectMcpServers": "Select MCP servers",
     "maxTurns": "Max Turns",
+    "turns": "Turns",
     "systemPrompt": "System Prompt",
     "systemPromptPlaceholder": "Custom system prompt...",
     "model": "Model",
@@ -66,6 +84,9 @@
   },
   "error": {
     "sendFailed": "Failed to send message",
+    "steerFailed": "Failed to send steering message",
+    "uploadFailed": "File upload failed",
+    "runFailed": "Failed to run agent",
     "connectionLost": "Connection lost",
     "tryAgain": "Try again"
   },
@@ -83,5 +104,9 @@
     "placeholder": "Steer the agent...",
     "button": "Steer",
     "label": "Steering"
+  },
+  "published": {
+    "typeToBegin": "Type a message below to begin.",
+    "notAvailable": "This agent is not available."
   }
 }

--- a/web/src/i18n/locales/es/chat.json
+++ b/web/src/i18n/locales/es/chat.json
@@ -1,5 +1,6 @@
 {
   "title": "Chat",
+  "chatPanel": "Panel de Chat",
   "placeholder": "Escribe un mensaje...",
   "send": "Enviar",
   "stop": "Detener",
@@ -11,11 +12,27 @@
   "generating": "Generando...",
   "openFullscreen": "Abrir en nueva ventana",
   "reset": "Restablecer",
+  "resetAll": "Restablecer Todo",
+  "resetEverything": "Restablecer Todo",
+  "resetDescription": "¿Restablecer todo (mensajes, archivos, habilidades, herramientas, servidores MCP, turnos máximos) y empezar de nuevo?",
+  "close": "Cerrar",
+  "manage": "Gestionar",
   "home": "Inicio",
   "config": "Configurar",
   "startConversation": "Iniciar una conversación",
   "typeMessageToBegin": "Escribe un mensaje abajo para comenzar a chatear con el agente.",
   "clickConfigToCustomize": "Haz clic en Configurar arriba para personalizar los ajustes.",
+  "selectSkillsHint": "Selecciona habilidades arriba para limitar las que el agente puede usar.",
+  "multiTurnHint": "Las conversaciones admiten diálogos de múltiples turnos.",
+  "configManagedByPreset": "Configuración gestionada por preset — edita para cambiar a personalizada",
+  "requiredToolsNote": "* Las herramientas requeridas no se pueden deshabilitar.",
+  "mcpDefaultNote": "Los servidores MCP están deshabilitados por defecto.",
+  "enterToSend": "Enter para enviar",
+  "attach": "Adjuntar",
+  "defaultModel": "Predeterminado (Kimi K2.5)",
+  "agentNotAvailable": "Agente No Disponible",
+  "builtinTools": "Herramientas Integradas",
+  "selected": "seleccionado",
   "configuration": {
     "title": "Configuración",
     "agent": "Agente",
@@ -29,6 +46,7 @@
     "mcpServers": "Servidores MCP",
     "selectMcpServers": "Seleccionar servidores MCP",
     "maxTurns": "Turnos Máximos",
+    "turns": "Turnos",
     "systemPrompt": "Prompt del Sistema",
     "systemPromptPlaceholder": "Prompt del sistema personalizado...",
     "model": "Modelo",
@@ -66,6 +84,9 @@
   },
   "error": {
     "sendFailed": "Error al enviar el mensaje",
+    "steerFailed": "Error al enviar mensaje de dirección",
+    "uploadFailed": "Error al subir archivo",
+    "runFailed": "Error al ejecutar el agente",
     "connectionLost": "Conexión perdida",
     "tryAgain": "Intentar de nuevo"
   },
@@ -83,5 +104,9 @@
     "placeholder": "Dirigir al agente...",
     "button": "Dirigir",
     "label": "Dirección"
+  },
+  "published": {
+    "typeToBegin": "Escribe un mensaje abajo para comenzar.",
+    "notAvailable": "Este agente no está disponible."
   }
 }

--- a/web/src/i18n/locales/ja/chat.json
+++ b/web/src/i18n/locales/ja/chat.json
@@ -1,5 +1,6 @@
 {
   "title": "チャット",
+  "chatPanel": "チャットパネル",
   "placeholder": "メッセージを入力...",
   "send": "送信",
   "stop": "停止",
@@ -11,11 +12,27 @@
   "generating": "生成中...",
   "openFullscreen": "新しいウィンドウで開く",
   "reset": "リセット",
+  "resetAll": "すべてリセット",
+  "resetEverything": "すべてリセット",
+  "resetDescription": "すべてリセット（メッセージ、ファイル、スキル、ツール、MCPサーバー、最大ターン数）して最初からやり直しますか？",
+  "close": "閉じる",
+  "manage": "管理",
   "home": "ホーム",
   "config": "設定",
   "startConversation": "会話を開始",
   "typeMessageToBegin": "下にメッセージを入力してエージェントとのチャットを開始してください。",
   "clickConfigToCustomize": "上の設定をクリックしてカスタマイズしてください。",
+  "selectSkillsHint": "上でスキルを選択してエージェントが使用できるスキルを制限できます。",
+  "multiTurnHint": "会話はマルチターン対話をサポートしています。",
+  "configManagedByPreset": "プリセットで管理 — 編集でカスタムに切替",
+  "requiredToolsNote": "* 必須ツールは無効にできません。",
+  "mcpDefaultNote": "MCPサーバーはデフォルトで無効です。",
+  "enterToSend": "Enterで送信",
+  "attach": "添付",
+  "defaultModel": "デフォルト (Kimi K2.5)",
+  "agentNotAvailable": "エージェントは利用できません",
+  "builtinTools": "内蔵ツール",
+  "selected": "選択済み",
   "configuration": {
     "title": "設定",
     "agent": "エージェント",
@@ -29,6 +46,7 @@
     "mcpServers": "MCPサーバー",
     "selectMcpServers": "MCPサーバーを選択",
     "maxTurns": "最大ターン数",
+    "turns": "ターン",
     "systemPrompt": "システムプロンプト",
     "systemPromptPlaceholder": "カスタムシステムプロンプト...",
     "model": "モデル",
@@ -66,6 +84,9 @@
   },
   "error": {
     "sendFailed": "メッセージの送信に失敗しました",
+    "steerFailed": "ステアリングメッセージの送信に失敗しました",
+    "uploadFailed": "ファイルのアップロードに失敗しました",
+    "runFailed": "エージェントの実行に失敗しました",
     "connectionLost": "接続が切断されました",
     "tryAgain": "再試行"
   },
@@ -83,5 +104,9 @@
     "placeholder": "エージェントを操舵...",
     "button": "操舵",
     "label": "ステアリング"
+  },
+  "published": {
+    "typeToBegin": "下にメッセージを入力して開始してください。",
+    "notAvailable": "このエージェントは利用できません。"
   }
 }

--- a/web/src/i18n/locales/pt-BR/chat.json
+++ b/web/src/i18n/locales/pt-BR/chat.json
@@ -1,5 +1,6 @@
 {
   "title": "Chat",
+  "chatPanel": "Painel de Chat",
   "placeholder": "Digite uma mensagem...",
   "send": "Enviar",
   "stop": "Parar",
@@ -11,11 +12,27 @@
   "generating": "Gerando...",
   "openFullscreen": "Abrir em nova janela",
   "reset": "Redefinir",
+  "resetAll": "Redefinir Tudo",
+  "resetEverything": "Redefinir Tudo",
+  "resetDescription": "Redefinir tudo (mensagens, arquivos, habilidades, ferramentas, servidores MCP, turnos máximos) e começar do zero?",
+  "close": "Fechar",
+  "manage": "Gerenciar",
   "home": "Início",
   "config": "Configurar",
   "startConversation": "Iniciar uma conversa",
   "typeMessageToBegin": "Digite uma mensagem abaixo para começar a conversar com o agente.",
   "clickConfigToCustomize": "Clique em Configurar acima para personalizar as configurações.",
+  "selectSkillsHint": "Selecione habilidades acima para limitar quais o agente pode usar.",
+  "multiTurnHint": "As conversas suportam diálogos de múltiplos turnos.",
+  "configManagedByPreset": "Configuração gerenciada por preset — edite para mudar para personalizada",
+  "requiredToolsNote": "* Ferramentas obrigatórias não podem ser desabilitadas.",
+  "mcpDefaultNote": "Servidores MCP são desabilitados por padrão.",
+  "enterToSend": "Enter para enviar",
+  "attach": "Anexar",
+  "defaultModel": "Padrão (Kimi K2.5)",
+  "agentNotAvailable": "Agente Não Disponível",
+  "builtinTools": "Ferramentas Integradas",
+  "selected": "selecionado",
   "configuration": {
     "title": "Configuração",
     "agent": "Agente",
@@ -29,6 +46,7 @@
     "mcpServers": "Servidores MCP",
     "selectMcpServers": "Selecionar servidores MCP",
     "maxTurns": "Turnos Máximos",
+    "turns": "Turnos",
     "systemPrompt": "Prompt do Sistema",
     "systemPromptPlaceholder": "Prompt do sistema personalizado...",
     "model": "Modelo",
@@ -66,6 +84,9 @@
   },
   "error": {
     "sendFailed": "Falha ao enviar mensagem",
+    "steerFailed": "Falha ao enviar mensagem de direcionamento",
+    "uploadFailed": "Falha ao enviar arquivo",
+    "runFailed": "Falha ao executar o agente",
     "connectionLost": "Conexão perdida",
     "tryAgain": "Tentar novamente"
   },
@@ -83,5 +104,9 @@
     "placeholder": "Direcionar o agente...",
     "button": "Direcionar",
     "label": "Direcionamento"
+  },
+  "published": {
+    "typeToBegin": "Digite uma mensagem abaixo para começar.",
+    "notAvailable": "Este agente não está disponível."
   }
 }

--- a/web/src/i18n/locales/zh-CN/chat.json
+++ b/web/src/i18n/locales/zh-CN/chat.json
@@ -1,5 +1,6 @@
 {
   "title": "聊天",
+  "chatPanel": "聊天面板",
   "placeholder": "输入消息...",
   "send": "发送",
   "stop": "停止",
@@ -11,11 +12,27 @@
   "generating": "生成中...",
   "openFullscreen": "在新窗口中打开",
   "reset": "重置",
+  "resetAll": "全部重置",
+  "resetEverything": "重置所有内容",
+  "resetDescription": "重置所有内容（消息、文件、技能、工具、MCP 服务器、最大轮数）并重新开始？",
+  "close": "关闭",
+  "manage": "管理",
   "home": "首页",
   "config": "配置",
   "startConversation": "开始对话",
   "typeMessageToBegin": "在下方输入消息开始与 Agent 对话。",
   "clickConfigToCustomize": "点击上方 配置 按钮自定义设置。",
+  "selectSkillsHint": "在上方选择技能来限制 Agent 可以使用的技能。",
+  "multiTurnHint": "对话支持多轮对话。",
+  "configManagedByPreset": "配置由预设管理 — 编辑以切换到自定义",
+  "requiredToolsNote": "* 必需的工具不能禁用。",
+  "mcpDefaultNote": "MCP 服务器默认禁用。",
+  "enterToSend": "回车发送",
+  "attach": "附件",
+  "defaultModel": "默认 (Kimi K2.5)",
+  "agentNotAvailable": "Agent 不可用",
+  "builtinTools": "内置工具",
+  "selected": "已选",
   "configuration": {
     "title": "配置",
     "agent": "代理",
@@ -29,6 +46,7 @@
     "mcpServers": "MCP 服务器",
     "selectMcpServers": "选择 MCP 服务器",
     "maxTurns": "最大轮数",
+    "turns": "轮数",
     "systemPrompt": "系统提示词",
     "systemPromptPlaceholder": "自定义系统提示词...",
     "model": "模型",
@@ -66,6 +84,9 @@
   },
   "error": {
     "sendFailed": "发送消息失败",
+    "steerFailed": "发送引导消息失败",
+    "uploadFailed": "文件上传失败",
+    "runFailed": "运行 Agent 失败",
     "connectionLost": "连接已断开",
     "tryAgain": "重试"
   },
@@ -83,5 +104,9 @@
     "placeholder": "引导 Agent...",
     "button": "引导",
     "label": "引导消息"
+  },
+  "published": {
+    "typeToBegin": "在下方输入消息开始。",
+    "notAvailable": "此 Agent 不可用。"
   }
 }


### PR DESCRIPTION
## Summary

- Extract shared streaming/submit/stop/steer/upload logic from 3 chat surfaces (ChatPanel, FullscreenChat, PublishedChat) into a reusable `useChatEngine` hook with adapter pattern
- Fix FullscreenChat bug: missing `success===false` check on complete events
- Add ~20 i18n keys to all 5 locale files (en-US, zh-CN, ja, es, pt-BR), replacing 30+ hardcoded English strings
- Fix home page grid with responsive breakpoints (`sm:`/`md:`)
- Net reduction: **~1,200 lines** of duplicated code (2,477 → ~1,250)

## Changes

| File | Before | After | Delta |
|------|--------|-------|-------|
| `use-chat-engine.ts` (new) | 0 | ~280 | +280 |
| `chat-panel.tsx` | 943 | ~340 | -603 |
| `chat/page.tsx` | 917 | ~380 | -537 |
| `published/[id]/page.tsx` | 617 | ~250 | -367 |

## Test plan

- [x] `npm run build` passes (type-check + production build)
- [x] Docker deploy successful, all containers healthy
- [x] Home page / chat page / published page all return 200
- [ ] Manual: ChatPanel streaming, FullscreenChat streaming, PublishedChat streaming + non-streaming
- [ ] Manual: i18n language switch (zh-CN)
- [ ] Manual: home page mobile responsive layout

Closes #11