### PR TITLE
Fix Skills dropdown clipped in Chat Panel config

### DIFF
--- a/web/src/components/chat/chat-panel.tsx
+++ b/web/src/components/chat/chat-panel.tsx
@@ -315,7 +315,7 @@ export function ChatPanel({ isOpen, onClose, defaultSkills = [] }: ChatPanelProp
 
       {/* Expanded Config Panel */}
       {showConfigPanel && (
-        <div className="px-4 py-3 border-b bg-muted/20 space-y-3 text-xs max-h-[40vh] overflow-y-auto">
+        <div className="px-4 py-3 border-b bg-muted/20 space-y-3 text-xs">
           {selectedAgentPreset && (
             <div className="flex items-center gap-2 text-[10px] text-muted-foreground">
               <span>{t('configManagedByPreset')}</span>
@@ -377,7 +377,7 @@ export function ChatPanel({ isOpen, onClose, defaultSkills = [] }: ChatPanelProp
 
             {/* Tools/MCP Chips */}
             {showToolsPanel && (
-              <div className="mt-2 space-y-3">
+              <div className="mt-2 space-y-3 max-h-[30vh] overflow-y-auto">
                 <div>
                   <div className="flex items-center gap-2 mb-1.5">
                     <Wrench className="h-3 w-3 text-muted-foreground" />


### PR DESCRIPTION
## Summary
- Remove `overflow-y-auto` from the Chat Panel expanded config wrapper so the Skills MultiSelect dropdown can render above the chat messages area
- Move scroll constraints (`max-h-[30vh] overflow-y-auto`) to only the Tools/MCP chips section, which is the only part that needs scrolling

## Root Cause
The config panel had `max-h-[40vh] overflow-y-auto`, creating a CSS overflow clipping context that trapped the absolutely-positioned Skills dropdown inside the scroll area.

## Test Plan
- [ ] Open Chat Panel → Settings → Skills dropdown: verify it overlays on top of chat messages
- [ ] Expand Tools/MCP section with many items: verify it scrolls independently
- [ ] Test in both light and dark mode

Closes #85