### PR TITLE
fix: SSE cancel-path DB connection leak

### DIFF
--- a/app/api/v1/published.py
+++ b/app/api/v1/published.py
@@ -19,7 +19,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.agent import SkillsAgent, EventStream, write_steering_message, poll_steering_messages, cleanup_steering_dir
 from app.api.v1.agent import _finalize_trace
-from app.api.v1.sessions import load_or_create_session, save_session_messages, save_session_checkpoint, pre_compress_if_needed
+from app.api.v1.sessions import load_or_create_session, save_session_messages, save_session_checkpoint, save_session_checkpoint_sync, pre_compress_if_needed
 from app.config import get_settings
 from app.db.database import AsyncSessionLocal, get_db
 from app.db.models import AgentPresetDB, AgentTraceDB, PublishedSessionDB, ExecutorDB
@@ -616,8 +616,9 @@ async def published_chat(agent_id: str, request: PublishedChatRequest):
                     )
                 elif last_messages_snapshot:
                     # Cancelled or interrupted — save last checkpoint (agent_context only)
+                    # Use sync DB to avoid orphaned async connections in cancelled context
                     try:
-                        await save_session_checkpoint(session_id, last_messages_snapshot)
+                        save_session_checkpoint_sync(session_id, last_messages_snapshot)
                     except Exception:
                         pass
 


### PR DESCRIPTION
## Summary

- Replace `asyncio.shield()` + async DB with direct sync DB (psycopg2) in `_finalize_trace` — eliminates orphaned asyncpg connections on SSE cancel
- Add `save_session_checkpoint_sync()` for cancelled-path session saves
- Apply sync checkpoint to both `agent.py` and `published.py` cancel paths

## Root Cause

`asyncio.shield()` wraps the DB coroutine in a background task. On cancel, the outer `await` raises `CancelledError` and falls through to the sync fallback — but the shielded inner task keeps running, opening an asyncpg connection that outlives the request scope. Uvicorn then force-kills it, producing "garbage collector cleaning up non-checked-in connection" warnings.

## Fix

Use psycopg2 (sync) directly — a single `UPDATE` via sync DB is <1ms, immune to async cancellation, and creates no orphaned connections. This is the same `SyncSessionLocal` already used elsewhere for thread-pool operations.

## Test Plan

- [x] Unit tests pass (427 passed)
- [x] E2E tests pass (176 passed)
- [x] Manual: cancel regular chat mid-stream → trace saved as `cancelled`, zero warnings
- [x] Manual: cancel published agent mid-stream → trace saved as `cancelled`, zero warnings
- [x] Stress: 5 concurrent cancels → all traces saved, zero connection leak warnings

Fixes #48