### PR TITLE
feat: agent builder chat session persistence and sidebar

### DIFF
--- a/web/src/app/agents/new/page.tsx
+++ b/web/src/app/agents/new/page.tsx
@@ -1,19 +1,171 @@
 'use client';
 
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
-import { ArrowLeft, FileText, MessageSquare } from 'lucide-react';
+import { ArrowLeft, FileText, MessageSquare, PanelLeft } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Button } from '@/components/ui/button';
 import { useCreateAgentPreset } from '@/hooks/use-agents';
 import { AgentBuilderChat } from '@/components/agents/agent-builder-chat';
 import { AgentConfigForm, type AgentFormValues } from '@/components/agents/agent-config-form';
+import { SessionSidebar } from '@/components/published/session-sidebar';
 import { useTranslation } from '@/i18n/client';
+import { agentPresetsApi, agentApi } from '@/lib/api';
+import { generateUUID } from '@/lib/utils';
+import { sessionMessagesToChatMessages } from '@/lib/session-utils';
+import { useQueryClient } from '@tanstack/react-query';
+import { publishedSessionKeys } from '@/hooks/use-published-sessions';
+import { Spinner } from '@/components/ui/spinner';
+import type { ChatMessage } from '@/stores/chat-store';
+
+const SESSION_STORAGE_KEY = 'agent-builder-session';
+
+function TabSwitcher({
+  active,
+  onTabChange,
+  chatLabel,
+  formLabel,
+  className = '',
+  size = 'sm',
+}: {
+  active: string;
+  onTabChange: (tab: 'chat' | 'form') => void;
+  chatLabel: string;
+  formLabel: string;
+  className?: string;
+  size?: 'sm' | 'md';
+}) {
+  const py = size === 'sm' ? 'py-1.5' : 'py-2';
+  const iconSize = size === 'sm' ? 'h-3.5 w-3.5' : 'h-4 w-4';
+  return (
+    <div className={`flex items-center rounded-lg bg-muted p-0.5 ${className}`}>
+      <button
+        onClick={() => onTabChange('chat')}
+        className={`flex-1 flex items-center justify-center gap-1.5 px-3 ${py} text-sm rounded-md transition-colors ${
+          active === 'chat'
+            ? 'bg-background shadow-sm font-medium'
+            : 'text-muted-foreground hover:text-foreground'
+        }`}
+      >
+        <MessageSquare className={iconSize} />
+        {chatLabel}
+      </button>
+      <button
+        onClick={() => onTabChange('form')}
+        className={`flex-1 flex items-center justify-center gap-1.5 px-3 ${py} text-sm rounded-md transition-colors ${
+          active === 'form'
+            ? 'bg-background shadow-sm font-medium'
+            : 'text-muted-foreground hover:text-foreground'
+        }`}
+      >
+        <FileText className={iconSize} />
+        {formLabel}
+      </button>
+    </div>
+  );
+}
+
+function getOrCreateSessionId(): string {
+  if (typeof window === 'undefined') return generateUUID();
+  const existing = sessionStorage.getItem(SESSION_STORAGE_KEY);
+  if (existing) return existing;
+  const id = generateUUID();
+  sessionStorage.setItem(SESSION_STORAGE_KEY, id);
+  return id;
+}
 
 export default function NewAgentPage() {
   const router = useRouter();
   const createPreset = useCreateAgentPreset();
+  const queryClient = useQueryClient();
   const { t } = useTranslation('agents');
+
+  // Active tab
+  const [activeTab, setActiveTab] = useState<'chat' | 'form'>('chat');
+
+  // Agent builder preset
+  const [agentBuilderId, setAgentBuilderId] = useState<string | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  // Session + chat state (lifted from AgentBuilderChat)
+  const [sessionId, setSessionId] = useState<string>(() => getOrCreateSessionId());
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [isRunning, setIsRunning] = useState(false);
+  const [restoringSession, setRestoringSession] = useState(false);
+
+  // Mobile sidebar
+  const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
+
+  // Fetch agent-builder preset
+  useEffect(() => {
+    const fetchAgentBuilder = async () => {
+      try {
+        setLoadError(null);
+        const preset = await agentPresetsApi.getByName('agent-builder');
+        setAgentBuilderId(preset.id);
+      } catch (error) {
+        console.error('Failed to fetch agent-builder:', error);
+        setLoadError(error instanceof Error ? error.message : 'Failed to load agent-builder preset');
+      }
+    };
+    fetchAgentBuilder();
+  }, []);
+
+  // Restore session on mount (after agentBuilderId is loaded)
+  useEffect(() => {
+    if (!agentBuilderId) return;
+
+    const restoreSession = async () => {
+      setRestoringSession(true);
+      try {
+        const sessionData = await agentApi.getSession(sessionId);
+        if (sessionData.messages.length > 0) {
+          setMessages(sessionMessagesToChatMessages(sessionData.messages));
+        }
+      } catch {
+        // Session not found — first visit, that's fine
+      } finally {
+        setRestoringSession(false);
+      }
+    };
+    restoreSession();
+  }, [agentBuilderId]); // Only on initial load, not on sessionId changes
+
+  // Auto-refresh session list when chat completes
+  const prevIsRunning = useRef(isRunning);
+  useEffect(() => {
+    if (prevIsRunning.current && !isRunning) {
+      queryClient.invalidateQueries({ queryKey: publishedSessionKeys.lists() });
+    }
+    prevIsRunning.current = isRunning;
+  }, [isRunning, queryClient]);
+
+  const handleNewChat = useCallback(() => {
+    const newId = generateUUID();
+    sessionStorage.setItem(SESSION_STORAGE_KEY, newId);
+    setSessionId(newId);
+    setMessages([]);
+    setMobileSidebarOpen(false);
+  }, []);
+
+  const handleSessionSwitch = useCallback(async (newSessionId: string) => {
+    if (newSessionId === sessionId || isRunning) return;
+
+    sessionStorage.setItem(SESSION_STORAGE_KEY, newSessionId);
+    setSessionId(newSessionId);
+    setMessages([]);
+    setMobileSidebarOpen(false);
+
+    try {
+      const data = await agentApi.getSession(newSessionId);
+      if (data.messages.length > 0) {
+        setMessages(sessionMessagesToChatMessages(data.messages));
+      }
+    } catch {
+      // First visit or not found
+    }
+  }, [sessionId, isRunning]);
 
   const handleSubmit = async (values: AgentFormValues) => {
     const preset = await createPreset.mutateAsync({
@@ -31,6 +183,126 @@ export default function NewAgentPage() {
     router.push(`/agents/${preset.id}`);
   };
 
+  // ── Chat tab layout ──
+  if (activeTab === 'chat') {
+    // Loading state
+    if (!agentBuilderId && !loadError) {
+      return (
+        <div className="flex items-center justify-center h-[calc(100vh-57px)]">
+          <div className="text-center">
+            <Spinner size="md" className="mx-auto mb-4" />
+            <p className="text-muted-foreground">{t('create.loadingBuilder')}</p>
+            <p className="text-xs text-muted-foreground mt-2">{t('create.loadingBuilderHint')}</p>
+          </div>
+        </div>
+      );
+    }
+
+    // Error state
+    if (loadError) {
+      return (
+        <div className="flex items-center justify-center h-[calc(100vh-57px)]">
+          <div className="text-center">
+            <div className="h-8 w-8 mx-auto mb-4 text-destructive text-2xl">✕</div>
+            <p className="text-destructive font-medium">{t('create.loadError')}</p>
+            <p className="text-xs text-muted-foreground mt-2">{loadError}</p>
+            <div className="flex items-center gap-2 justify-center mt-4">
+              <Button variant="outline" size="sm" onClick={() => window.location.reload()}>
+                {t('create.retry')}
+              </Button>
+              <Button variant="outline" size="sm" onClick={() => setActiveTab('form')}>
+                {t('create.tabManual')}
+              </Button>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    // Restoring session
+    if (restoringSession) {
+      return (
+        <div className="flex items-center justify-center h-[calc(100vh-57px)]">
+          <Spinner size="md" />
+        </div>
+      );
+    }
+
+    return (
+      <div className="flex h-[calc(100vh-57px)]">
+        {/* Desktop sidebar */}
+        <div className="w-[260px] shrink-0 hidden md:flex flex-col border-r bg-muted/30">
+          <SessionSidebar
+            agentId={agentBuilderId!}
+            activeSessionId={sessionId}
+            onSessionSelect={handleSessionSwitch}
+            onNewChat={handleNewChat}
+            isRunning={isRunning}
+          />
+        </div>
+
+        {/* Mobile sidebar overlay */}
+        {mobileSidebarOpen && (
+          <div className="fixed inset-0 z-50 md:hidden">
+            <div
+              className="absolute inset-0 bg-black/50"
+              onClick={() => setMobileSidebarOpen(false)}
+            />
+            <div className="absolute inset-y-0 left-0 w-[280px] bg-background border-r shadow-xl flex flex-col animate-in slide-in-from-left duration-200">
+              <SessionSidebar
+                agentId={agentBuilderId!}
+                activeSessionId={sessionId}
+                onSessionSelect={handleSessionSwitch}
+                onNewChat={handleNewChat}
+                isRunning={isRunning}
+              />
+            </div>
+          </div>
+        )}
+
+        {/* Chat area */}
+        <div className="flex-1 flex flex-col min-w-0">
+          {/* Tab switcher header */}
+          <div className="border-b px-4 py-2 flex items-center gap-3 shrink-0">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="md:hidden p-1.5"
+              onClick={() => setMobileSidebarOpen(true)}
+            >
+              <PanelLeft className="h-5 w-5" />
+            </Button>
+            <Link
+              href="/agents"
+              className="inline-flex items-center text-sm text-muted-foreground hover:text-foreground"
+            >
+              <ArrowLeft className="mr-1 h-4 w-4" />
+              <span className="hidden sm:inline">{t('create.backToAgents')}</span>
+            </Link>
+            <div className="flex-1" />
+            <TabSwitcher
+              active={activeTab}
+              onTabChange={setActiveTab}
+              chatLabel={t('create.tabChat')}
+              formLabel={t('create.tabManual')}
+            />
+          </div>
+
+          {/* Chat content */}
+          <AgentBuilderChat
+            agentBuilderId={agentBuilderId!}
+            sessionId={sessionId}
+            messages={messages}
+            setMessages={setMessages}
+            isRunning={isRunning}
+            setIsRunning={setIsRunning}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  // ── Form tab layout ──
   return (
     <div className="container mx-auto py-8 max-w-3xl">
       {/* Header */}
@@ -46,49 +318,30 @@ export default function NewAgentPage() {
         <p className="text-muted-foreground mt-1">{t('create.subtitle')}</p>
       </div>
 
-      {/* Tabs */}
-      <Tabs defaultValue="chat" className="w-full">
-        <TabsList className="grid w-full grid-cols-2 mb-6">
-          <TabsTrigger value="chat" className="flex items-center gap-2">
-            <MessageSquare className="h-4 w-4" />
-            {t('create.tabChat')}
-          </TabsTrigger>
-          <TabsTrigger value="form" className="flex items-center gap-2">
-            <FileText className="h-4 w-4" />
-            {t('create.tabManual')}
-          </TabsTrigger>
-        </TabsList>
+      {/* Tab switcher */}
+      <TabSwitcher
+        active={activeTab}
+        onTabChange={setActiveTab}
+        chatLabel={t('create.tabChat')}
+        formLabel={t('create.tabManual')}
+        className="mb-6"
+        size="md"
+      />
 
-        {/* Chat Mode */}
-        <TabsContent value="chat">
-          <Card>
-            <CardHeader>
-              <CardTitle>{t('create.chatTitle')}</CardTitle>
-              <CardDescription>{t('create.chatDescription')}</CardDescription>
-            </CardHeader>
-            <CardContent>
-              <AgentBuilderChat />
-            </CardContent>
-          </Card>
-        </TabsContent>
-
-        {/* Form Mode */}
-        <TabsContent value="form">
-          <Card>
-            <CardHeader>
-              <CardTitle>{t('create.formTitle')}</CardTitle>
-              <CardDescription>{t('create.formDescription')}</CardDescription>
-            </CardHeader>
-            <CardContent>
-              <AgentConfigForm
-                mode="create"
-                isProcessing={createPreset.isPending}
-                onSubmit={handleSubmit}
-              />
-            </CardContent>
-          </Card>
-        </TabsContent>
-      </Tabs>
+      {/* Form Mode */}
+      <Card>
+        <CardHeader>
+          <CardTitle>{t('create.formTitle')}</CardTitle>
+          <CardDescription>{t('create.formDescription')}</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <AgentConfigForm
+            mode="create"
+            isProcessing={createPreset.isPending}
+            onSubmit={handleSubmit}
+          />
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/web/src/i18n/locales/en-US/agents.json
+++ b/web/src/i18n/locales/en-US/agents.json
@@ -118,7 +118,18 @@
     "success": "Agent created successfully",
     "error": "Failed to create agent",
     "useBuilder": "Use Agent Builder",
-    "builderDescription": "Let AI help you configure your agent"
+    "builderDescription": "Let AI help you configure your agent",
+    "builderTitle": "Agent Builder",
+    "describeAgent": "Describe the Agent you want to create",
+    "describeAgentHint": "For example: \"I need an agent that can analyze CSV files and generate reports\"",
+    "loadingBuilder": "Loading agent-builder...",
+    "loadingBuilderHint": "Make sure the \"agent-builder\" Agent exists",
+    "loadError": "Failed to load agent-builder",
+    "agentCreated": "Agent created successfully!",
+    "viewAgent": "View Agent",
+    "hideConfig": "Hide Config",
+    "showConfig": "Config",
+    "retry": "Retry"
   },
   "edit": {
     "title": "Edit Agent",

--- a/web/src/i18n/locales/es/agents.json
+++ b/web/src/i18n/locales/es/agents.json
@@ -118,7 +118,18 @@
     "success": "Agente creado exitosamente",
     "error": "Error al crear el agente",
     "useBuilder": "Usar Constructor de Agentes",
-    "builderDescription": "Deja que la IA te ayude a configurar tu agente"
+    "builderDescription": "Deja que la IA te ayude a configurar tu agente",
+    "builderTitle": "Constructor de Agentes",
+    "describeAgent": "Describe el Agente que quieres crear",
+    "describeAgentHint": "Por ejemplo: \"Necesito un agente que pueda analizar archivos CSV y generar informes\"",
+    "loadingBuilder": "Cargando constructor de agentes...",
+    "loadingBuilderHint": "Asegúrate de que el Agente \"agent-builder\" exista",
+    "loadError": "Error al cargar el constructor de agentes",
+    "agentCreated": "¡Agente creado exitosamente!",
+    "viewAgent": "Ver Agente",
+    "hideConfig": "Ocultar Config",
+    "showConfig": "Config",
+    "retry": "Reintentar"
   },
   "edit": {
     "title": "Editar Agente",

--- a/web/src/i18n/locales/ja/agents.json
+++ b/web/src/i18n/locales/ja/agents.json
@@ -118,7 +118,18 @@
     "success": "エージェントが正常に作成されました",
     "error": "エージェントの作成に失敗しました",
     "useBuilder": "エージェントビルダーを使用",
-    "builderDescription": "AIにエージェントの設定を手伝ってもらう"
+    "builderDescription": "AIにエージェントの設定を手伝ってもらう",
+    "builderTitle": "エージェントビルダー",
+    "describeAgent": "作成したいエージェントを説明してください",
+    "describeAgentHint": "例：「CSVファイルを分析してレポートを生成できるエージェントが必要です」",
+    "loadingBuilder": "エージェントビルダーを読み込み中...",
+    "loadingBuilderHint": "\"agent-builder\" エージェントが存在することを確認してください",
+    "loadError": "エージェントビルダーの読み込みに失敗しました",
+    "agentCreated": "エージェントが正常に作成されました！",
+    "viewAgent": "エージェントを表示",
+    "hideConfig": "設定を隠す",
+    "showConfig": "設定",
+    "retry": "リトライ"
   },
   "edit": {
     "title": "エージェントを編集",

--- a/web/src/i18n/locales/pt-BR/agents.json
+++ b/web/src/i18n/locales/pt-BR/agents.json
@@ -118,7 +118,18 @@
     "success": "Agente criado com sucesso",
     "error": "Falha ao criar agente",
     "useBuilder": "Usar Construtor de Agentes",
-    "builderDescription": "Deixe a IA ajudá-lo a configurar seu agente"
+    "builderDescription": "Deixe a IA ajudá-lo a configurar seu agente",
+    "builderTitle": "Construtor de Agentes",
+    "describeAgent": "Descreva o Agente que você quer criar",
+    "describeAgentHint": "Por exemplo: \"Preciso de um agente que possa analisar arquivos CSV e gerar relatórios\"",
+    "loadingBuilder": "Carregando construtor de agentes...",
+    "loadingBuilderHint": "Certifique-se de que o Agente \"agent-builder\" existe",
+    "loadError": "Falha ao carregar o construtor de agentes",
+    "agentCreated": "Agente criado com sucesso!",
+    "viewAgent": "Ver Agente",
+    "hideConfig": "Ocultar Config",
+    "showConfig": "Config",
+    "retry": "Tentar novamente"
   },
   "edit": {
     "title": "Editar Agente",

--- a/web/src/i18n/locales/zh-CN/agents.json
+++ b/web/src/i18n/locales/zh-CN/agents.json
@@ -118,7 +118,18 @@
     "success": "代理创建成功",
     "error": "创建代理失败",
     "useBuilder": "使用代理构建器",
-    "builderDescription": "让 AI 帮助你配置代理"
+    "builderDescription": "让 AI 帮助你配置代理",
+    "builderTitle": "代理构建器",
+    "describeAgent": "描述你想创建的 Agent",
+    "describeAgentHint": "例如：\"我需要一个可以分析 CSV 文件并生成报告的 Agent\"",
+    "loadingBuilder": "正在加载代理构建器...",
+    "loadingBuilderHint": "请确保 \"agent-builder\" Agent 存在",
+    "loadError": "加载代理构建器失败",
+    "agentCreated": "Agent 创建成功！",
+    "viewAgent": "查看 Agent",
+    "hideConfig": "隐藏配置",
+    "showConfig": "配置",
+    "retry": "重试"
   },
   "edit": {
     "title": "编辑代理",


### PR DESCRIPTION
## Summary
- Add session persistence to the Agent Builder Chat page (`/agents/new`) so conversations survive page refreshes
- Add a session sidebar (reusing `SessionSidebar` component) for browsing, switching, and managing past agent-builder conversations
- Refactor `AgentBuilderChat` to use the shared `useChatEngine` hook, reducing ~180 lines of manual streaming logic

## Changes
- **`web/src/app/agents/new/page.tsx`** — Conditional layout: chat tab = full-width with sidebar, form tab = narrow card. Session state lifted here with `sessionStorage` persistence.
- **`web/src/components/agents/agent-builder-chat.tsx`** — Accepts props for state, uses `useChatEngine` hook instead of manual streaming logic.
- **i18n** — Added 12 new keys across all 5 locale files (en-US, zh-CN, ja, es, pt-BR).

Closes #52

## Test plan
- [ ] Navigate to `/agents/new` — Chat tab shows full-width layout with session sidebar
- [ ] Send a message — response streams correctly
- [ ] Refresh page — chat history is preserved
- [ ] Click "New Chat" in sidebar — starts fresh session
- [ ] Click a past session — loads that session's messages
- [ ] Switch to "Manual Build" tab — shows narrow form layout
- [ ] Mobile viewport — sidebar toggles via hamburger button