### PR TITLE
fix: add fallback for crypto.randomUUID in non-secure contexts

### DIFF
--- a/web/src/app/chat/page.tsx
+++ b/web/src/app/chat/page.tsx
@@ -23,6 +23,7 @@ import { useChatEngine } from "@/hooks/use-chat-engine";
 import { ChatMessageItem } from "@/components/chat/chat-message";
 import { ModelSelect, AgentPresetSelect, ExecutorSelect } from "@/components/chat/selects";
 import { useTranslation } from "@/i18n/client";
+import { generateUUID } from "@/lib/utils";
 
 export default function FullscreenChatPage() {
   const { t } = useTranslation('chat');
@@ -60,7 +61,7 @@ export default function FullscreenChatPage() {
         const state = useChatStore.getState();
         let currentSessionId = state.sessionId;
         if (!currentSessionId) {
-          currentSessionId = crypto.randomUUID();
+          currentSessionId = generateUUID();
           setSessionId(currentSessionId);
         }
 

--- a/web/src/app/published/[id]/page.tsx
+++ b/web/src/app/published/[id]/page.tsx
@@ -11,6 +11,7 @@ import type { ChatMessage } from "@/stores/chat-store";
 import { ChatMessageItem } from "@/components/chat/chat-message";
 import { useChatEngine } from "@/hooks/use-chat-engine";
 import { useTranslation } from "@/i18n/client";
+import { generateUUID } from "@/lib/utils";
 import { toast } from "sonner";
 import { sessionMessagesToChatMessages } from "@/lib/session-utils";
 import { SessionSidebar } from "@/components/published/session-sidebar";
@@ -50,11 +51,11 @@ function getSessionStorageKey(agentId: string): string {
 }
 
 function getOrCreateSessionId(agentId: string): string {
-  if (typeof window === 'undefined') return crypto.randomUUID();
+  if (typeof window === 'undefined') return generateUUID();
   const key = getSessionStorageKey(agentId);
   const existing = sessionStorage.getItem(key);
   if (existing) return existing;
-  const id = crypto.randomUUID();
+  const id = generateUUID();
   sessionStorage.setItem(key, id);
   return id;
 }
@@ -190,7 +191,7 @@ export default function PublishedChatPage() {
   }, [isRunning, queryClient]);
 
   const handleNewChat = useCallback(() => {
-    const newId = crypto.randomUUID();
+    const newId = generateUUID();
     sessionStorage.setItem(getSessionStorageKey(agentId), newId);
     setSessionId(newId);
     setMessages([]);

--- a/web/src/app/skills/evolve/page.tsx
+++ b/web/src/app/skills/evolve/page.tsx
@@ -37,6 +37,7 @@ import { ChatMessageItem } from "@/components/chat/chat-message";
 import type { StreamEventRecord } from "@/types/stream-events";
 import { handleStreamEvent, serializeEventsToText } from "@/lib/stream-utils";
 import { useTranslation } from "@/i18n/client";
+import { generateUUID } from "@/lib/utils";
 import { toast } from "sonner";
 
 interface LocalMessage extends ChatMessage {}
@@ -90,7 +91,7 @@ export default function SkillEvolvePage() {
   const initialMessageSentRef = useRef(false);
 
   // Session ID for server-side session management (new per evolve chat)
-  const [sessionId, setEvolveSessionId] = useState(() => crypto.randomUUID());
+  const [sessionId, setEvolveSessionId] = useState(() => generateUUID());
 
   const hasTraces = selectedTraceIds.size > 0;
   const hasFeedback = feedback.trim().length > 0;
@@ -205,7 +206,7 @@ export default function SkillEvolvePage() {
     setSyncResult(null);
     initialMessageSentRef.current = false;
     setAgentPreset(null);
-    setEvolveSessionId(crypto.randomUUID());
+    setEvolveSessionId(generateUUID());
   };
 
   const buildInitialMessageText = (): string => {

--- a/web/src/components/agents/agent-builder-chat.tsx
+++ b/web/src/components/agents/agent-builder-chat.tsx
@@ -15,6 +15,7 @@ import { ModelSelect } from '@/components/chat/selects';
 import type { ChatMessage } from '@/stores/chat-store';
 import type { StreamEventRecord } from '@/types/stream-events';
 import { handleStreamEvent, serializeEventsToText } from '@/lib/stream-utils';
+import { generateUUID } from '@/lib/utils';
 
 export function AgentBuilderChat() {
   const router = useRouter();
@@ -38,7 +39,7 @@ export function AgentBuilderChat() {
   const [selectedModelName, setSelectedModelName] = useState<string | null>('kimi-k2.5');
 
   // Session ID for server-side session management
-  const [sessionId] = useState(() => crypto.randomUUID());
+  const [sessionId] = useState(() => generateUUID());
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);

--- a/web/src/components/chat/chat-panel.tsx
+++ b/web/src/components/chat/chat-panel.tsx
@@ -26,6 +26,7 @@ import { useChatEngine } from "@/hooks/use-chat-engine";
 import { ChatMessageItem } from "./chat-message";
 import { ModelSelect, AgentPresetSelect, ExecutorSelect } from "./selects";
 import { useTranslation } from "@/i18n/client";
+import { generateUUID } from "@/lib/utils";
 
 interface ChatPanelProps {
   isOpen: boolean;
@@ -98,7 +99,7 @@ export function ChatPanel({ isOpen, onClose, defaultSkills = [] }: ChatPanelProp
         const state = useChatStore.getState();
         let currentSessionId = state.sessionId;
         if (!currentSessionId) {
-          currentSessionId = crypto.randomUUID();
+          currentSessionId = generateUUID();
           setSessionId(currentSessionId);
         }
 

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -13,6 +13,16 @@ export function formatDate(date: string | Date): string {
   });
 }
 
+export function generateUUID(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return '10000000-1000-4000-8000-100000000000'.replace(/[018]/g, c => {
+    const n = Number(c);
+    return (n ^ (crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (n / 4)))).toString(16);
+  });
+}
+
 export function formatRelativeTime(date: string | Date): string {
   const now = new Date();
   const then = new Date(date);


### PR DESCRIPTION
## Summary

Closes #30

- Add `generateUUID()` utility in `web/src/lib/utils.ts` that uses `crypto.randomUUID()` when available, falling back to `crypto.getRandomValues()` for UUID v4 generation
- Replace all 7 direct `crypto.randomUUID()` calls across 5 files with `generateUUID()`

**Root cause:** `crypto.randomUUID()` requires a [secure context](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID). `localhost` is always secure, but accessing via LAN IP over HTTP (e.g. `http://192.168.x.x:62600`) is not — common in Docker remote deployments.

**Affected files:**
- `web/src/lib/utils.ts` — new `generateUUID()` function
- `web/src/app/chat/page.tsx`
- `web/src/app/published/[id]/page.tsx`
- `web/src/app/skills/evolve/page.tsx`
- `web/src/components/chat/chat-panel.tsx`
- `web/src/components/agents/agent-builder-chat.tsx`

## Test plan
- [ ] Access via `http://localhost:62600` — should work as before
- [ ] Access via `http://<LAN-IP>:62600` — chat should no longer throw `crypto.randomUUID is not a function`
- [ ] Verify session IDs are valid UUIDs in all chat contexts (main chat, published agent, evolve, agent builder)