### PR TITLE
feat: display session ID on published agent chat page

### DIFF
--- a/web/src/i18n/locales/en-US/chat.json
+++ b/web/src/i18n/locales/en-US/chat.json
@@ -107,6 +107,8 @@
   },
   "published": {
     "typeToBegin": "Type a message below to begin.",
-    "notAvailable": "This agent is not available."
+    "notAvailable": "This agent is not available.",
+    "sessionId": "Session",
+    "sessionIdCopied": "Session ID copied"
   }
 }

--- a/web/src/i18n/locales/es/chat.json
+++ b/web/src/i18n/locales/es/chat.json
@@ -107,6 +107,8 @@
   },
   "published": {
     "typeToBegin": "Escribe un mensaje abajo para comenzar.",
-    "notAvailable": "Este agente no está disponible."
+    "notAvailable": "Este agente no está disponible.",
+    "sessionId": "Sesión",
+    "sessionIdCopied": "ID de sesión copiado"
   }
 }

--- a/web/src/i18n/locales/ja/chat.json
+++ b/web/src/i18n/locales/ja/chat.json
@@ -107,6 +107,8 @@
   },
   "published": {
     "typeToBegin": "下にメッセージを入力して開始してください。",
-    "notAvailable": "このエージェントは利用できません。"
+    "notAvailable": "このエージェントは利用できません。",
+    "sessionId": "セッション",
+    "sessionIdCopied": "セッションIDをコピーしました"
   }
 }

--- a/web/src/i18n/locales/pt-BR/chat.json
+++ b/web/src/i18n/locales/pt-BR/chat.json
@@ -107,6 +107,8 @@
   },
   "published": {
     "typeToBegin": "Digite uma mensagem abaixo para começar.",
-    "notAvailable": "Este agente não está disponível."
+    "notAvailable": "Este agente não está disponível.",
+    "sessionId": "Sessão",
+    "sessionIdCopied": "ID da sessão copiado"
   }
 }

--- a/web/src/i18n/locales/zh-CN/chat.json
+++ b/web/src/i18n/locales/zh-CN/chat.json
@@ -107,6 +107,8 @@
   },
   "published": {
     "typeToBegin": "在下方输入消息开始。",
-    "notAvailable": "此 Agent 不可用。"
+    "notAvailable": "此 Agent 不可用。",
+    "sessionId": "会话",
+    "sessionIdCopied": "会话 ID 已复制"
   }
 }


### PR DESCRIPTION
## Summary
- Add a compact session ID badge to the published agent chat page header
- Click to copy full session ID to clipboard with toast confirmation
- Hidden on mobile (`hidden sm:inline-flex`) to avoid crowding
- Full i18n support across all 5 languages

Closes #17

## Test plan
- [ ] Open a published agent chat page, verify session ID badge appears in header
- [ ] Click the badge, verify full ID is copied and toast appears
- [ ] Click "New Chat", verify session ID updates
- [ ] Test on mobile viewport, verify badge is hidden
- [ ] Switch languages, verify label translates correctly