### PR TITLE
fix: restore trace IDs on session messages in fullscreen chat

### DIFF
--- a/app/api/v1/agent.py
+++ b/app/api/v1/agent.py
@@ -383,6 +383,7 @@ async def run_agent(request: AgentRequest, db: AsyncSession = Depends(get_db)):
             llm_calls=[asdict(call) for call in result.llm_calls],
             duration_ms=duration_ms,
             executor_name=config.get("executor_name"),
+            session_id=session_id,
         )
         db.add(trace)
         await db.commit()
@@ -491,6 +492,7 @@ async def run_agent_stream(request: AgentRequest, db: AsyncSession = Depends(get
                 llm_calls=[],
                 duration_ms=0,
                 executor_name=config.get("executor_name"),
+                session_id=session_id,
             )
             trace_db.add(trace)
             await trace_db.commit()

--- a/app/api/v1/backup.py
+++ b/app/api/v1/backup.py
@@ -281,6 +281,7 @@ async def _create_backup_zip(
                 "llm_calls": tr.llm_calls,
                 "created_at": _serialize_datetime(tr.created_at),
                 "duration_ms": tr.duration_ms,
+                "session_id": tr.session_id,
             })
         offset += TRACE_BATCH_SIZE
     stats.agent_traces = len(traces_data)
@@ -619,6 +620,7 @@ async def _restore_from_zip(
                 llm_calls=tr.get("llm_calls"),
                 created_at=datetime.fromisoformat(tr["created_at"]) if tr.get("created_at") else datetime.utcnow(),
                 duration_ms=tr.get("duration_ms"),
+                session_id=tr.get("session_id"),
             )
             db.add(trace)
             restored.agent_traces += 1

--- a/app/api/v1/published.py
+++ b/app/api/v1/published.py
@@ -430,6 +430,7 @@ async def published_chat(agent_id: str, request: PublishedChatRequest):
                 llm_calls=[],
                 duration_ms=0,
                 executor_name=config.get("executor_name"),
+                session_id=session_id,
             )
             trace_db.add(trace)
             await trace_db.commit()
@@ -718,6 +719,7 @@ async def published_chat_sync(agent_id: str, request: PublishedChatRequest):
             llm_calls=[],
             duration_ms=0,
             executor_name=config.get("executor_name"),
+            session_id=session_id,
         )
         trace_db.add(trace)
         await trace_db.commit()

--- a/app/db/database.py
+++ b/app/db/database.py
@@ -230,6 +230,18 @@ async def _run_migrations():
             END $$
         """))
 
+    # Add session_id column to agent_traces table
+    async with engine.begin() as conn:
+        await conn.execute(text("""
+            DO $$ BEGIN
+                ALTER TABLE agent_traces ADD COLUMN session_id VARCHAR(36) DEFAULT NULL;
+            EXCEPTION WHEN duplicate_column THEN NULL;
+            END $$
+        """))
+        await conn.execute(text(
+            "CREATE INDEX IF NOT EXISTS ix_agent_traces_session_id ON agent_traces (session_id)"
+        ))
+
     # Ensure meta skills from filesystem are registered in the database
     await _ensure_meta_skills_registered()
 

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -316,10 +316,14 @@ class AgentTraceDB(Base):
     executor_name: Mapped[Optional[str]] = mapped_column(
         String(64), nullable=True
     )  # Executor used (e.g., "remotion", "base", None for local)
+    session_id: Mapped[Optional[str]] = mapped_column(
+        String(36), nullable=True
+    )  # Session ID linking this trace to a chat session
 
     __table_args__ = (
         Index("ix_agent_traces_created_at", "created_at"),
         Index("ix_agent_traces_success", "success"),
+        Index("ix_agent_traces_session_id", "session_id"),
     )
 
     def __repr__(self) -> str:

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -854,6 +854,17 @@ export const agentApi = {
     }
     return response.json();
   },
+
+  getSessionTraceIds: async (sessionId: string): Promise<string[]> => {
+    const response = await fetch(
+      `${AGENT_API_BASE}/traces/by-session/${encodeURIComponent(sessionId)}`
+    );
+    if (!response.ok) {
+      return [];
+    }
+    const data = await response.json();
+    return data.trace_ids || [];
+  },
 };
 
 // Traces API


### PR DESCRIPTION
## Summary

- Add `session_id` column to `agent_traces` table to link traces to chat sessions
- Add `GET /traces/by-session/{session_id}` endpoint returning trace IDs in chronological order
- Add `session_id` filter to `GET /traces` list endpoint
- Update session restore hook to fetch and attach trace IDs to restored messages
- Update backup export/import to include `session_id` field

Closes #79

## Test plan

- [x] Deploy and verify sync endpoint stores `session_id` in trace
- [x] Deploy and verify streaming endpoint stores `session_id` in trace
- [x] Verify `by-session` endpoint returns trace IDs in chronological order
- [x] Verify multi-message sessions correctly associate all traces
- [x] Open fullscreen chat, send messages, refresh page — trace IDs should persist on restored messages