### PR TITLE
feat: dual-store session context — separate display from agent working state

### DIFF
--- a/app/agent/__init__.py
+++ b/app/agent/__init__.py
@@ -1,11 +1,12 @@
 """Agent module"""
-from .agent import SkillsAgent, AgentResult, AgentStep, StreamEvent
+from .agent import SkillsAgent, AgentResult, AgentStep, StreamEvent, compress_messages_standalone
 from .event_stream import EventStream
 from .steering import write_steering_message, poll_steering_messages, cleanup_steering_dir
 from .tools import TOOLS, call_tool, acall_tool
 
 __all__ = [
     "SkillsAgent", "AgentResult", "AgentStep", "StreamEvent", "EventStream",
+    "compress_messages_standalone",
     "write_steering_message", "poll_steering_messages", "cleanup_steering_dir",
     "TOOLS", "call_tool", "acall_tool",
 ]

--- a/app/api/v1/backup.py
+++ b/app/api/v1/backup.py
@@ -294,6 +294,7 @@ async def _create_backup_zip(
             "id": sess.id,
             "agent_id": sess.agent_id,
             "messages": sess.messages,
+            "agent_context": sess.agent_context,
             "created_at": _serialize_datetime(sess.created_at),
             "updated_at": _serialize_datetime(sess.updated_at),
         })
@@ -635,6 +636,7 @@ async def _restore_from_zip(
                 id=sess["id"],
                 agent_id=sess["agent_id"],
                 messages=sess.get("messages"),
+                agent_context=sess.get("agent_context"),
                 created_at=datetime.fromisoformat(sess["created_at"]) if sess.get("created_at") else datetime.utcnow(),
                 updated_at=datetime.fromisoformat(sess["updated_at"]) if sess.get("updated_at") else datetime.utcnow(),
             )

--- a/app/api/v1/sessions.py
+++ b/app/api/v1/sessions.py
@@ -2,29 +2,48 @@
 
 Used by both the agent (chat panel) and published agent endpoints
 to load/create/save server-side sessions via PublishedSessionDB.
+
+Dual-store design:
+- `messages`: Append-only display history — never compressed, preserves all
+  tool_use/tool_result blocks for frontend rendering.
+- `agent_context`: Agent working message list — whole-replaced each request,
+  may contain compression summaries.  NULL → fallback to `messages`.
 """
+import json
+import logging
+from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Optional, Tuple, List
+from typing import Optional, List
 
 from sqlalchemy import select, update
 
 from app.db.database import AsyncSessionLocal
 from app.db.models import PublishedSessionDB
 
+logger = logging.getLogger("skills_api")
+
 # Sentinel agent_id for chat-panel sessions (not tied to a published agent)
 CHAT_SENTINEL_AGENT_ID = "__chat__"
+
+
+@dataclass
+class SessionData:
+    """Data returned from load_or_create_session."""
+    session_id: str
+    display_messages: Optional[List[dict]] = None  # Full display history (for append)
+    agent_context: Optional[List[dict]] = None      # Agent working messages
 
 
 async def load_or_create_session(
     session_id: str,
     agent_id: str,
-) -> Tuple[str, Optional[List[dict]]]:
+) -> SessionData:
     """Load existing session or create a new one.
 
-    Returns (session_id, history) where history is None for brand-new sessions.
+    Returns SessionData with display_messages and agent_context.
+    For brand-new sessions both fields are None.
+    For existing sessions with agent_context=NULL, falls back to copying messages.
     """
-    history = None
-
     async with AsyncSessionLocal() as db:
         result = await db.execute(
             select(PublishedSessionDB).where(
@@ -35,18 +54,28 @@ async def load_or_create_session(
         session_record = result.scalar_one_or_none()
 
         if session_record:
-            history = session_record.messages or []
+            display = session_record.messages or []
+            # Fallback: if agent_context is NULL, use messages as starting context
+            ctx = session_record.agent_context
+            if ctx is None:
+                ctx = list(display)  # Copy so mutations don't affect display
+            return SessionData(
+                session_id=session_id,
+                display_messages=display,
+                agent_context=ctx if ctx else None,
+            )
         else:
             # Create new session with caller-provided ID
             new_session = PublishedSessionDB(
                 id=session_id,
                 agent_id=agent_id,
                 messages=[],
+                agent_context=None,
             )
             db.add(new_session)
             await db.commit()
 
-    return session_id, history
+            return SessionData(session_id=session_id)
 
 
 async def save_session_messages(
@@ -54,12 +83,14 @@ async def save_session_messages(
     final_answer: str,
     request_text: str,
     final_messages: Optional[list] = None,
+    display_append_messages: Optional[list] = None,
 ) -> None:
-    """Save full conversation messages to session.
+    """Save conversation data to session (dual-store).
 
-    If *final_messages* is provided (the full Anthropic message list from the
-    agent run), it replaces the session messages entirely.  Otherwise we
-    append a simple user/assistant pair.
+    - `agent_context`: whole-replaced with *final_messages* (the agent's working
+      message list, which may include compression summaries).
+    - `messages`: *display_append_messages* are appended to the existing display
+      history.  If not provided, falls back to appending a simple user+assistant pair.
     """
     try:
         async with AsyncSessionLocal() as session_db:
@@ -69,29 +100,105 @@ async def save_session_messages(
                 )
             )
             session_record = result.scalar_one_or_none()
