### PR TITLE
feat: add session sidebar and fix session restore for published agent

### DIFF
--- a/web/src/app/published/[id]/page.tsx
+++ b/web/src/app/published/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useRef, useEffect, useCallback } from "react";
 import { useParams } from "next/navigation";
-import { Paperclip, X, Square, Bot, Loader2, MessageSquarePlus, Navigation } from "lucide-react";
+import { Paperclip, X, Square, Bot, Loader2, MessageSquarePlus, Navigation, PanelLeft, Copy, Check } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { publishedAgentApi } from "@/lib/api";
@@ -11,8 +11,39 @@ import type { ChatMessage } from "@/stores/chat-store";
 import { ChatMessageItem } from "@/components/chat/chat-message";
 import { useChatEngine } from "@/hooks/use-chat-engine";
 import { useTranslation } from "@/i18n/client";
+import { toast } from "sonner";
+import { sessionMessagesToChatMessages } from "@/lib/session-utils";
+import { SessionSidebar } from "@/components/published/session-sidebar";
+import { useQueryClient } from "@tanstack/react-query";
+import { publishedSessionKeys } from "@/hooks/use-published-sessions";
 
 type LocalMessage = ChatMessage;
+
+function SessionIdBadge({ sessionId, label, copiedText }: { sessionId: string; label: string; copiedText: string }) {
+  const [copied, setCopied] = useState(false);
+  const shortId = `${sessionId.slice(0, 4)}...${sessionId.slice(-4)}`;
+
+  const handleCopy = useCallback(() => {
+    navigator.clipboard.writeText(sessionId).then(() => {
+      setCopied(true);
+      toast.success(copiedText);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }, [sessionId, copiedText]);
+
+  return (
+    <button
+      onClick={handleCopy}
+      className="hidden sm:inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs font-mono text-muted-foreground bg-muted/50 hover:bg-muted transition-colors cursor-pointer shrink-0"
+      title={`${label}: ${sessionId}`}
+      aria-label={`${label}: ${sessionId}`}
+    >
+      <span className="text-muted-foreground/70">{label}:</span>
+      <span>{shortId}</span>
+      {copied ? <Check className="h-3 w-3 text-green-500" /> : <Copy className="h-3 w-3 opacity-50" />}
+    </button>
+  );
+}
 
 function getSessionStorageKey(agentId: string): string {
   return `published-session-${agentId}`;
@@ -32,6 +63,7 @@ export default function PublishedChatPage() {
   const { t } = useTranslation('chat');
   const params = useParams();
   const agentId = params.id as string;
+  const queryClient = useQueryClient();
 
   // Agent info
   const [agentName, setAgentName] = useState<string | null>(null);
@@ -48,6 +80,9 @@ export default function PublishedChatPage() {
   const [messages, setMessages] = useState<LocalMessage[]>([]);
   const [isRunning, setIsRunning] = useState(false);
   const [uploadedFiles, setUploadedFiles] = useState<UploadedFile[]>([]);
+
+  // Mobile sidebar
+  const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
 
   // Stable refs for sessionId and apiResponseMode (used in adapters)
   const sessionIdRef = useRef(sessionId);
@@ -126,38 +161,7 @@ export default function PublishedChatPage() {
       try {
         const sessionData = await publishedAgentApi.getSession(agentId, sessionId);
         if (sessionData.messages.length > 0) {
-          const restoredMessages: LocalMessage[] = [];
-          for (const msg of sessionData.messages) {
-            if (msg.role === "user") {
-              if (typeof msg.content === "string") {
-                restoredMessages.push({
-                  id: `restored-${restoredMessages.length}`,
-                  role: "user",
-                  content: msg.content,
-                  timestamp: Date.now(),
-                });
-              }
-            } else if (msg.role === "assistant") {
-              let text = "";
-              if (typeof msg.content === "string") {
-                text = msg.content;
-              } else if (Array.isArray(msg.content)) {
-                text = msg.content
-                  .filter((b: Record<string, unknown>) => b.type === "text")
-                  .map((b: Record<string, unknown>) => b.text as string)
-                  .join("\n");
-              }
-              if (text.trim()) {
-                restoredMessages.push({
-                  id: `restored-${restoredMessages.length}`,
-                  role: "assistant",
-                  content: text,
-                  rawAnswer: text,
-                  timestamp: Date.now(),
-                });
-              }
-            }
-          }
+          const restoredMessages = sessionMessagesToChatMessages(sessionData.messages);
           setMessages(restoredMessages);
         }
       } catch {
@@ -176,13 +180,42 @@ export default function PublishedChatPage() {
     engine.messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, [messages, engine.streamingContent]);
 
-  const handleNewChat = () => {
+  // Auto-refresh session list when chat completes
+  const prevIsRunning = useRef(isRunning);
+  useEffect(() => {
+    if (prevIsRunning.current && !isRunning) {
+      queryClient.invalidateQueries({ queryKey: publishedSessionKeys.lists() });
+    }
+    prevIsRunning.current = isRunning;
+  }, [isRunning, queryClient]);
+
+  const handleNewChat = useCallback(() => {
     const newId = crypto.randomUUID();
     sessionStorage.setItem(getSessionStorageKey(agentId), newId);
     setSessionId(newId);
     setMessages([]);
     setUploadedFiles([]);
-  };
+    setMobileSidebarOpen(false);
+  }, [agentId]);
+
+  const handleSessionSwitch = useCallback(async (newSessionId: string) => {
+    if (newSessionId === sessionId || isRunning) return;
+
+    sessionStorage.setItem(getSessionStorageKey(agentId), newSessionId);
+    setSessionId(newSessionId);
+    setMessages([]);
+    setUploadedFiles([]);
+    setMobileSidebarOpen(false);
+
+    try {
+      const data = await publishedAgentApi.getSession(agentId, newSessionId);
+      if (data.messages.length > 0) {
+        setMessages(sessionMessagesToChatMessages(data.messages));
+      }
+    } catch {
+      // First visit or not found
+    }
+  }, [agentId, sessionId, isRunning]);
 
   if (loadingInfo || restoringSession) {
     return (
@@ -205,90 +238,135 @@ export default function PublishedChatPage() {
   }
 
   return (
-    <div className="flex flex-col h-screen">
-      {/* Header */}
-      <div className="border-b px-6 py-4 flex items-center gap-3 shrink-0">
-        <Bot className="h-6 w-6 text-primary" />
-        <div className="flex-1">
-          <h1 className="font-semibold text-lg">{agentName}</h1>
-          {agentDescription && <p className="text-sm text-muted-foreground">{agentDescription}</p>}
-        </div>
-        <Button variant="outline" size="sm" onClick={handleNewChat} disabled={isRunning} title={t('newChat')}>
-          <MessageSquarePlus className="h-4 w-4 mr-1" />
-          {t('newChat')}
-        </Button>
+    <div className="flex h-screen">
+      {/* Desktop sidebar */}
+      <div className="w-[260px] shrink-0 hidden md:flex flex-col border-r bg-muted/30">
+        <SessionSidebar
+          agentId={agentId}
+          activeSessionId={sessionId}
+          onSessionSelect={handleSessionSwitch}
+          onNewChat={handleNewChat}
+          isRunning={isRunning}
+        />
       </div>
 
-      {/* Messages */}
-      <div className="flex-1 overflow-auto p-6 space-y-4">
-        {messages.length === 0 ? (
-          <div className="text-center text-muted-foreground py-16">
-            <Bot className="h-12 w-12 mx-auto mb-4 opacity-50" />
-            <p className="text-lg">{t('startConversation')}</p>
-            <p className="text-sm mt-2">{t('published.typeToBegin')}</p>
-          </div>
-        ) : (
-          messages.map((message) => (
-            <div key={message.id} className="max-w-4xl mx-auto">
-              <ChatMessageItem
-                message={message}
-                streamingContent={message.id === engine.streamingMessageId ? engine.streamingContent : null}
-                streamingEvents={message.id === engine.streamingMessageId ? engine.streamingEvents : undefined}
-                streamingOutputFiles={message.id === engine.streamingMessageId ? engine.currentOutputFiles : undefined}
-                hideTraceLink
-              />
-            </div>
-          ))
-        )}
-        <div ref={engine.messagesEndRef} />
-      </div>
-
-      {/* Input */}
-      <div className="border-t px-6 py-4 shrink-0">
-        <div className="max-w-4xl mx-auto">
-          {uploadedFiles.length > 0 && (
-            <div className="mb-3 flex flex-wrap gap-2">
-              {uploadedFiles.map((file) => (
-                <div key={file.file_id} className="flex items-center gap-1 bg-muted rounded px-2 py-1 text-xs">
-                  <Paperclip className="h-3 w-3" />
-                  <span className="max-w-[150px] truncate" title={file.filename}>{file.filename}</span>
-                  <button onClick={() => engine.handleRemoveFile(file.file_id)} className="hover:text-destructive ml-1" title={t('files.remove')}>
-                    <X className="h-3 w-3" />
-                  </button>
-                </div>
-              ))}
-            </div>
-          )}
-          <div className="flex gap-2">
-            <Textarea
-              value={engine.input}
-              onChange={(e) => engine.setInput(e.target.value)}
-              onKeyDown={engine.handleKeyDown}
-              placeholder={isRunning ? t('steering.placeholder') : t('placeholder')}
-              className="min-h-[80px] resize-none"
+      {/* Mobile sidebar overlay */}
+      {mobileSidebarOpen && (
+        <div className="fixed inset-0 z-50 md:hidden">
+          {/* Backdrop */}
+          <div
+            className="absolute inset-0 bg-black/50"
+            onClick={() => setMobileSidebarOpen(false)}
+          />
+          {/* Sidebar panel */}
+          <div className="absolute inset-y-0 left-0 w-[280px] bg-background border-r shadow-xl flex flex-col animate-in slide-in-from-left duration-200">
+            <SessionSidebar
+              agentId={agentId}
+              activeSessionId={sessionId}
+              onSessionSelect={handleSessionSwitch}
+              onNewChat={handleNewChat}
+              isRunning={isRunning}
             />
           </div>
-          <div className="flex justify-between items-center mt-2">
-            <div className="flex items-center gap-2">
-              <input ref={engine.fileInputRef} type="file" multiple onChange={engine.handleFileUpload} className="hidden" disabled={isRunning || engine.isUploading} />
-              <Button variant="outline" size="sm" onClick={() => engine.fileInputRef.current?.click()} disabled={isRunning || engine.isUploading} title={t('files.upload')}>
-                <Paperclip className="h-4 w-4 mr-1" />
-                {engine.isUploading ? t('files.uploading') : t('attach')}
-              </Button>
-              <span className="text-xs text-muted-foreground">{t('enterToSend')}</span>
+        </div>
+      )}
+
+      {/* Chat area */}
+      <div className="flex-1 flex flex-col min-w-0">
+        {/* Header */}
+        <div className="border-b px-4 sm:px-6 py-4 flex items-center gap-3 shrink-0">
+          {/* Mobile sidebar toggle */}
+          <Button
+            variant="ghost"
+            size="sm"
+            className="md:hidden p-1.5"
+            onClick={() => setMobileSidebarOpen(true)}
+          >
+            <PanelLeft className="h-5 w-5" />
+          </Button>
+          <Bot className="h-6 w-6 text-primary" />
+          <div className="flex-1 min-w-0">
+            <h1 className="font-semibold text-lg">{agentName}</h1>
+            {agentDescription && <p className="text-sm text-muted-foreground truncate">{agentDescription}</p>}
+          </div>
+          <SessionIdBadge sessionId={sessionId} label={t('published.sessionId')} copiedText={t('published.sessionIdCopied')} />
+          <Button variant="outline" size="sm" onClick={handleNewChat} disabled={isRunning} title={t('newChat')}>
+            <MessageSquarePlus className="h-4 w-4 sm:mr-1" />
+            <span className="hidden sm:inline">{t('newChat')}</span>
+          </Button>
+        </div>
+
+        {/* Messages */}
+        <div className="flex-1 overflow-auto p-4 sm:p-6 space-y-4">
+          {messages.length === 0 ? (
+            <div className="text-center text-muted-foreground py-16">
+              <Bot className="h-12 w-12 mx-auto mb-4 opacity-50" />
+              <p className="text-lg">{t('startConversation')}</p>
+              <p className="text-sm mt-2">{t('published.typeToBegin')}</p>
             </div>
-            {isRunning ? (
-              <div className="flex items-center gap-2">
-                <Button onClick={engine.handleStop} variant="destructive" size="sm">
-                  <Square className="h-4 w-4 mr-1" />{t('stop')}
-                </Button>
-                <Button onClick={engine.handleSubmit} disabled={!engine.input.trim()} size="sm">
-                  <Navigation className="h-4 w-4 mr-1" />{t('steering.button')}
-                </Button>
+          ) : (
+            messages.map((message) => (
+              <div key={message.id} className="max-w-4xl mx-auto">
+                <ChatMessageItem
+                  message={message}
+                  streamingContent={message.id === engine.streamingMessageId ? engine.streamingContent : null}
+                  streamingEvents={message.id === engine.streamingMessageId ? engine.streamingEvents : undefined}
+                  streamingOutputFiles={message.id === engine.streamingMessageId ? engine.currentOutputFiles : undefined}
+                  hideTraceLink
+                />
               </div>
-            ) : (
-              <Button onClick={engine.handleSubmit} disabled={!engine.input.trim()}>{t('send')}</Button>
+            ))
+          )}
+          <div ref={engine.messagesEndRef} />
+        </div>
+
+        {/* Input */}
+        <div className="border-t px-4 sm:px-6 py-4 shrink-0">
+          <div className="max-w-4xl mx-auto">
+            {uploadedFiles.length > 0 && (
+              <div className="mb-3 flex flex-wrap gap-2">
+                {uploadedFiles.map((file) => (
+                  <div key={file.file_id} className="flex items-center gap-1 bg-muted rounded px-2 py-1 text-xs">
+                    <Paperclip className="h-3 w-3" />
+                    <span className="max-w-[150px] truncate" title={file.filename}>{file.filename}</span>
+                    <button onClick={() => engine.handleRemoveFile(file.file_id)} className="hover:text-destructive ml-1" title={t('files.remove')}>
+                      <X className="h-3 w-3" />
+                    </button>
+                  </div>
+                ))}
+              </div>
             )}
+            <div className="flex gap-2">
+              <Textarea
+                value={engine.input}
+                onChange={(e) => engine.setInput(e.target.value)}
+                onKeyDown={engine.handleKeyDown}
+                placeholder={isRunning ? t('steering.placeholder') : t('placeholder')}
+                className="min-h-[80px] resize-none"
+              />
+            </div>
+            <div className="flex justify-between items-center mt-2">
+              <div className="flex items-center gap-2">
+                <input ref={engine.fileInputRef} type="file" multiple onChange={engine.handleFileUpload} className="hidden" disabled={isRunning || engine.isUploading} />
+                <Button variant="outline" size="sm" onClick={() => engine.fileInputRef.current?.click()} disabled={isRunning || engine.isUploading} title={t('files.upload')}>
+                  <Paperclip className="h-4 w-4 mr-1" />
+                  {engine.isUploading ? t('files.uploading') : t('attach')}
+                </Button>
+                <span className="text-xs text-muted-foreground hidden sm:inline">{t('enterToSend')}</span>
+              </div>
+              {isRunning ? (
+                <div className="flex items-center gap-2">
+                  <Button onClick={engine.handleStop} variant="destructive" size="sm">
+                    <Square className="h-4 w-4 mr-1" />{t('stop')}
+                  </Button>
+                  <Button onClick={engine.handleSubmit} disabled={!engine.input.trim()} size="sm">
+                    <Navigation className="h-4 w-4 mr-1" />{t('steering.button')}
+                  </Button>
+                </div>
+              ) : (
+                <Button onClick={engine.handleSubmit} disabled={!engine.input.trim()}>{t('send')}</Button>
+              )}
+            </div>
           </div>
         </div>
       </div>

--- a/web/src/components/published/session-sidebar.tsx
+++ b/web/src/components/published/session-sidebar.tsx
@@ -1,0 +1,245 @@
+'use client';
+
+import React, { useState, useMemo } from 'react';
+import { MessageSquarePlus, Trash2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Spinner } from '@/components/ui/spinner';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/alert-dialog';
+import { usePublishedSessions, useDeletePublishedSession } from '@/hooks/use-published-sessions';
+import { useTranslation } from '@/i18n/client';
+import { formatRelativeTime } from '@/lib/formatters';
+import { toast } from 'sonner';
+import type { SessionListItem } from '@/lib/api';
+
+interface SessionSidebarProps {
+  agentId: string;
+  activeSessionId: string;
+  onSessionSelect: (sessionId: string) => void;
+  onNewChat: () => void;
+  isRunning: boolean;
+}
+
+interface SessionGroup {
+  label: string;
+  sessions: SessionListItem[];
+}
+
+function groupSessionsByDate(sessions: SessionListItem[], labels: {
+  today: string;
+  yesterday: string;
+  previous7Days: string;
+  older: string;
+}): SessionGroup[] {
+  const now = new Date();
+  const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime();
+  const yesterdayStart = todayStart - 86400000;
+  const weekStart = todayStart - 6 * 86400000;
+
+  const groups: Record<string, SessionListItem[]> = {
+    today: [],
+    yesterday: [],
+    previous7Days: [],
+    older: [],
+  };
+
+  for (const session of sessions) {
+    const ts = new Date(session.updated_at).getTime();
+    if (ts >= todayStart) {
+      groups.today.push(session);
+    } else if (ts >= yesterdayStart) {
+      groups.yesterday.push(session);
+    } else if (ts >= weekStart) {
+      groups.previous7Days.push(session);
+    } else {
+      groups.older.push(session);
+    }
+  }
+
+  const result: SessionGroup[] = [];
+  if (groups.today.length > 0) result.push({ label: labels.today, sessions: groups.today });
+  if (groups.yesterday.length > 0) result.push({ label: labels.yesterday, sessions: groups.yesterday });
+  if (groups.previous7Days.length > 0) result.push({ label: labels.previous7Days, sessions: groups.previous7Days });
+  if (groups.older.length > 0) result.push({ label: labels.older, sessions: groups.older });
+  return result;
+}
+
+export function SessionSidebar({
+  agentId,
+  activeSessionId,
+  onSessionSelect,
+  onNewChat,
+  isRunning,
+}: SessionSidebarProps) {
+  const { t } = useTranslation('chat');
+  const { data, isLoading } = usePublishedSessions({ agentId, limit: 50 });
+  const deleteMutation = useDeletePublishedSession();
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+
+  const sessions = data?.sessions ?? [];
+
+  const groups = useMemo(() => {
+    return groupSessionsByDate(sessions, {
+      today: t('published.sidebar.today'),
+      yesterday: t('published.sidebar.yesterday'),
+      previous7Days: t('published.sidebar.previous7Days'),
+      older: t('published.sidebar.older'),
+    });
+  }, [sessions, t]);
+
+  const handleDelete = async (sessionId: string) => {
+    setDeletingId(sessionId);
+    try {
+      await deleteMutation.mutateAsync(sessionId);
+      toast.success(t('published.sidebar.deleted'));
+      if (sessionId === activeSessionId) {
+        onNewChat();
+      }
+    } catch {
+      toast.error(t('published.sidebar.deleteError'));
+    } finally {
+      setDeletingId(null);
+    }
+  };
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* New Chat button */}
+      <div className="p-3 border-b">
+        <Button
+          variant="outline"
+          className="w-full justify-start gap-2"
+          onClick={onNewChat}
+          disabled={isRunning}
+        >
+          <MessageSquarePlus className="h-4 w-4" />
+          {t('newChat')}
+        </Button>
+      </div>
+
+      {/* Session list */}
+      <div className="flex-1 overflow-y-auto">
+        {isLoading ? (
+          <div className="flex items-center justify-center py-8">
+            <Spinner size="sm" />
+          </div>
+        ) : sessions.length === 0 ? (
+          <div className="px-3 py-8 text-center text-sm text-muted-foreground">
+            {t('published.sidebar.noSessions')}
+          </div>
+        ) : (
+          <div className="py-2">
+            {groups.map((group) => (
+              <div key={group.label}>
+                <div className="px-3 py-1.5 text-xs font-medium text-muted-foreground uppercase tracking-wider">
+                  {group.label}
+                </div>
+                {group.sessions.map((session) => (
+                  <SessionItem
+                    key={session.id}
+                    session={session}
+                    isActive={session.id === activeSessionId}
+                    isDeleting={session.id === deletingId}
+                    isRunning={isRunning}
+                    onSelect={() => onSessionSelect(session.id)}
+                    onDelete={() => handleDelete(session.id)}
+                    t={t}
+                  />
+                ))}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function SessionItem({
+  session,
+  isActive,
+  isDeleting,
+  isRunning,
+  onSelect,
+  onDelete,
+  t,
+}: {
+  session: SessionListItem;
+  isActive: boolean;
+  isDeleting: boolean;
+  isRunning: boolean;
+  onSelect: () => void;
+  onDelete: () => void;
+  t: (key: string, options?: Record<string, unknown>) => string;
+}) {
+  const preview = session.first_user_message || t('published.sidebar.emptyMessage');
+  const msgCount = session.message_count;
+  const timeAgo = formatRelativeTime(session.updated_at);
+
+  return (
+    <div
+      className={`group relative mx-1.5 mb-0.5 rounded-lg cursor-pointer transition-colors ${
+        isActive
+          ? 'bg-accent text-accent-foreground'
+          : 'hover:bg-muted/50'
+      } ${isDeleting ? 'opacity-50 pointer-events-none' : ''}`}
+      onClick={() => {
+        if (!isRunning && !isActive) onSelect();
+      }}
+    >
+      <div className="px-3 py-2.5 pr-9">
+        <div className="text-sm font-medium truncate leading-snug">
+          {preview}
+        </div>
+        <div className="flex items-center gap-1.5 mt-1 text-xs text-muted-foreground">
+          <span>{t('published.sidebar.messagesCount', { count: msgCount })}</span>
+          <span>·</span>
+          <span>{timeAgo}</span>
+        </div>
+      </div>
+
+      {/* Delete button - visible on hover */}
+      <div className="absolute right-1.5 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 transition-opacity">
+        <AlertDialog>
+          <AlertDialogTrigger asChild>
+            <button
+              className="p-1.5 rounded-md hover:bg-destructive/10 hover:text-destructive transition-colors"
+              onClick={(e) => e.stopPropagation()}
+              title={t('published.sidebar.deleteConfirm')}
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+            </button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>{t('published.sidebar.deleteConfirm')}</AlertDialogTitle>
+              <AlertDialogDescription>{t('published.sidebar.deleteDescription')}</AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>{t('close', { ns: 'chat' })}</AlertDialogCancel>
+              <AlertDialogAction
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onDelete();
+                }}
+                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              >
+                <Trash2 className="h-4 w-4 mr-1" />
+                {t('clear', { ns: 'chat' })}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </div>
+    </div>
+  );
+}

--- a/web/src/i18n/locales/en-US/chat.json
+++ b/web/src/i18n/locales/en-US/chat.json
@@ -107,6 +107,23 @@
   },
   "published": {
     "typeToBegin": "Type a message below to begin.",
-    "notAvailable": "This agent is not available."
+    "notAvailable": "This agent is not available.",
+    "sessionId": "Session",
+    "sessionIdCopied": "Session ID copied",
+    "sidebar": {
+      "title": "History",
+      "noSessions": "No conversations yet",
+      "today": "Today",
+      "yesterday": "Yesterday",
+      "previous7Days": "Previous 7 Days",
+      "older": "Older",
+      "deleteConfirm": "Delete this conversation?",
+      "deleteDescription": "This action cannot be undone.",
+      "deleted": "Conversation deleted",
+      "deleteError": "Failed to delete",
+      "emptyMessage": "Empty conversation",
+      "messagesCount": "{{count}} msg",
+      "messagesCount_other": "{{count}} msgs"
+    }
   }
 }

--- a/web/src/i18n/locales/es/chat.json
+++ b/web/src/i18n/locales/es/chat.json
@@ -107,6 +107,23 @@
   },
   "published": {
     "typeToBegin": "Escribe un mensaje abajo para comenzar.",
-    "notAvailable": "Este agente no está disponible."
+    "notAvailable": "Este agente no está disponible.",
+    "sessionId": "Sesión",
+    "sessionIdCopied": "ID de sesión copiado",
+    "sidebar": {
+      "title": "Historial",
+      "noSessions": "Sin conversaciones",
+      "today": "Hoy",
+      "yesterday": "Ayer",
+      "previous7Days": "Últimos 7 días",
+      "older": "Anteriores",
+      "deleteConfirm": "¿Eliminar esta conversación?",
+      "deleteDescription": "Esta acción no se puede deshacer.",
+      "deleted": "Conversación eliminada",
+      "deleteError": "Error al eliminar",
+      "emptyMessage": "Conversación vacía",
+      "messagesCount": "{{count}} msg",
+      "messagesCount_other": "{{count}} msgs"
+    }
   }
 }

--- a/web/src/i18n/locales/ja/chat.json
+++ b/web/src/i18n/locales/ja/chat.json
@@ -107,6 +107,23 @@
   },
   "published": {
     "typeToBegin": "下にメッセージを入力して開始してください。",
-    "notAvailable": "このエージェントは利用できません。"
+    "notAvailable": "このエージェントは利用できません。",
+    "sessionId": "セッション",
+    "sessionIdCopied": "セッションIDをコピーしました",
+    "sidebar": {
+      "title": "履歴",
+      "noSessions": "会話がありません",
+      "today": "今日",
+      "yesterday": "昨日",
+      "previous7Days": "過去7日間",
+      "older": "それ以前",
+      "deleteConfirm": "この会話を削除しますか？",
+      "deleteDescription": "この操作は元に戻せません。",
+      "deleted": "会話を削除しました",
+      "deleteError": "削除に失敗しました",
+      "emptyMessage": "空の会話",
+      "messagesCount": "{{count}} 件",
+      "messagesCount_other": "{{count}} 件"
+    }
   }
 }

--- a/web/src/i18n/locales/pt-BR/chat.json
+++ b/web/src/i18n/locales/pt-BR/chat.json
@@ -107,6 +107,23 @@
   },
   "published": {
     "typeToBegin": "Digite uma mensagem abaixo para começar.",
-    "notAvailable": "Este agente não está disponível."
+    "notAvailable": "Este agente não está disponível.",
+    "sessionId": "Sessão",
+    "sessionIdCopied": "ID da sessão copiado",
+    "sidebar": {
+      "title": "Histórico",
+      "noSessions": "Nenhuma conversa",
+      "today": "Hoje",
+      "yesterday": "Ontem",
+      "previous7Days": "Últimos 7 dias",
+      "older": "Anteriores",
+      "deleteConfirm": "Excluir esta conversa?",
+      "deleteDescription": "Esta ação não pode ser desfeita.",
+      "deleted": "Conversa excluída",
+      "deleteError": "Falha ao excluir",
+      "emptyMessage": "Conversa vazia",
+      "messagesCount": "{{count}} msg",
+      "messagesCount_other": "{{count}} msgs"
+    }
   }
 }

--- a/web/src/i18n/locales/zh-CN/chat.json
+++ b/web/src/i18n/locales/zh-CN/chat.json
@@ -107,6 +107,23 @@
   },
   "published": {
     "typeToBegin": "在下方输入消息开始。",
-    "notAvailable": "此 Agent 不可用。"
+    "notAvailable": "此 Agent 不可用。",
+    "sessionId": "会话",
+    "sessionIdCopied": "会话 ID 已复制",
+    "sidebar": {
+      "title": "历史记录",
+      "noSessions": "暂无对话",
+      "today": "今天",
+      "yesterday": "昨天",
+      "previous7Days": "过去 7 天",
+      "older": "更早",
+      "deleteConfirm": "确认删除此对话？",
+      "deleteDescription": "此操作无法撤销。",
+      "deleted": "对话已删除",
+      "deleteError": "删除失败",
+      "emptyMessage": "空对话",
+      "messagesCount": "{{count}} 条消息",
+      "messagesCount_other": "{{count}} 条消息"
+    }
   }
 }

--- a/web/src/lib/formatters.ts
+++ b/web/src/lib/formatters.ts
@@ -17,6 +17,20 @@ export function formatFileSize(bytes: number): string {
   return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + ' ' + sizes[i];
 }
 
+export function formatRelativeTime(dateStr: string): string {
+  const now = Date.now();
+  const diff = now - new Date(dateStr).getTime();
+  const minutes = Math.floor(diff / 60000);
+  const hours = Math.floor(diff / 3600000);
+  const days = Math.floor(diff / 86400000);
+
+  if (minutes < 1) return 'Just now';
+  if (minutes < 60) return `${minutes}m ago`;
+  if (hours < 24) return `${hours}h ago`;
+  if (days < 7) return `${days}d ago`;
+  return new Date(dateStr).toLocaleDateString();
+}
+
 export function getLanguageFromFilename(filename: string): string {
   const ext = filename.split('.').pop()?.toLowerCase() || '';
   const languageMap: Record<string, string> = {


### PR DESCRIPTION
## Summary
- Fix broken session restore — replaced inline loop (which dropped tool calls/rich content) with `sessionMessagesToChatMessages()`
- Add ChatGPT-style session sidebar with date-grouped history (Today / Yesterday / Previous 7 Days / Older)
- Desktop: persistent 260px left sidebar; Mobile: slide-in overlay with backdrop
- Support session switching, deletion with AlertDialog confirmation, auto-refresh on chat completion
- Add `formatRelativeTime` utility and i18n translations for all 5 languages

Closes #19

## Test plan
- [ ] Refresh page after a multi-tool conversation → messages restore with tool calls and results
- [ ] Desktop: sidebar visible with session list grouped by date
- [ ] Click "New Chat" → new session, sidebar updates after first message
- [ ] Click a different session → messages load correctly
- [ ] Hover session → delete icon → confirm → session removed
- [ ] Mobile: sidebar hidden, toggle button opens overlay, selecting session closes it
- [ ] Session ID badge visible in header, click to copy
- [ ] Dark mode renders correctly
- [ ] `cd web && npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)