### PR TITLE
feat: add API key preflight check before agent calls

### DIFF
--- a/app/api/v1/published.py
+++ b/app/api/v1/published.py
@@ -374,6 +374,10 @@ async def published_chat(agent_id: str, request: PublishedChatRequest):
 
         config = await _resolve_published_config(preset)
 
+    # Validate API key before proceeding
+    from app.api.v1.agent import _validate_api_key
+    _validate_api_key(config)
+
     # Session management — published agents may omit session_id for auto-creation
     if request.session_id:
         session_data = await load_or_create_session(request.session_id, agent_id)
@@ -659,6 +663,10 @@ async def published_chat_sync(agent_id: str, request: PublishedChatRequest):
             )
 
         config = await _resolve_published_config(preset)
+
+    # Validate API key before proceeding
+    from app.api.v1.agent import _validate_api_key
+    _validate_api_key(config)
 
     # Session management — published agents may omit session_id for auto-creation
     if request.session_id:

--- a/app/llm/provider.py
+++ b/app/llm/provider.py
@@ -80,6 +80,17 @@ class LLMResponse:
         return [b for b in self.content if isinstance(b, LLMToolCall)]
 
 
+# Provider name → environment variable name for the API key
+PROVIDER_API_KEY_MAP = {
+    "anthropic": "ANTHROPIC_API_KEY",
+    "openai": "OPENAI_API_KEY",
+    "google": "GOOGLE_API_KEY",
+    "deepseek": "DEEPSEEK_API_KEY",
+    "kimi": "MOONSHOT_API_KEY",
+    "openrouter": "OPENROUTER_API_KEY",
+}
+
+
 class LLMClient:
     """
     Unified LLM client using native SDKs.
@@ -114,15 +125,7 @@ class LLMClient:
         Always reads from .env on disk so that all uvicorn workers
         see keys set via the Settings UI (multi-worker safe).
         """
-        key_map = {
-            "anthropic": "ANTHROPIC_API_KEY",
-            "openai": "OPENAI_API_KEY",
-            "google": "GOOGLE_API_KEY",
-            "deepseek": "DEEPSEEK_API_KEY",
-            "kimi": "MOONSHOT_API_KEY",
-            "openrouter": "OPENROUTER_API_KEY",
-        }
-        env_var = key_map.get(provider, f"{provider.upper()}_API_KEY")
+        env_var = PROVIDER_API_KEY_MAP.get(provider, f"{provider.upper()}_API_KEY")
         return read_env_value(env_var)
 
     def _get_openai_client(self):

--- a/tests/test_e2e/test_e2e_workflows.py
+++ b/tests/test_e2e/test_e2e_workflows.py
@@ -990,6 +990,9 @@ class TestPublishedAgentSessionE2E:
         mock_preset.max_turns = 5
         mock_preset.mcp_servers = []
         mock_preset.system_prompt = None
+        mock_preset.model_provider = None
+        mock_preset.model_name = None
+        mock_preset.executor_id = None
 
         call_idx = {"i": 0}
         results = [mock_preset, None, None, None, None]

--- a/web/src/app/chat/page.tsx
+++ b/web/src/app/chat/page.tsx
@@ -104,6 +104,18 @@ export default function FullscreenChatPage() {
       steer: async (traceId, message) => { await agentApi.steerAgent(traceId, message); },
     },
     onSessionId: (id) => setSessionId(id),
+    validateBeforeRun: () => {
+      const state = useChatStore.getState();
+      const effectiveProvider = state.selectedModelProvider || 'kimi';
+      const providers = modelsData?.providers;
+      if (!providers) return null;
+      const providerInfo = providers.find(p => p.name === effectiveProvider);
+      if (providerInfo && !providerInfo.api_key_set) {
+        const label = effectiveProvider.charAt(0).toUpperCase() + effectiveProvider.slice(1);
+        return t('error.apiKeyNotSet', { provider: label });
+      }
+      return null;
+    },
   });
 
   // Fetch data — defer skills/tools/MCP until config panel is open

--- a/web/src/components/chat/chat-panel.tsx
+++ b/web/src/components/chat/chat-panel.tsx
@@ -151,6 +151,18 @@ export function ChatPanel({ isOpen, onClose, defaultSkills = [] }: ChatPanelProp
       },
     },
     onSessionId: (id) => setSessionId(id),
+    validateBeforeRun: () => {
+      const state = useChatStore.getState();
+      const effectiveProvider = state.selectedModelProvider || 'kimi';
+      const providers = modelsData?.providers;
+      if (!providers) return null;
+      const providerInfo = providers.find(p => p.name === effectiveProvider);
+      if (providerInfo && !providerInfo.api_key_set) {
+        const label = effectiveProvider.charAt(0).toUpperCase() + effectiveProvider.slice(1);
+        return t('error.apiKeyNotSet', { provider: label });
+      }
+      return null;
+    },
   });
 
   // Fetch available data