-            if session_record:
-                if final_messages:
-                    await session_db.execute(
-                        update(PublishedSessionDB)
-                        .where(PublishedSessionDB.id == session_id)
-                        .values(
-                            messages=final_messages,
-                            updated_at=datetime.utcnow(),
-                        )
-                    )
-                else:
-                    current_messages = session_record.messages or []
-                    current_messages.append({"role": "user", "content": request_text})
+            if not session_record:
+                return
+
+            # Build values dict
+            values = {"updated_at": datetime.utcnow()}
+
+            # agent_context — whole-replace
+            if final_messages is not None:
+                values["agent_context"] = final_messages
+
+            # messages — append display data
+            current_display = session_record.messages or []
+            if display_append_messages:
+                current_display = current_display + display_append_messages
+            else:
+                # Fallback: append simple user+assistant pair
+                if request_text:
+                    current_display = list(current_display)
+                    current_display.append({"role": "user", "content": request_text})
                     if final_answer:
-                        current_messages.append({"role": "assistant", "content": final_answer})
-                    await session_db.execute(
-                        update(PublishedSessionDB)
-                        .where(PublishedSessionDB.id == session_id)
-                        .values(
-                            messages=current_messages,
-                            updated_at=datetime.utcnow(),
-                        )
-                    )
-                await session_db.commit()
+                        current_display.append({"role": "assistant", "content": final_answer})
+            values["messages"] = current_display
+
+            await session_db.execute(
+                update(PublishedSessionDB)
+                .where(PublishedSessionDB.id == session_id)
+                .values(**values)
+            )
+            await session_db.commit()
     except Exception:
         pass  # Don't fail the response if session save fails
+
+
+async def save_session_checkpoint(
+    session_id: str,
+    agent_context: list,
+) -> None:
+    """Incremental checkpoint: update only agent_context (turn_complete saves).
+
+    This does NOT touch `messages` — display history is only appended at the
+    final save to avoid partial/duplicate entries during streaming.
+    """
+    try:
+        async with AsyncSessionLocal() as session_db:
+            await session_db.execute(
+                update(PublishedSessionDB)
+                .where(PublishedSessionDB.id == session_id)
+                .values(
+                    agent_context=agent_context,
+                    updated_at=datetime.utcnow(),
+                )
+            )
+            await session_db.commit()
+    except Exception:
+        pass  # fire-and-forget
+
+
+async def pre_compress_if_needed(
+    agent_context: List[dict],
+    model_provider: str,
+    model_name: str,
+) -> List[dict]:
+    """Pre-compress agent context if token estimate exceeds model threshold.
+
+    Called before passing context to the agent to avoid "LLM stream failed"
+    errors when accumulated tokens exceed the model's context window.
+
+    Returns the (possibly compressed) context.
+    """
+    from app.agent.agent import COMPRESSION_THRESHOLD_RATIO, CHARS_PER_TOKEN
+    from app.llm.models import get_context_limit
+
+    if not agent_context:
+        return agent_context
+
+    context_limit = get_context_limit(model_provider, model_name)
+    threshold = int(context_limit * COMPRESSION_THRESHOLD_RATIO)
+
+    # Estimate token count from serialized content
+    total_chars = sum(
+        len(json.dumps(msg.get("content", ""), ensure_ascii=False))
+        for msg in agent_context
+    )
+    estimated_tokens = int(total_chars / CHARS_PER_TOKEN)
+
+    if estimated_tokens <= threshold:
+        return agent_context
+
+    logger.info(
+        f"[Pre-Compress] Estimated {estimated_tokens} tokens exceeds threshold {threshold}, compressing..."
+    )
+
+    try:
+        from app.agent.agent import compress_messages_standalone
+        compressed, s_in, s_out = await compress_messages_standalone(
+            agent_context, model_provider, model_name, verbose=True
+        )
+        logger.info(f"[Pre-Compress] Done: {len(agent_context)} → {len(compressed)} messages (summary: {s_in}in/{s_out}out)")
+        return compressed
+    except Exception as e:
+        logger.warning(f"[Pre-Compress] Failed: {e}, using original context")
+        return agent_context

--- a/app/db/database.py
+++ b/app/db/database.py
@@ -205,6 +205,15 @@ async def _run_migrations():
             "CREATE INDEX IF NOT EXISTS ix_published_sessions_agent_id ON published_sessions (agent_id)"
         ))
 
