### PR TITLE
ui: replace header more icon with settings gear

### DIFF
--- a/web/src/components/layout/app-header.tsx
+++ b/web/src/components/layout/app-header.tsx
@@ -7,7 +7,7 @@ import {
   Sun,
   Moon,
   BookOpen,
-  MoreHorizontal,
+  Settings,
   Container,
   Folder,
   Terminal,
@@ -76,7 +76,7 @@ export function AppHeader() {
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button variant="ghost" size="icon" aria-label={t('nav.more')}>
-                  <MoreHorizontal className="h-4 w-4" />
+                  <Settings className="h-4 w-4" />
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">


### PR DESCRIPTION
## Summary
- Replaced the `MoreHorizontal` (three-dot) icon in the header dropdown with a `Settings` (gear) icon
- Better conveys the menu's purpose: system management (Executors, Files, Environment, Backup) and monitoring (Traces, Sessions)

## Test plan
- [x] Verified icon renders correctly after Docker rebuild