### PR TITLE
docs: add build-from-source instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,16 @@ cd skill-compose/docker
 docker compose down
 ```
 
+Build from source (after code changes):
+
+```bash
+cd skill-compose/docker
+cp .env.example .env  # First time only; Add your own API keys
+./rebuild.sh          # Rebuild all services
+./rebuild.sh api      # Rebuild API only
+./rebuild.sh web      # Rebuild Web only
+```
+
 <details>
 <summary>Cleanup (reset to initial state)</summary>
 

--- a/README_es.md
+++ b/README_es.md
@@ -102,6 +102,16 @@ cd skill-compose/docker
 docker compose down
 ```
 
+Compilar desde el código fuente (después de cambios en el código):
+
+```bash
+cd skill-compose/docker
+cp .env.example .env  # Solo la primera vez; agrega tus API keys
+./rebuild.sh          # Reconstruir todos los servicios
+./rebuild.sh api      # Reconstruir solo API
+./rebuild.sh web      # Reconstruir solo Web
+```
+
 <details>
 <summary>Limpieza (restablecer al estado inicial)</summary>
 

--- a/README_ja.md
+++ b/README_ja.md
@@ -102,6 +102,16 @@ cd skill-compose/docker
 docker compose down
 ```
 
+ソースからビルド（コード変更後）：
+
+```bash
+cd skill-compose/docker
+cp .env.example .env  # 初回のみ；API キーを設定してください
+./rebuild.sh          # 全サービスを再ビルド
+./rebuild.sh api      # API のみ再ビルド
+./rebuild.sh web      # Web のみ再ビルド
+```
+
 <details>
 <summary>クリーンアップ（初期状態にリセット）</summary>
 

--- a/README_pt-BR.md
+++ b/README_pt-BR.md
@@ -102,6 +102,16 @@ cd skill-compose/docker
 docker compose down
 ```
 
+Compilar a partir do código-fonte (após alterações no código):
+
+```bash
+cd skill-compose/docker
+cp .env.example .env  # Apenas na primeira vez; adicione suas API keys
+./rebuild.sh          # Reconstruir todos os serviços
+./rebuild.sh api      # Reconstruir apenas API
+./rebuild.sh web      # Reconstruir apenas Web
+```
+
 <details>
 <summary>Limpeza (redefinir para o estado inicial)</summary>
 

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -102,6 +102,16 @@ cd skill-compose/docker
 docker compose down
 ```
 
+从源码构建（代码变更后）：
+
+```bash
+cd skill-compose/docker
+cp .env.example .env  # 仅首次需要；填入你的 API Key
+./rebuild.sh          # 重建所有服务
+./rebuild.sh api      # 仅重建 API
+./rebuild.sh web      # 仅重建 Web
+```
+
 <details>
 <summary>清理（重置为初始状态）</summary>
 


### PR DESCRIPTION
## Summary
- Add "Build from source" section after "Stop services" in Quick Start
- Cover `rebuild.sh` usage (all / api / web) and first-time `.env` setup
- Update all 5 language READMEs (en, zh-CN, ja, es, pt-BR)

Closes #34

## Test plan
- [ ] Verify markdown renders correctly on GitHub for all 5 READMEs
- [ ] Verify `rebuild.sh` commands are accurate