### PR TITLE
fix: resolve session PK conflict when applying agent preset to chat

### DIFF
--- a/web/src/app/agents/[id]/page.tsx
+++ b/web/src/app/agents/[id]/page.tsx
@@ -77,6 +77,7 @@ export default function AgentDetailPage() {
     setSelectedExecutorId: setChatExecutorId,
     clearMessages,
     clearUploadedFiles,
+    setSessionId,
   } = useChatStore();
   const chatPanel = useChatPanel();
 
@@ -90,6 +91,8 @@ export default function AgentDetailPage() {
 
   const applyPresetToChat = () => {
     if (!preset) return;
+    // Reset session so the new agent gets a fresh server-side session
+    setSessionId(null);
     setSelectedSkills(preset.skill_ids || []);
     setMaxTurns(preset.max_turns);
     if (preset.builtin_tools === null && tools.length > 0) {

--- a/web/src/app/chat/page.tsx
+++ b/web/src/app/chat/page.tsx
@@ -155,6 +155,8 @@ export default function FullscreenChatPage() {
   const applyPreset = (presetId: string) => {
     const preset = agentPresets.find((p) => p.id === presetId);
     if (!preset) return;
+    // Reset session so the new agent gets a fresh server-side session
+    setSessionId(null);
     setSelectedAgentPreset(preset.id);
     setSelectedSkills(preset.skill_ids || []);
     setMaxTurns(preset.max_turns);

--- a/web/src/components/chat/chat-panel.tsx
+++ b/web/src/components/chat/chat-panel.tsx
@@ -215,6 +215,8 @@ export function ChatPanel({ isOpen, onClose, defaultSkills = [] }: ChatPanelProp
   const applyPreset = (presetId: string) => {
     const preset = agentPresets.find((p) => p.id === presetId);
     if (!preset) return;
+    // Reset session so the new agent gets a fresh server-side session
+    setSessionId(null);
     setSelectedAgentPreset(preset.id);
     setSelectedSkills(preset.skill_ids || []);
     setMaxTurns(preset.max_turns);


### PR DESCRIPTION
## Summary
- **Frontend**: Reset `sessionId` to null in all `applyPreset` paths (agent detail page, chat panel, fullscreen chat) so switching agents creates a fresh server-side session
- **Backend**: `load_or_create_session` now handles the edge case where a session exists with a different `agent_id` — resets and reassigns instead of failing with IntegrityError

## Test plan
- [ ] Clear browser localStorage, open chat, send a message
- [ ] Navigate to Agent detail → click "Apply to Chat" → send a message → should work without error
- [ ] Switch agents via chat panel dropdown → send a message → should work
- [ ] Verify multi-turn conversation still works after applying a preset

Closes #50