### PR TITLE
docs: add executor profile cleanup to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,9 @@ docker compose -f docker-compose.dev.yaml up -d
 cd skill-compose/docker
 # '-v' will remove all data stored in volumes
 docker compose down -v
+
+# If you started executor profiles, stop them too
+docker compose --profile ml --profile gpu down -v
 ```
 
 </details>

--- a/README_es.md
+++ b/README_es.md
@@ -125,6 +125,9 @@ docker compose -f docker-compose.dev.yaml up -d
 cd skill-compose/docker
 # '-v' eliminará todos los datos almacenados en los volúmenes
 docker compose down -v
+
+# Si iniciaste perfiles de executor, deténlos también
+docker compose --profile ml --profile gpu down -v
 ```
 
 </details>

--- a/README_ja.md
+++ b/README_ja.md
@@ -125,6 +125,9 @@ docker compose -f docker-compose.dev.yaml up -d
 cd skill-compose/docker
 # '-v' はボリュームに保存されたすべてのデータを削除します
 docker compose down -v
+
+# executor プロファイルを起動している場合は、それらも停止してください
+docker compose --profile ml --profile gpu down -v
 ```
 
 </details>

--- a/README_pt-BR.md
+++ b/README_pt-BR.md
@@ -125,6 +125,9 @@ docker compose -f docker-compose.dev.yaml up -d
 cd skill-compose/docker
 # '-v' removerá todos os dados armazenados nos volumes
 docker compose down -v
+
+# Se você iniciou perfis de executor, pare-os também
+docker compose --profile ml --profile gpu down -v
 ```
 
 </details>

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -125,6 +125,9 @@ docker compose -f docker-compose.dev.yaml up -d
 cd skill-compose/docker
 # '-v' 会删除所有存储在卷中的数据
 docker compose down -v
+
+# 如果启动了 executor profiles，也需要一并停止
+docker compose --profile ml --profile gpu down -v
 ```
 
 </details>


### PR DESCRIPTION
## Summary
- Add `docker compose --profile ml --profile gpu down -v` command to the Cleanup section of README
- Updated all 5 language variants (en, zh-CN, ja, es, pt-BR)

## Test plan
- [ ] Verify cleanup commands are correct by running them in a test environment