### PR TITLE
feat: add session sidebar and history to skill evolve page

### DIFF
--- a/web/src/i18n/locales/en-US/skills.json
+++ b/web/src/i18n/locales/en-US/skills.json
@@ -236,7 +236,9 @@
       "turns": "Turns: {{count}}",
       "tokens": "Tokens: {{count}}",
       "duration": "Duration: {{duration}}s"
-    }
+    },
+    "newChat": "New Chat",
+    "history": "History"
   },
   "sync": {
     "title": "Filesystem Sync",

--- a/web/src/i18n/locales/es/skills.json
+++ b/web/src/i18n/locales/es/skills.json
@@ -236,7 +236,9 @@
       "turns": "Turnos: {{count}}",
       "tokens": "Tokens: {{count}}",
       "duration": "Duración: {{duration}}s"
-    }
+    },
+    "newChat": "Nuevo Chat",
+    "history": "Historial"
   },
   "sync": {
     "title": "Sincronización del Sistema de Archivos",

--- a/web/src/i18n/locales/ja/skills.json
+++ b/web/src/i18n/locales/ja/skills.json
@@ -236,7 +236,9 @@
       "turns": "ターン数: {{count}}",
       "tokens": "トークン数: {{count}}",
       "duration": "所要時間: {{duration}}秒"
-    }
+    },
+    "newChat": "新しいチャット",
+    "history": "履歴"
   },
   "sync": {
     "title": "ファイルシステム同期",

--- a/web/src/i18n/locales/pt-BR/skills.json
+++ b/web/src/i18n/locales/pt-BR/skills.json
@@ -236,7 +236,9 @@
       "turns": "Turnos: {{count}}",
       "tokens": "Tokens: {{count}}",
       "duration": "Duração: {{duration}}s"
-    }
+    },
+    "newChat": "Novo Chat",
+    "history": "Histórico"
   },
   "sync": {
     "title": "Sincronização do Sistema de Arquivos",

--- a/web/src/i18n/locales/zh-CN/skills.json
+++ b/web/src/i18n/locales/zh-CN/skills.json
@@ -236,7 +236,9 @@
       "turns": "轮次：{{count}}",
       "tokens": "Token：{{count}}",
       "duration": "耗时：{{duration}}秒"
-    }
+    },
+    "newChat": "新对话",
+    "history": "历史记录"
   },
   "sync": {
     "title": "文件系统同步",


### PR DESCRIPTION
## Summary

- Add session sidebar to evolve chat phase, reusing `SessionSidebar` from published agent pages
- Add "History" button on select phase for quick access to past evolve sessions
- Session switching loads messages from server and restores chat state
- Auto-refresh session list when evolve completes
- Mobile sidebar as overlay with backdrop
- i18n keys for all 5 languages

Closes #67