### PR TITLE
feat: improve tool output quality — tail truncation, fuzzy edit, output logs, timing

### DIFF
--- a/app/tools/file_scanner.py
+++ b/app/tools/file_scanner.py
@@ -35,7 +35,7 @@ IGNORED_FILENAMES = {
 
 IGNORED_PREFIXES = ('_script_', '.', '__')
 
-IGNORED_DIRS = {'__pycache__', '.git', 'node_modules', '.ipynb_checkpoints'}
+IGNORED_DIRS = {'__pycache__', '.git', 'node_modules', '.ipynb_checkpoints', '.output_logs'}
 
 
 def _should_ignore(filepath: Path) -> bool:

--- a/app/tools/ipython_kernel.py
+++ b/app/tools/ipython_kernel.py
@@ -41,7 +41,7 @@ class IPythonKernel:
         self,
         startup_timeout: int = 30,
         execute_timeout: int = 300,
-        max_output_chars: int = 30000,
+        max_output_chars: int = 10000,
         working_dir: Optional[str] = None,
         env: Optional[dict] = None,
     ):
@@ -159,14 +159,24 @@ class IPythonKernel:
 
         output = "\n".join(output_parts).strip() if output_parts else ""
 
-        # Truncate if needed
+        # Truncate if needed (tail — keeps the most recent/useful output)
         if len(output) > self._max_output_chars:
-            output = output[: self._max_output_chars] + "\n... [OUTPUT TRUNCATED]"
+            omitted = len(output) - self._max_output_chars
+            output = (
+                f"[Output truncated: showing last {self._max_output_chars} of {len(output)} chars "
+                f"({omitted} omitted).]\n"
+                + output[-self._max_output_chars:]
+            )
 
         has_error = bool(error_parts)
         error_text = "\n".join(error_parts) if has_error else None
         if error_text and len(error_text) > self._max_output_chars:
-            error_text = error_text[: self._max_output_chars] + "\n... [ERROR TRUNCATED]"
+            omitted_err = len(error_text) - self._max_output_chars
+            error_text = (
+                f"[Error truncated: showing last {self._max_output_chars} of {len(error_text)} chars "
+                f"({omitted_err} omitted).]\n"
+                + error_text[-self._max_output_chars:]
+            )
 
         # Combine output and error for the full output field
         if has_error:


### PR DESCRIPTION
## Summary

- **Tail truncation**: bash/execute_code long output now keeps the tail (where errors and final results appear) instead of the head
- **Actionable truncation notice**: full output saved to `.output_logs/` when truncated, with a message telling the LLM to use `read` tool to view it
- **Edit fuzzy match**: when exact match fails, tries Unicode normalization (smart quotes -> ASCII quotes, em dashes -> hyphens, special spaces -> regular spaces); 1:1 char mapping preserves positions
- **Execution timing**: all execute_code/bash variants (local, workspace-bound, executor-bound) return `duration_seconds`
- **Remove L2 re-truncation**: deleted `truncate_tool_result()` — tool results go to LLM unmodified; context size managed by compression
- **L1 limit adjusted**: `MAX_OUTPUT_CHARS` changed from 30000 to 10000

## Test plan

- [x] 427 unit tests passed
- [x] 176 E2E tests passed
- [x] 47 compression tests passed
- [x] Live validation: execute_code with 20000 lines -> `showing last 10000 of 208889 chars`, LLM correctly references `line_19999`
- [x] Live validation: bash `seq 50000` -> tail truncation + `.output_logs` path + `read` hint in truncation message
- [x] Live validation: edit fuzzy match — smart quotes `""''`, em dash `—` all matched successfully via normalization
- [x] Live validation: `duration_seconds` field present (execute_code 1.09s / bash 0.0s)
- [x] Live validation: no L2 truncation — LLM answer correctly references tail data

Closes #54