--- a/web/src/hooks/use-chat-engine.ts
+++ b/web/src/hooks/use-chat-engine.ts
@@ -55,6 +55,8 @@ export interface ChatEngineOptions {
   responseMode?: 'streaming' | 'non_streaming';
   /** Called when session_id changes (e.g. from run_started event) */
   onSessionId?: (id: string) => void;
+  /** Pre-flight validation before running. Return error message to abort (shown as toast), or null to proceed. */
+  validateBeforeRun?: () => string | null;
 }
 
 export interface ChatEngineReturn {
@@ -119,6 +121,15 @@ export function useChatEngine(options: ChatEngineOptions): ChatEngineReturn {
 
     // Prevent concurrent runs
     if (ma.getIsRunning()) return;
+
+    // Pre-flight validation (e.g. API key check)
+    if (adapterRef.current.validateBeforeRun) {
+      const error = adapterRef.current.validateBeforeRun();
+      if (error) {
+        toast.error(error);
+        return;
+      }
+    }
 
     const abortController = new AbortController();
     abortControllerRef.current = abortController;

--- a/web/src/i18n/locales/en-US/chat.json
+++ b/web/src/i18n/locales/en-US/chat.json
@@ -89,7 +89,8 @@
     "uploadFailed": "File upload failed",
     "runFailed": "Failed to run agent",
     "connectionLost": "Connection lost",
-    "tryAgain": "Try again"
+    "tryAgain": "Try again",
+    "apiKeyNotSet": "API key for {{provider}} is not configured. Please set it in Settings > Environment."
   },
   "history": {
     "title": "History",

--- a/web/src/i18n/locales/es/chat.json
+++ b/web/src/i18n/locales/es/chat.json
@@ -89,7 +89,8 @@
     "uploadFailed": "Error al subir archivo",
     "runFailed": "Error al ejecutar el agente",
     "connectionLost": "Conexión perdida",
-    "tryAgain": "Intentar de nuevo"
+    "tryAgain": "Intentar de nuevo",
+    "apiKeyNotSet": "La clave API de {{provider}} no está configurada. Configúrela en Ajustes > Entorno."
   },
   "history": {
     "title": "Historial",

--- a/web/src/i18n/locales/ja/chat.json
+++ b/web/src/i18n/locales/ja/chat.json
@@ -89,7 +89,8 @@
     "uploadFailed": "ファイルのアップロードに失敗しました",
     "runFailed": "エージェントの実行に失敗しました",
     "connectionLost": "接続が切断されました",
-    "tryAgain": "再試行"
+    "tryAgain": "再試行",
+    "apiKeyNotSet": "{{provider}} の API キーが設定されていません。設定 > 環境変数 で設定してください。"
   },
   "history": {
     "title": "履歴",

--- a/web/src/i18n/locales/pt-BR/chat.json
+++ b/web/src/i18n/locales/pt-BR/chat.json
@@ -89,7 +89,8 @@
     "uploadFailed": "Falha ao enviar arquivo",
     "runFailed": "Falha ao executar o agente",
     "connectionLost": "Conexão perdida",
-    "tryAgain": "Tentar novamente"
+    "tryAgain": "Tentar novamente",
+    "apiKeyNotSet": "A chave de API do {{provider}} não está configurada. Configure em Configurações > Ambiente."
   },
   "history": {
     "title": "Histórico",

--- a/web/src/i18n/locales/zh-CN/chat.json
+++ b/web/src/i18n/locales/zh-CN/chat.json
@@ -89,7 +89,8 @@
     "uploadFailed": "文件上传失败",
     "runFailed": "运行 Agent 失败",
     "connectionLost": "连接已断开",
-    "tryAgain": "重试"
+    "tryAgain": "重试",
+    "apiKeyNotSet": "{{provider}} 的 API Key 未配置，请在 设置 > 环境变量 中设置。"
   },
   "history": {
     "title": "历史记录",

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1743,6 +1743,7 @@ export interface ModelInfo {
 
 export interface ProviderInfo {
   name: string;
+  api_key_set: boolean;
   models: ModelInfo[];
 }
 


### PR DESCRIPTION
## Summary
- Add `api_key_set` field to `/models/providers` response for each provider
- Frontend pre-checks API key status before sending chat messages, showing a toast error if unconfigured
- Backend validates API key in agent run/stream and published agent endpoints (HTTP 400 safety net)
- Extract `PROVIDER_API_KEY_MAP` as a shared constant in `app/llm/provider.py`
- i18n: add `apiKeyNotSet` error message in all 5 languages

Closes #65

## Test plan
- [ ] Select a provider without API key configured → verify toast error appears before message is sent
- [ ] Verify configured provider (e.g., Kimi) works normally
- [ ] Test published agent with unconfigured provider → verify HTTP 400 response
- [ ] Check all 5 languages display the error message correctly