+    # Add agent_context column to published_sessions table
+    async with engine.begin() as conn:
+        await conn.execute(text("""
+            DO $$ BEGIN
+                ALTER TABLE published_sessions ADD COLUMN agent_context JSONB DEFAULT NULL;
+            EXCEPTION WHEN duplicate_column THEN NULL;
+            END $$
+        """))
+
     # Add category and is_pinned columns to skills table
     async with engine.begin() as conn:
         await conn.execute(text("""

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -511,7 +511,10 @@ class PublishedSessionDB(Base):
     )
     messages: Mapped[Optional[List[dict]]] = mapped_column(
         JSONB, nullable=True, default=list
-    )  # [{"role": "user", "content": "..."}, {"role": "assistant", "content": "..."}]
+    )  # Append-only display history — never compressed, preserves all tool_use/tool_result blocks
+    agent_context: Mapped[Optional[List[dict]]] = mapped_column(
+        JSONB, nullable=True, default=None
+    )  # Agent working message list — whole-replaced each request, may contain compression summaries
     created_at: Mapped[datetime] = mapped_column(
         DateTime, default=datetime.utcnow, nullable=False
     )

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -161,12 +161,14 @@ def make_background_task(
 def make_published_session(
     agent_id: str,
     messages: Optional[List[dict]] = None,
+    agent_context: Optional[List[dict]] = None,
     **kwargs,
 ) -> PublishedSessionDB:
     return PublishedSessionDB(
         id=kwargs.get("id", str(uuid.uuid4())),
         agent_id=agent_id,
         messages=messages or [],
+        agent_context=agent_context,
         created_at=kwargs.get("created_at", datetime.utcnow()),
         updated_at=kwargs.get("updated_at", datetime.utcnow()),
     )

--- a/tests/test_api/test_agent_run.py
+++ b/tests/test_api/test_agent_run.py
@@ -15,6 +15,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from httpx import AsyncClient
 
+from app.api.v1.sessions import SessionData
+
 
 # ---------------------------------------------------------------------------
 # Mock dataclasses matching app.agent.agent (AgentStep, LLMCall, AgentResult)
@@ -77,7 +79,7 @@ def _make_mock_agent(result: Optional[MockAgentResult] = None):
 
 
 @patch("app.api.v1.agent.save_session_messages", new_callable=AsyncMock)
-@patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=("test-session-id", None))
+@patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=SessionData(session_id="test-session-id"))
 @patch("app.api.v1.agent.SkillsAgent")
 async def test_agent_run_simple(MockAgent, _mock_load, _mock_save, client: AsyncClient):
     """POST /agent/run with a simple request returns 200 with success=True."""
@@ -97,7 +99,7 @@ async def test_agent_run_simple(MockAgent, _mock_load, _mock_save, client: Async
 
 
 @patch("app.api.v1.agent.save_session_messages", new_callable=AsyncMock)
-@patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=("test-session-id", None))
+@patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=SessionData(session_id="test-session-id"))
 @patch("app.api.v1.agent.SkillsAgent")
 async def test_agent_run_with_skills(MockAgent, _mock_load, _mock_save, client: AsyncClient):
     """POST /agent/run with skills parameter passes skills to agent."""
@@ -118,7 +120,7 @@ async def test_agent_run_with_skills(MockAgent, _mock_load, _mock_save, client: 
 
 
 @patch("app.api.v1.agent.save_session_messages", new_callable=AsyncMock)
-@patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=("test-session-id", None))
+@patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=SessionData(session_id="test-session-id"))
 @patch("app.api.v1.agent.SkillsAgent")
 async def test_agent_run_with_max_turns(MockAgent, _mock_load, _mock_save, client: AsyncClient):
     """POST /agent/run with max_turns passes the value to agent."""
@@ -137,7 +139,7 @@ async def test_agent_run_with_max_turns(MockAgent, _mock_load, _mock_save, clien
 
 
 @patch("app.api.v1.agent.save_session_messages", new_callable=AsyncMock)
-@patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=("test-session-id", None))
+@patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=SessionData(session_id="test-session-id"))
 @patch("app.api.v1.agent.SkillsAgent")
 async def test_agent_run_with_session_id(MockAgent, _mock_load, _mock_save, client: AsyncClient):
     """POST /agent/run with session_id accepts and processes the request."""
@@ -154,7 +156,7 @@ async def test_agent_run_with_session_id(MockAgent, _mock_load, _mock_save, clie
 
 
 @patch("app.api.v1.agent.save_session_messages", new_callable=AsyncMock)
-@patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=("test-session-id", None))
+@patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=SessionData(session_id="test-session-id"))
 @patch("app.api.v1.agent.SkillsAgent")
 async def test_agent_run_with_files(MockAgent, _mock_load, _mock_save, client: AsyncClient):
     """POST /agent/run with uploaded_files appends file info to request."""
@@ -185,7 +187,7 @@ async def test_agent_run_with_files(MockAgent, _mock_load, _mock_save, client: A
 
 
 @patch("app.api.v1.agent.save_session_messages", new_callable=AsyncMock)
-@patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=("test-session-id", None))
+@patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=SessionData(session_id="test-session-id"))
 @patch("app.api.v1.agent.SkillsAgent")
 async def test_agent_run_failure(MockAgent, _mock_load, _mock_save, client: AsyncClient):
     """POST /agent/run when agent fails returns 200 with success=False."""
@@ -209,7 +211,7 @@ async def test_agent_run_failure(MockAgent, _mock_load, _mock_save, client: Asyn
 
 
 @patch("app.api.v1.agent.save_session_messages", new_callable=AsyncMock)
-@patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=("test-session-id", None))
+@patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=SessionData(session_id="test-session-id"))
 @patch("app.api.v1.agent.SkillsAgent")
 async def test_agent_run_saves_trace(MockAgent, _mock_load, _mock_save, client: AsyncClient):
     """POST /agent/run saves an execution trace and returns trace_id."""
@@ -228,7 +230,7 @@ async def test_agent_run_saves_trace(MockAgent, _mock_load, _mock_save, client: 
 
 
 @patch("app.api.v1.agent.save_session_messages", new_callable=AsyncMock)
-@patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=("test-session-id", None))
+@patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=SessionData(session_id="test-session-id"))
 @patch("app.api.v1.agent.SkillsAgent")
 async def test_agent_run_with_mcp_servers(MockAgent, _mock_load, _mock_save, client: AsyncClient):
     """POST /agent/run with equipped_mcp_servers passes them to agent."""

--- a/tests/test_api/test_agent_stream.py
+++ b/tests/test_api/test_agent_stream.py
@@ -18,6 +18,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.agent.agent import StreamEvent
 from app.agent.event_stream import EventStream
+from app.api.v1.sessions import SessionData
 
 
 @dataclass
@@ -126,10 +127,12 @@ def _mock_session_local(db_session: AsyncSession):
 
 
 @pytest.mark.asyncio
+@patch("app.api.v1.agent.pre_compress_if_needed", new_callable=AsyncMock, return_value=[])
+@patch("app.api.v1.agent.save_session_checkpoint", new_callable=AsyncMock)
 @patch("app.api.v1.agent.save_session_messages", new_callable=AsyncMock)
-@patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=("test-session-id", None))
+@patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=SessionData(session_id="test-session-id"))
 @patch("app.api.v1.agent.SkillsAgent")
-async def test_stream_returns_event_stream(MockAgent, _mock_load, _mock_save, client):
+async def test_stream_returns_event_stream(MockAgent, _mock_load, _mock_save, _mock_checkpoint, _mock_precompress, client):
     MockAgent.return_value = _make_mock_agent_instance()
 
     response = await client.post(
@@ -141,11 +144,13 @@ async def test_stream_returns_event_stream(MockAgent, _mock_load, _mock_save, cl
 
 
 @pytest.mark.asyncio
+@patch("app.api.v1.agent.pre_compress_if_needed", new_callable=AsyncMock, return_value=[])
+@patch("app.api.v1.agent.save_session_checkpoint", new_callable=AsyncMock)
 @patch("app.api.v1.agent.save_session_messages", new_callable=AsyncMock)
-@patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=("test-session-id", None))
+@patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=SessionData(session_id="test-session-id"))
 @patch("app.api.v1.agent.AsyncSessionLocal")
 @patch("app.api.v1.agent.SkillsAgent")
-async def test_stream_sends_run_started(MockAgent, MockSessionLocal, _mock_load, _mock_save, client, db_session):
+async def test_stream_sends_run_started(MockAgent, MockSessionLocal, _mock_load, _mock_save, _mock_checkpoint, _mock_precompress, client, db_session):
     MockAgent.return_value = _make_mock_agent_instance()
     MockSessionLocal.side_effect = lambda: _mock_session_local(db_session)()
 
@@ -164,11 +169,13 @@ async def test_stream_sends_run_started(MockAgent, MockSessionLocal, _mock_load,
 
 
 @pytest.mark.asyncio
+@patch("app.api.v1.agent.pre_compress_if_needed", new_callable=AsyncMock, return_value=[])
+@patch("app.api.v1.agent.save_session_checkpoint", new_callable=AsyncMock)
 @patch("app.api.v1.agent.save_session_messages", new_callable=AsyncMock)
-@patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=("test-session-id", None))
+@patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=SessionData(session_id="test-session-id"))
 @patch("app.api.v1.agent.AsyncSessionLocal")
 @patch("app.api.v1.agent.SkillsAgent")
-async def test_stream_sends_trace_saved(MockAgent, MockSessionLocal, _mock_load, _mock_save, client, db_session):
+async def test_stream_sends_trace_saved(MockAgent, MockSessionLocal, _mock_load, _mock_save, _mock_checkpoint, _mock_precompress, client, db_session):
     MockAgent.return_value = _make_mock_agent_instance()
     MockSessionLocal.side_effect = lambda: _mock_session_local(db_session)()
 
@@ -184,11 +191,13 @@ async def test_stream_sends_trace_saved(MockAgent, MockSessionLocal, _mock_load,
 
 
 @pytest.mark.asyncio
+@patch("app.api.v1.agent.pre_compress_if_needed", new_callable=AsyncMock, return_value=[])
+@patch("app.api.v1.agent.save_session_checkpoint", new_callable=AsyncMock)
 @patch("app.api.v1.agent.save_session_messages", new_callable=AsyncMock)
-@patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=("test-session-id", None))
+@patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=SessionData(session_id="test-session-id"))
 @patch("app.api.v1.agent.AsyncSessionLocal")
 @patch("app.api.v1.agent.SkillsAgent")
-async def test_stream_with_skills(MockAgent, MockSessionLocal, _mock_load, _mock_save, client, db_session):
+async def test_stream_with_skills(MockAgent, MockSessionLocal, _mock_load, _mock_save, _mock_checkpoint, _mock_precompress, client, db_session):
     MockAgent.return_value = _make_mock_agent_instance()
     MockSessionLocal.side_effect = lambda: _mock_session_local(db_session)()
 
@@ -203,11 +212,13 @@ async def test_stream_with_skills(MockAgent, MockSessionLocal, _mock_load, _mock
 
 
 @pytest.mark.asyncio
+@patch("app.api.v1.agent.pre_compress_if_needed", new_callable=AsyncMock, return_value=[])
+@patch("app.api.v1.agent.save_session_checkpoint", new_callable=AsyncMock)
 @patch("app.api.v1.agent.save_session_messages", new_callable=AsyncMock)
-@patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=("test-session-id", None))
+@patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=SessionData(session_id="test-session-id"))
 @patch("app.api.v1.agent.AsyncSessionLocal")
 @patch("app.api.v1.agent.SkillsAgent")
-async def test_stream_with_mcp_servers(MockAgent, MockSessionLocal, _mock_load, _mock_save, client, db_session):
+async def test_stream_with_mcp_servers(MockAgent, MockSessionLocal, _mock_load, _mock_save, _mock_checkpoint, _mock_precompress, client, db_session):
     MockAgent.return_value = _make_mock_agent_instance()
     MockSessionLocal.side_effect = lambda: _mock_session_local(db_session)()
 
@@ -222,11 +233,13 @@ async def test_stream_with_mcp_servers(MockAgent, MockSessionLocal, _mock_load, 
 
 
 @pytest.mark.asyncio
+@patch("app.api.v1.agent.pre_compress_if_needed", new_callable=AsyncMock, return_value=[])
+@patch("app.api.v1.agent.save_session_checkpoint", new_callable=AsyncMock)
 @patch("app.api.v1.agent.save_session_messages", new_callable=AsyncMock)
-@patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=("test-session-id", None))
+@patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=SessionData(session_id="test-session-id"))
 @patch("app.api.v1.agent.AsyncSessionLocal")
 @patch("app.api.v1.agent.SkillsAgent")
-async def test_stream_error_handling(MockAgent, MockSessionLocal, _mock_load, _mock_save, client, db_session):
+async def test_stream_error_handling(MockAgent, MockSessionLocal, _mock_load, _mock_save, _mock_checkpoint, _mock_precompress, client, db_session):
     """When agent encounters error, it pushes error complete event and stream includes it."""
     # In the async architecture, agent.run() catches errors internally
     # and pushes a complete event with success=False

--- a/tests/test_api/test_sessions.py
+++ b/tests/test_api/test_sessions.py
@@ -1,0 +1,644 @@
+"""
+Unit tests for session management helpers (app/api/v1/sessions.py).
+
+Tests the dual-store session pattern:
+- `messages`: Append-only display history (never compressed)
+- `agent_context`: Agent working message list (whole-replaced each request)
+
+All tests run against a real PostgreSQL test database (skills_api_test).
+"""
+import uuid
+from unittest.mock import patch, AsyncMock
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select, text
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from app.db.database import Base
+from app.db.models import PublishedSessionDB
+from app.api.v1.sessions import (
+    SessionData,
+    load_or_create_session,
+    save_session_messages,
+    save_session_checkpoint,
+    pre_compress_if_needed,
+)
+
+
+TEST_DATABASE_URL = "postgresql+asyncpg://skills:skills123@localhost:62620/skills_api_test"
+
+AGENT_ID = "test-agent-001"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — own engine + factory per test (isolated from conftest db_session)
+# ---------------------------------------------------------------------------
+
+@pytest_asyncio.fixture()
+async def session_env():
+    """Provide (async_session, async_sessionmaker) with fresh tables per test.
+
+    The session functions in sessions.py use AsyncSessionLocal() internally,
+    so we patch it with the factory returned here.
+    """
+    from app.db import models  # noqa: F401 — register models with Base
+
+    engine = create_async_engine(TEST_DATABASE_URL, echo=False, pool_size=3)
+
+    async with engine.begin() as conn:
+        await conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
+        await conn.run_sync(Base.metadata.create_all)
+
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    session = factory()
+    try:
+        yield session, factory
+    finally:
+        await session.close()
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+        await engine.dispose()
+
+
+# ---------------------------------------------------------------------------
+# Test: load_or_create_session
+# ---------------------------------------------------------------------------
+
+
+class TestLoadOrCreateSession:
+    """Tests for load_or_create_session."""
+
+    @pytest.mark.asyncio
+    async def test_create_new_session(self, session_env):
+        """Brand-new session returns SessionData with None fields."""
+        db, factory = session_env
+        session_id = str(uuid.uuid4())
+
+        with patch("app.api.v1.sessions.AsyncSessionLocal", factory):
+            data = await load_or_create_session(session_id, AGENT_ID)
+
+        assert isinstance(data, SessionData)
+        assert data.session_id == session_id
+        assert data.display_messages is None
+        assert data.agent_context is None
+
+        # Verify record was created in DB
+        result = await db.execute(
+            select(PublishedSessionDB).where(PublishedSessionDB.id == session_id)
+        )
+        record = result.scalar_one_or_none()
+        assert record is not None
+        assert record.agent_id == AGENT_ID
+        assert record.messages == []
+        assert record.agent_context is None
+
+    @pytest.mark.asyncio
+    async def test_load_existing_with_agent_context(self, session_env):
+        """Existing session with agent_context returns both stores."""
+        db, factory = session_env
+        session_id = str(uuid.uuid4())
+        display_msgs = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "Hi!"},
+        ]
+        agent_ctx = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "<summary>Greeting exchange</summary>"},
+        ]
+
+        session = PublishedSessionDB(
+            id=session_id, agent_id=AGENT_ID,
+            messages=display_msgs, agent_context=agent_ctx,
+        )
+        db.add(session)
+        await db.commit()
+
+        with patch("app.api.v1.sessions.AsyncSessionLocal", factory):
+            data = await load_or_create_session(session_id, AGENT_ID)
+
+        assert data.session_id == session_id
+        assert data.display_messages == display_msgs
+        assert data.agent_context == agent_ctx
+
+    @pytest.mark.asyncio
+    async def test_backward_compat_null_agent_context(self, session_env):
+        """When agent_context is NULL, fallback to copying messages."""
+        db, factory = session_env
+        session_id = str(uuid.uuid4())
+        display_msgs = [
+            {"role": "user", "content": "What is 2+2?"},
+            {"role": "assistant", "content": "4"},
+        ]
+
+        session = PublishedSessionDB(
+            id=session_id, agent_id=AGENT_ID,
+            messages=display_msgs, agent_context=None,
+        )
+        db.add(session)
+        await db.commit()
+
+        with patch("app.api.v1.sessions.AsyncSessionLocal", factory):
+            data = await load_or_create_session(session_id, AGENT_ID)
+
+        assert data.display_messages == display_msgs
+        # agent_context should be a COPY of display messages
+        assert data.agent_context == display_msgs
+        # But not the same object
+        assert data.agent_context is not data.display_messages
+
+    @pytest.mark.asyncio
+    async def test_empty_existing_session(self, session_env):
+        """Existing session with empty messages returns None agent_context."""
+        db, factory = session_env
+        session_id = str(uuid.uuid4())
+
+        session = PublishedSessionDB(
+            id=session_id, agent_id=AGENT_ID,
+            messages=[], agent_context=None,
+        )
+        db.add(session)
+        await db.commit()
+
+        with patch("app.api.v1.sessions.AsyncSessionLocal", factory):
+            data = await load_or_create_session(session_id, AGENT_ID)
+
+        assert data.display_messages == []
+        # Empty list fallback → [] → `if ctx` is False → None
+        assert data.agent_context is None
+
+    @pytest.mark.asyncio
+    async def test_wrong_agent_id_creates_new(self, session_env):
+        """Session lookup with different agent_id creates a new session."""
+        db, factory = session_env
+        original_id = str(uuid.uuid4())
+
+        session = PublishedSessionDB(
+            id=original_id, agent_id="other-agent",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        db.add(session)
+        await db.commit()
+
+        # Use a different session_id to avoid PK conflict
+        new_session_id = str(uuid.uuid4())
+        with patch("app.api.v1.sessions.AsyncSessionLocal", factory):
+            data = await load_or_create_session(new_session_id, AGENT_ID)
+
+        assert data.session_id == new_session_id
+        assert data.display_messages is None
+
+
+# ---------------------------------------------------------------------------
+# Test: save_session_messages
+# ---------------------------------------------------------------------------
+
+
+class TestSaveSessionMessages:
+    """Tests for save_session_messages (dual-store save)."""
+
+    @pytest.mark.asyncio
+    async def test_append_display_and_replace_agent_context(self, session_env):
+        """Display messages appended, agent_context whole-replaced."""
+        db, factory = session_env
+        session_id = str(uuid.uuid4())
+        existing_display = [
+            {"role": "user", "content": "turn 1"},
+            {"role": "assistant", "content": "response 1"},
+        ]
+
+        session = PublishedSessionDB(
+            id=session_id, agent_id=AGENT_ID,
+            messages=existing_display,
+            agent_context=[{"role": "user", "content": "old context"}],
+        )
+        db.add(session)
+        await db.commit()
+
+        new_display = [
+            {"role": "user", "content": "turn 2"},
+            {"role": "assistant", "content": "response 2"},
+        ]
+        new_agent_ctx = [
+            {"role": "user", "content": "compressed summary"},
+            {"role": "user", "content": "turn 2"},
+            {"role": "assistant", "content": "response 2"},
+        ]
+
+        with patch("app.api.v1.sessions.AsyncSessionLocal", factory):
+            await save_session_messages(
+                session_id=session_id,
+                final_answer="response 2",
+                request_text="turn 2",
+                final_messages=new_agent_ctx,
+                display_append_messages=new_display,
+            )
+
+        # Re-read from DB with fresh session
+        async with factory() as fresh:
+            result = await fresh.execute(
+                select(PublishedSessionDB).where(PublishedSessionDB.id == session_id)
+            )
+            record = result.scalar_one()
+
+        # messages should be existing + appended
+        assert len(record.messages) == 4
+        assert record.messages[:2] == existing_display
+        assert record.messages[2:] == new_display
+
+        # agent_context should be completely replaced
+        assert record.agent_context == new_agent_ctx
+
+    @pytest.mark.asyncio
+    async def test_fallback_simple_user_assistant_pair(self, session_env):
+        """Without display_append_messages, falls back to user+assistant pair."""
+        db, factory = session_env
+        session_id = str(uuid.uuid4())
+
+        session = PublishedSessionDB(
+            id=session_id, agent_id=AGENT_ID, messages=[],
+        )
+        db.add(session)
+        await db.commit()
+
+        with patch("app.api.v1.sessions.AsyncSessionLocal", factory):
+            await save_session_messages(
+                session_id=session_id,
+                final_answer="The answer is 42",
+                request_text="What is the meaning?",
+            )
+
+        async with factory() as fresh:
+            result = await fresh.execute(
+                select(PublishedSessionDB).where(PublishedSessionDB.id == session_id)
+            )
+            record = result.scalar_one()
+
+        assert len(record.messages) == 2
+        assert record.messages[0] == {"role": "user", "content": "What is the meaning?"}
+        assert record.messages[1] == {"role": "assistant", "content": "The answer is 42"}
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_session_is_noop(self, session_env):
+        """Saving to a nonexistent session does not raise."""
+        _, factory = session_env
+        with patch("app.api.v1.sessions.AsyncSessionLocal", factory):
+            await save_session_messages(
+                session_id="nonexistent-id",
+                final_answer="answer",
+                request_text="request",
+            )
+
+    @pytest.mark.asyncio
+    async def test_agent_context_not_set_when_final_messages_none(self, session_env):
+        """When final_messages is None, agent_context should not be updated."""
+        db, factory = session_env
+        session_id = str(uuid.uuid4())
+        original_ctx = [{"role": "user", "content": "original"}]
+
+        session = PublishedSessionDB(
+            id=session_id, agent_id=AGENT_ID,
+            messages=[], agent_context=original_ctx,
+        )
+        db.add(session)
+        await db.commit()
+
+        with patch("app.api.v1.sessions.AsyncSessionLocal", factory):
+            await save_session_messages(
+                session_id=session_id,
+                final_answer="answer",
+                request_text="request",
+                final_messages=None,
+            )
+
+        # The save creates its own session, so we need a fresh read
+        async with factory() as fresh:
+            result = await fresh.execute(
+                select(PublishedSessionDB).where(PublishedSessionDB.id == session_id)
+            )
+            record = result.scalar_one()
+
+        # agent_context should remain unchanged
+        assert record.agent_context == original_ctx
+
+
+# ---------------------------------------------------------------------------
+# Test: save_session_checkpoint
+# ---------------------------------------------------------------------------
+
+
+class TestSaveSessionCheckpoint:
+    """Tests for save_session_checkpoint (agent_context only)."""
+
+    @pytest.mark.asyncio
+    async def test_checkpoint_updates_only_agent_context(self, session_env):
+        """Checkpoint updates agent_context without touching messages."""
+        db, factory = session_env
+        session_id = str(uuid.uuid4())
+        original_messages = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "world"},
+        ]
+
+        session = PublishedSessionDB(
+            id=session_id, agent_id=AGENT_ID,
+            messages=original_messages, agent_context=None,
+        )
+        db.add(session)
+        await db.commit()
+
+        checkpoint_ctx = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "world"},
+            {"role": "user", "content": "new turn"},
+        ]
+
+        with patch("app.api.v1.sessions.AsyncSessionLocal", factory):
+            await save_session_checkpoint(session_id, checkpoint_ctx)
+
+        async with factory() as fresh:
+            result = await fresh.execute(
+                select(PublishedSessionDB).where(PublishedSessionDB.id == session_id)
+            )
+            record = result.scalar_one()
+
+        # messages should be UNCHANGED
+        assert record.messages == original_messages
+        # agent_context should be updated
+        assert record.agent_context == checkpoint_ctx
+
+    @pytest.mark.asyncio
+    async def test_multiple_checkpoints_replace(self, session_env):
+        """Multiple checkpoints each replace the previous agent_context."""
+        db, factory = session_env
+        session_id = str(uuid.uuid4())
+
+        session = PublishedSessionDB(
+            id=session_id, agent_id=AGENT_ID,
+            messages=[{"role": "user", "content": "hi"}],
+            agent_context=[{"role": "user", "content": "initial"}],
+        )
+        db.add(session)
+        await db.commit()
+
+        ctx_v1 = [{"role": "user", "content": "checkpoint 1"}]
+        ctx_v2 = [{"role": "user", "content": "checkpoint 2"}]
+
+        with patch("app.api.v1.sessions.AsyncSessionLocal", factory):
+            await save_session_checkpoint(session_id, ctx_v1)
+            await save_session_checkpoint(session_id, ctx_v2)
+
+        async with factory() as fresh:
+            result = await fresh.execute(
+                select(PublishedSessionDB).where(PublishedSessionDB.id == session_id)
+            )
+            record = result.scalar_one()
+
+        # Should be latest checkpoint, not accumulated
+        assert record.agent_context == ctx_v2
+        # messages untouched
+        assert record.messages == [{"role": "user", "content": "hi"}]
+
+
+# ---------------------------------------------------------------------------
+# Test: pre_compress_if_needed
+# ---------------------------------------------------------------------------
+
+
+class TestPreCompressIfNeeded:
+    """Tests for pre_compress_if_needed."""
+
+    @pytest.mark.asyncio
+    async def test_empty_context_passthrough(self):
+        """Empty or None context returns as-is."""
+        result = await pre_compress_if_needed([], "kimi", "kimi-k2.5")
+        assert result == []
+
+        result = await pre_compress_if_needed(None, "kimi", "kimi-k2.5")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_below_threshold_passthrough(self):
+        """Context below threshold passes through unchanged."""
+        short_context = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi there"},
+        ]
+        result = await pre_compress_if_needed(short_context, "kimi", "kimi-k2.5")
+        assert result == short_context
+
+    @pytest.mark.asyncio
+    async def test_above_threshold_triggers_compression(self):
+        """Context above threshold calls compress_messages_standalone."""
+        large_context = []
+        for i in range(100):
+            large_context.append({"role": "user", "content": f"Question {i}: " + "x" * 5000})
+            large_context.append({"role": "assistant", "content": f"Answer {i}: " + "y" * 5000})
+
+        compressed_result = [
+            {"role": "user", "content": "<summary>Compressed</summary>"},
+            {"role": "user", "content": "last question"},
+            {"role": "assistant", "content": "last answer"},
+        ]
+
+        with patch("app.agent.agent.compress_messages_standalone", new_callable=AsyncMock) as mock_compress:
+            mock_compress.return_value = (compressed_result, 1000, 200)
+            result = await pre_compress_if_needed(large_context, "kimi", "kimi-k2.5")
+
+        assert result == compressed_result
+        mock_compress.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_compression_failure_returns_original(self):
+        """If compression fails, returns original context."""
+        large_context = []
+        for i in range(100):
+            large_context.append({"role": "user", "content": "x" * 5000})
+            large_context.append({"role": "assistant", "content": "y" * 5000})
+
+        with patch("app.agent.agent.compress_messages_standalone", new_callable=AsyncMock) as mock_compress:
+            mock_compress.side_effect = Exception("LLM API error")
+            result = await pre_compress_if_needed(large_context, "kimi", "kimi-k2.5")
+
+        # Should return original, not raise
+        assert result == large_context
+
+
+# ---------------------------------------------------------------------------
+# Test: Dual-store invariant (integration)
+# ---------------------------------------------------------------------------
+
+
+class TestDualStoreInvariant:
+    """Integration tests verifying the dual-store invariant:
+    - messages is append-only (grows monotonically)
+    - agent_context is whole-replaced (may shrink after compression)
+    """
+
+    @pytest.mark.asyncio
+    async def test_multi_turn_dual_store(self, session_env):
+        """Simulate 3 turns: messages grows, agent_context gets replaced each time."""
+        db, factory = session_env
+        session_id = str(uuid.uuid4())
+
+        session = PublishedSessionDB(
+            id=session_id, agent_id=AGENT_ID,
+            messages=[], agent_context=None,
+        )
+        db.add(session)
+        await db.commit()
+
+        # Turn 1
+        with patch("app.api.v1.sessions.AsyncSessionLocal", factory):
+            await save_session_messages(
+                session_id=session_id,
+                final_answer="Response 1",
+                request_text="Question 1",
+                final_messages=[
+                    {"role": "user", "content": "Question 1"},
+                    {"role": "assistant", "content": "Response 1"},
+                ],
+                display_append_messages=[
+                    {"role": "user", "content": "Question 1"},
+                    {"role": "assistant", "content": "Response 1"},
+                ],
+            )
+
+        async with factory() as fresh:
+            r = await fresh.execute(
+                select(PublishedSessionDB).where(PublishedSessionDB.id == session_id)
+            )
+            rec = r.scalar_one()
+        assert len(rec.messages) == 2
+        assert len(rec.agent_context) == 2
+
+        # Turn 2
+        with patch("app.api.v1.sessions.AsyncSessionLocal", factory):
+            await save_session_messages(
+                session_id=session_id,
+                final_answer="Response 2",
+                request_text="Question 2",
+                final_messages=[
+                    {"role": "user", "content": "Question 1"},
+                    {"role": "assistant", "content": "Response 1"},
+                    {"role": "user", "content": "Question 2"},
+                    {"role": "assistant", "content": "Response 2"},
+                ],
+                display_append_messages=[
+                    {"role": "user", "content": "Question 2"},
+                    {"role": "assistant", "content": "Response 2"},
+                ],
+            )
+
+        async with factory() as fresh:
+            r = await fresh.execute(
+                select(PublishedSessionDB).where(PublishedSessionDB.id == session_id)
+            )
+            rec = r.scalar_one()
+        assert len(rec.messages) == 4  # Grew: 2 → 4
+        assert len(rec.agent_context) == 4  # Replaced: now 4
+
+        # Turn 3 — with compression (agent_context shrinks)
+        with patch("app.api.v1.sessions.AsyncSessionLocal", factory):
+            await save_session_messages(
+                session_id=session_id,
+                final_answer="Response 3",
+                request_text="Question 3",
+                final_messages=[
+                    {"role": "user", "content": "<summary>Compressed turns 1-2</summary>"},
+                    {"role": "user", "content": "Question 3"},
+                    {"role": "assistant", "content": "Response 3"},
+                ],
+                display_append_messages=[
+                    {"role": "user", "content": "Question 3"},
+                    {"role": "assistant", "content": "Response 3"},
+                ],
+            )
+
+        async with factory() as fresh:
+            r = await fresh.execute(
+                select(PublishedSessionDB).where(PublishedSessionDB.id == session_id)
+            )
+            rec = r.scalar_one()
+
+        # messages: monotonically grows (4 → 6)
+        assert len(rec.messages) == 6
+        assert rec.messages[0]["content"] == "Question 1"
+        assert rec.messages[5]["content"] == "Response 3"
+
+        # agent_context: whole-replaced, now compressed (3 messages)
+        assert len(rec.agent_context) == 3
+        assert "<summary>" in rec.agent_context[0]["content"]
+
+    @pytest.mark.asyncio
+    async def test_checkpoint_then_final_save(self, session_env):
+        """Checkpoints update agent_context during streaming; final save appends display."""
+        db, factory = session_env
+        session_id = str(uuid.uuid4())
+
+        session = PublishedSessionDB(
+            id=session_id, agent_id=AGENT_ID,
+            messages=[
+                {"role": "user", "content": "turn 1"},
+                {"role": "assistant", "content": "resp 1"},
+            ],
+            agent_context=[
+                {"role": "user", "content": "turn 1"},
+                {"role": "assistant", "content": "resp 1"},
+            ],
+        )
+        db.add(session)
+        await db.commit()
+
+        # Simulate streaming: checkpoint saves agent_context mid-stream
+        with patch("app.api.v1.sessions.AsyncSessionLocal", factory):
+            await save_session_checkpoint(session_id, [
+                {"role": "user", "content": "turn 1"},
+                {"role": "assistant", "content": "resp 1"},
+                {"role": "user", "content": "turn 2"},
+                {"role": "assistant", "content": "partial resp 2..."},
+            ])
+
+        async with factory() as fresh:
+            r = await fresh.execute(
+                select(PublishedSessionDB).where(PublishedSessionDB.id == session_id)
+            )
+            rec = r.scalar_one()
+        # messages unchanged during checkpoint
+        assert len(rec.messages) == 2
+        # agent_context updated
+        assert len(rec.agent_context) == 4
+
+        # Final save: append display + replace agent_context
+        with patch("app.api.v1.sessions.AsyncSessionLocal", factory):
+            await save_session_messages(
+                session_id=session_id,
+                final_answer="complete resp 2",
+                request_text="turn 2",
+                final_messages=[
+                    {"role": "user", "content": "turn 1"},
+                    {"role": "assistant", "content": "resp 1"},
+                    {"role": "user", "content": "turn 2"},
+                    {"role": "assistant", "content": "complete resp 2"},
+                ],
+                display_append_messages=[
+                    {"role": "user", "content": "turn 2"},
+                    {"role": "assistant", "content": "complete resp 2"},
+                ],
+            )
+
+        async with factory() as fresh:
+            r = await fresh.execute(
+                select(PublishedSessionDB).where(PublishedSessionDB.id == session_id)
+            )
+            rec = r.scalar_one()
+        # messages grew
+        assert len(rec.messages) == 4
+        # agent_context final
+        assert len(rec.agent_context) == 4
+        assert rec.agent_context[-1]["content"] == "complete resp 2"


### PR DESCRIPTION
## Summary

- Add `agent_context` JSONB column to `published_sessions` for agent working state, keeping `messages` as append-only display history
- Pre-compress agent context at session load time to prevent token overflow ("LLM stream failed" errors on long conversations)
- Extract `compress_messages_standalone` for pre-compression without instantiating full `SkillsAgent`
- Add `save_session_checkpoint` for incremental agent_context saves during streaming (without touching display messages)

Closes #40

## Test plan

- [x] 17 new unit tests in `test_sessions.py` — load/create, dual-store save, checkpoint, pre-compress, backward compat
- [x] `agent_context` assertions added to real LLM compression tests (`test_e2e_compression_real.py`)
- [x] All 404 unit tests pass (`./scripts/run-tests.sh unit`)
- [x] All 176 E2E tests pass (`./scripts/run-tests.sh e2e`)
- [x] Backward compatible — existing sessions with `agent_context=NULL` fallback to copying `messages`