### PR TITLE
Add code-to-diagram skill, diagram executor, and DiagramArchitect agent

### DIFF
--- a/config/executors.json
+++ b/config/executors.json
@@ -34,6 +34,13 @@
       "url": "http://executor-remotion:62680",
       "memory_limit": "4G",
       "gpu_required": false
+    },
+    "diagram": {
+      "description": "Mermaid.js diagram rendering with Node.js 20, Chromium, mmdc for code-to-diagram",
+      "image": "skillcompose/executor-diagram:latest",
+      "url": "http://executor-diagram:62680",
+      "memory_limit": "4G",
+      "gpu_required": false
     }
   }
 }

--- a/config/seed_agents.json
+++ b/config/seed_agents.json
@@ -125,6 +125,26 @@
       "is_system": false,
       "is_published": true,
       "api_response_mode": "streaming"
+    },
+    {
+      "name": "DiagramArchitect",
+      "description": "Generate architecture diagrams, ER diagrams, sequence diagrams, class diagrams, and flowcharts from codebases or GitHub repos. Analyzes code structure and renders production-quality diagrams via Mermaid.js.",
+      "system_prompt": "# Diagram Architect\n\nYou are a technical architecture visualization expert. You analyze codebases and produce clear, accurate diagrams.\n\n## Workflow\n\n### Step 1: Understand the Request\n- What does the user want to visualize? (architecture, ER, sequence, class, flowchart, dependency graph)\n- What is the scope? (entire project, single module, specific API flow)\n- Where is the code? (local path, GitHub URL, uploaded files)\n\nIf the user's request is vague (e.g., \"draw me a diagram\"), ask which type. If they say \"give me an overview\", default to an architecture diagram.\n\n### Step 2: Load Skill\nUse `get_skill(\"code-to-diagram\")` to load the diagram generation methodology.\n\n### Step 3: Analyze Code\nFollow the progressive analysis strategy from the skill:\n1. `glob` to scan directory structure\n2. `read` entry points (main.py, package.json, etc.)\n3. `grep` for specific patterns based on diagram type:\n   - ER: `grep(\"class.*Model\")`, `grep(\"Column\\(\")`, `grep(\"relationship\")`\n   - Architecture: `grep(\"router\")`, `grep(\"app.include\")`, `grep(\"import \")`\n   - Sequence: Read the specific endpoint handler chain\n   - Class: `grep(\"class \")`, `grep(\"def \")` within target files\n\nFor GitHub URLs:\n```bash\ngit clone --depth 1 <url> /tmp/repo-name\n```\nThen analyze the cloned repo.\n\n### Step 4: Generate Diagram\n1. Write the `.mmd` file with proper Mermaid syntax\n2. Ensure puppeteer config exists:\n   ```bash\n   [ -f /tmp/puppeteer-config.json ] || echo '{\"args\":[\"--no-sandbox\",\"--disable-setuid-sandbox\"]}' > /tmp/puppeteer-config.json\n   ```\n3. Render both formats:\n   ```bash\n   mmdc -i diagram.mmd -o diagram.svg -b transparent -p /tmp/puppeteer-config.json\n   mmdc -i diagram.mmd -o diagram.png -b white -s 2 -p /tmp/puppeteer-config.json\n   ```\n\n### Step 5: Verify & Deliver\n- Read the rendered PNG to visually verify correctness\n- If issues found (syntax error, missing nodes, wrong relationships), fix and re-render\n- Deliver both SVG and PNG\n\n## Multi-Diagram Projects\nWhen the codebase is large or the user wants comprehensive documentation:\n1. Start with a high-level architecture overview\n2. Ask if they want detail diagrams (ER, sequence, class)\n3. Generate each in a `diagrams/` folder with consistent naming\n\n## Important Rules\n- **Always verify** the rendered image before delivering\n- **Don't guess relationships** — only draw what the code explicitly shows\n- **Keep diagrams focused** — max ~20 nodes per diagram, split if larger\n- **Use the Mermaid reference** — `get_skill(\"code-to-diagram\")` then read `references/mermaid-patterns.md` for syntax details\n\n## Requirements\n\nThis agent requires the **diagram** executor which provides:\n- Node.js 20 + Chromium + mmdc (Mermaid CLI)\n- CJK fonts for international text\n\nIf mmdc is not available, inform the user to select the **diagram** executor in the Chat panel.\n",
+      "skill_ids": [
+        "code-to-diagram",
+        "pdf"
+      ],
+      "mcp_servers": [
+        "git",
+        "time"
+      ],
+      "builtin_tools": null,
+      "max_turns": 60,
+      "model_provider": "kimi",
+      "model_name": "kimi-k2.5",
+      "is_system": false,
+      "is_published": true,
+      "api_response_mode": "streaming"
     }
   ]
 }

--- a/docker/api/entrypoint.sh
+++ b/docker/api/entrypoint.sh
@@ -31,8 +31,8 @@ if [ ! -f /app/config/mcp.json ]; then
     echo "Config initialized."
 else
     echo "Config directory already initialized."
-    # Always update seed files (new skills/agents may have been added)
-    for f in seed_agents.json seed_skills.json; do
+    # Always update seed files (new skills/agents/executors may have been added)
+    for f in seed_agents.json seed_skills.json executors.json; do
         if [ -f /app/default-config/$f ]; then
             cp /app/default-config/$f /app/config/$f 2>/dev/null || true
         fi

--- a/docker/docker-compose.dev.yaml
+++ b/docker/docker-compose.dev.yaml
@@ -353,8 +353,36 @@ services:
         limits:
           memory: 8G
 
-
-
+  # Custom executor - Diagram (Mermaid.js rendering with Node.js + Chromium + mmdc)
+  executor-diagram:
+    build:
+      context: ./executor
+      dockerfile: Dockerfile.diagram
+    image: skillcompose/executor-diagram:latest
+    container_name: skills-executor-diagram
+    restart: unless-stopped
+    profiles:
+      - diagram
+    volumes:
+      - workspaces:/app/workspaces
+      - skills:/app/skills:ro
+      - uploads:/app/uploads:ro
+    environment:
+      - EXECUTOR_NAME=diagram
+      - EXECUTOR_PORT=62680
+      - TZ=${TZ:-UTC}
+    networks:
+      - skills-network
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:62680/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    deploy:
+      resources:
+        limits:
+          memory: 4G
 
 
 

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -259,6 +259,33 @@ services:
               count: 1
               capabilities: [gpu]
 
+  executor-diagram:
+    image: skillcompose/executor-diagram:latest
+    container_name: skills-executor-diagram
+    restart: unless-stopped
+    profiles:
+      - diagram
+    volumes:
+      - workspaces:/app/workspaces
+      - skills:/app/skills:ro
+      - uploads:/app/uploads:ro
+    environment:
+      - EXECUTOR_NAME=diagram
+      - EXECUTOR_PORT=62680
+      - TZ=${TZ:-UTC}
+    networks:
+      - skills-network
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:62680/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    deploy:
+      resources:
+        limits:
+          memory: 4G
+
 networks:
   skills-network:
     driver: bridge

--- a/docker/executor/Dockerfile.diagram
+++ b/docker/executor/Dockerfile.diagram
@@ -1,0 +1,72 @@
+# ==============================================================================
+# Executor: Diagram - Mermaid.js Rendering Environment
+# ==============================================================================
+# Extends python:3.11-slim with Node.js 20, Chromium, and @mermaid-js/mermaid-cli
+# for rendering Mermaid diagrams to SVG/PNG.
+#
+# Included tools:
+# - Node.js 20 + npm (mermaid-cli runtime)
+# - Chromium (headless browser for Puppeteer)
+# - mmdc (@mermaid-js/mermaid-cli) — global install
+# - git (for cloning repos to analyze)
+#
+# Included Python packages:
+# - requests, httpx (HTTP clients)
+# - pillow (image processing)
+# ==============================================================================
+
+FROM python:3.11-slim
+
+LABEL org.opencontainers.image.title="Skills Executor - Diagram"
+LABEL org.opencontainers.image.description="Mermaid.js diagram rendering with Node.js, Chromium, mmdc"
+LABEL org.opencontainers.image.version="1.0.0"
+
+WORKDIR /app
+
+# Install system dependencies: Chromium + git
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    git \
+    chromium \
+    # CJK + emoji fonts for international text rendering
+    fonts-noto-cjk \
+    fonts-noto-color-emoji \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Node.js 20 via NodeSource
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install mermaid-cli globally
+RUN npm install -g @mermaid-js/mermaid-cli
+
+# Create puppeteer config for headless/root environments
+RUN echo '{"args":["--no-sandbox","--disable-setuid-sandbox"]}' > /tmp/puppeteer-config.json
+
+# Install executor server dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Install common Python packages
+RUN pip install --no-cache-dir \
+    requests \
+    httpx \
+    pillow
+
+# Copy executor server and kernel module
+COPY executor_server.py .
+COPY ipython_kernel.py .
+
+# Environment
+ENV EXECUTOR_NAME=diagram
+ENV WORKSPACES_DIR=/app/workspaces
+ENV PYTHONUNBUFFERED=1
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
+
+# Create workspaces directory
+RUN mkdir -p /app/workspaces
+
+EXPOSE 62680
+
+CMD uvicorn executor_server:app --host 0.0.0.0 --port ${EXECUTOR_PORT:-62680}

--- a/seed_skills/code-to-diagram/SKILL.md
+++ b/seed_skills/code-to-diagram/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: code-to-diagram
+description: "Generate architecture diagrams, ER diagrams, sequence diagrams, flowcharts, and class diagrams from codebases using Mermaid.js. Use when users ask to visualize code structure, draw architecture diagrams, create ER diagrams from database models, generate sequence diagrams from API flows, or produce any diagram from source code. Triggers on: 'draw architecture', 'generate diagram', 'visualize code', 'ER diagram', 'sequence diagram', 'class diagram', 'flowchart from code', 'module dependency graph'."
+---
+
+# Code to Diagram
+
+Generate production-quality diagrams from source code via Mermaid.js, rendered to SVG/PNG with `mmdc`.
+
+## Environment
+
+**Executor required:** This skill needs the `diagram` executor (Chromium + Node.js + mmdc pre-installed).
+If `mmdc` is not available, install first:
+```bash
+npm install -g @mermaid-js/mermaid-cli
+```
+
+Puppeteer config for headless environments — create at `/tmp/puppeteer-config.json` if missing:
+```json
+{"args": ["--no-sandbox", "--disable-setuid-sandbox"]}
+```
+
+## Workflow
+
+1. **Analyze** — Read the codebase to understand structure (`glob`, `grep`, `read`)
+2. **Plan** — Decide diagram type(s) based on user request and code patterns
+3. **Generate** — Write `.mmd` file with Mermaid syntax
+4. **Render** — Run `mmdc` to produce SVG and PNG
+5. **Verify** — Read the output image and check correctness
+
+## Diagram Type Selection
+
+| User Intent | Diagram Type | Mermaid Keyword |
+|-------------|-------------|-----------------|
+| System overview, module layout | Architecture | `graph TD` + `subgraph` |
+| Database tables, ORM models | ER Diagram | `erDiagram` |
+| API flow, request lifecycle | Sequence Diagram | `sequenceDiagram` |
+| Inheritance, interfaces | Class Diagram | `classDiagram` |
+| Business logic, conditionals | Flowchart | `flowchart TD` |
+| Task states, lifecycle | State Diagram | `stateDiagram-v2` |
+| Import/dependency tree | Dependency Graph | `graph LR` |
+| Timeline, project phases | Gantt Chart | `gantt` |
+
+## Analysis Strategy
+
+Do NOT read every file. Use progressive analysis:
+
+**Step 1 — Directory scan:**
+`glob("**/*.py")` or `glob("**/*.ts")` to understand module structure.
+
+**Step 2 — Entry points:**
+- Python: `main.py`, `app.py`, `__init__.py`, `pyproject.toml`
+- Node.js: `package.json`, `index.ts`, `app.ts`
+- Java: `pom.xml`, `Application.java`
+
+**Step 3 — Targeted reads by diagram type:**
+- **ER** → ORM models (`models.py`, `schema.prisma`, `*.entity.ts`)
+- **Architecture** → Router registrations, dependency injection, config
+- **Sequence** → Specific endpoint handler + service call chain
+- **Class** → Class definitions via `grep("class ")`
+
+**Step 4 — GitHub repos:**
+```bash
+git clone --depth 1 <url> /tmp/repo-name
+```
+Then apply the same progressive scan.
+
+## Rendering
+
+```bash
+# SVG (transparent background, good for docs)
+mmdc -i diagram.mmd -o diagram.svg -b transparent -p /tmp/puppeteer-config.json
+
+# PNG (white background, 2x scale for sharpness)
+mmdc -i diagram.mmd -o diagram.png -b white -s 2 -p /tmp/puppeteer-config.json
+```
+
+Always generate both formats. Use `-s 2` for PNG (sharp at any zoom level).
+
+## Mermaid Syntax Reference
+
+For detailed patterns and examples per diagram type, see [references/mermaid-patterns.md](references/mermaid-patterns.md).
+
+Key rules:
+- Short IDs, descriptive labels: `DB[("PostgreSQL 16")]`
+- Use `subgraph` for logical grouping in architecture diagrams
+- Limit ER diagrams to ~10 entities — split by domain if larger
+- `participant` aliases in sequence diagrams for short names
+- Quote labels with special chars: `A["Node (v1)"]`
+- Max ~20 nodes per diagram — split into multiple if larger
+
+## Output Conventions
+
+- Write `.mmd` source + rendered files to workspace
+- Descriptive names: `architecture.mmd`, `er-diagram.png`, `api-sequence.svg`
+- Multiple diagrams → create `diagrams/` folder with index
+
+## Quality Checklist
+
+- All entities/modules from the code are represented
+- Relationships and data flow directions are correct
+- Labels readable, not truncated or overlapping
+- No Mermaid syntax errors
+- Output image visually verified

--- a/seed_skills/code-to-diagram/references/mermaid-patterns.md
+++ b/seed_skills/code-to-diagram/references/mermaid-patterns.md
@@ -1,0 +1,285 @@
+# Mermaid Diagram Patterns
+
+## Table of Contents
+- [Architecture Diagram](#architecture-diagram)
+- [ER Diagram](#er-diagram)
+- [Sequence Diagram](#sequence-diagram)
+- [Class Diagram](#class-diagram)
+- [Flowchart](#flowchart)
+- [State Diagram](#state-diagram)
+- [Dependency Graph](#dependency-graph)
+- [Gantt Chart](#gantt-chart)
+- [Styling Tips](#styling-tips)
+
+## Architecture Diagram
+
+Use `graph TD` (top-down) or `graph LR` (left-right) with `subgraph` for layers.
+
+```mermaid
+graph TD
+    Client["Browser / Mobile"]
+
+    subgraph Frontend["Frontend :3000"]
+        UI["React App"]
+        Store["Redux Store"]
+    end
+
+    subgraph Backend["API Server :8000"]
+        API["REST API"]
+        Auth["Auth Middleware"]
+        BL["Business Logic"]
+    end
+
+    subgraph Data["Data Layer"]
+        DB[("PostgreSQL")]
+        Cache[("Redis")]
+        S3["S3 / Object Storage"]
+    end
+
+    Client --> UI
+    UI --> Store
+    UI --> API
+    API --> Auth --> BL
+    BL --> DB
+    BL --> Cache
+    BL --> S3
+```
+
+**Tips:**
+- Use `[("...")]` for database cylinder shape
+- Use `["..."]` for rectangles, `(["..."])` for rounded
+- Group related components in `subgraph` with descriptive titles
+- Add port numbers in subgraph titles for clarity
+
+## ER Diagram
+
+```mermaid
+erDiagram
+    users {
+        uuid id PK
+        varchar email UK
+        varchar name
+        timestamp created_at
+    }
+
+    orders {
+        uuid id PK
+        uuid user_id FK
+        decimal total
+        varchar status
+        timestamp created_at
+    }
+
+    order_items {
+        uuid id PK
+        uuid order_id FK
+        uuid product_id FK
+        int quantity
+        decimal price
+    }
+
+    products {
+        uuid id PK
+        varchar name
+        decimal price
+        int stock
+    }
+
+    users ||--o{ orders : places
+    orders ||--|{ order_items : contains
+    products ||--o{ order_items : "included in"
+```
+
+**Relationship symbols:**
+- `||--||` one to one
+- `||--o{` one to many
+- `o{--o{` many to many
+- `|` mandatory, `o` optional
+
+**Tips:**
+- Include PK/FK/UK annotations
+- Use common SQL types: `uuid`, `varchar`, `int`, `decimal`, `timestamp`, `text`, `boolean`, `json`
+- Quote relationship labels with spaces: `"included in"`
+
+## Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant F as Frontend
+    participant A as API
+    participant DB as Database
+
+    U->>F: Click "Submit"
+    F->>A: POST /api/orders
+    activate A
+    A->>DB: INSERT INTO orders
+    DB-->>A: order_id
+    A->>A: Validate & process
+    A-->>F: 201 Created {id}
+    deactivate A
+    F-->>U: Show confirmation
+
+    alt Payment fails
+        A-->>F: 400 Bad Request
+        F-->>U: Show error
+    end
+```
+
+**Arrow types:**
+- `->>` solid line with arrowhead (sync call)
+- `-->>` dashed line with arrowhead (response)
+- `--)` async message
+
+**Tips:**
+- Use `participant X as "Short Name"` for readability
+- `activate`/`deactivate` to show lifeline
+- `alt`/`else` for conditional branches
+- `loop` for repeated operations
+- `Note over A,B: text` for annotations
+
+## Class Diagram
+
+```mermaid
+classDiagram
+    class Animal {
+        +String name
+        +int age
+        +makeSound() String
+    }
+
+    class Dog {
+        +String breed
+        +fetch() void
+        +makeSound() String
+    }
+
+    class Cat {
+        +bool indoor
+        +purr() void
+        +makeSound() String
+    }
+
+    class Shelter {
+        -List~Animal~ animals
+        +addAnimal(Animal a) void
+        +getCount() int
+    }
+
+    Animal <|-- Dog : extends
+    Animal <|-- Cat : extends
+    Shelter o-- Animal : houses
+```
+
+**Visibility:**
+- `+` public, `-` private, `#` protected, `~` package
+
+**Relationships:**
+- `<|--` inheritance
+- `*--` composition
+- `o--` aggregation
+- `-->` association
+- `..>` dependency
+
+## Flowchart
+
+```mermaid
+flowchart TD
+    Start([Start]) --> Input[/Read user input/]
+    Input --> Validate{Valid?}
+    Validate -->|Yes| Process[Process data]
+    Validate -->|No| Error[Show error]
+    Error --> Input
+    Process --> Save[(Save to DB)]
+    Save --> Notify[/Send notification/]
+    Notify --> End([End])
+```
+
+**Node shapes:**
+- `[text]` rectangle
+- `(text)` rounded
+- `{text}` diamond (decision)
+- `[(text)]` cylinder (database)
+- `([text])` stadium (start/end)
+- `[/text/]` parallelogram (I/O)
+
+## State Diagram
+
+```mermaid
+stateDiagram-v2
+    [*] --> Draft
+    Draft --> Pending : submit
+    Pending --> Approved : approve
+    Pending --> Rejected : reject
+    Rejected --> Draft : revise
+    Approved --> Published : publish
+    Published --> Archived : archive
+    Archived --> [*]
+
+    state Pending {
+        [*] --> UnderReview
+        UnderReview --> NeedsChanges : request changes
+        NeedsChanges --> UnderReview : resubmit
+        UnderReview --> Ready : approve
+    }
+```
+
+## Dependency Graph
+
+Use `graph LR` for module dependency visualization:
+
+```mermaid
+graph LR
+    main --> api
+    main --> config
+    api --> auth
+    api --> handlers
+    handlers --> services
+    services --> db
+    services --> cache
+    auth --> db
+    config --> db
+```
+
+## Gantt Chart
+
+```mermaid
+gantt
+    title Project Timeline
+    dateFormat YYYY-MM-DD
+
+    section Design
+    Requirements     :done, req, 2024-01-01, 2024-01-14
+    UI Design        :done, ui, after req, 14d
+
+    section Development
+    Backend API      :active, api, after ui, 21d
+    Frontend         :fe, after ui, 28d
+
+    section Testing
+    Integration Test :test, after api, 14d
+    UAT              :uat, after fe, 7d
+```
+
+## Styling Tips
+
+### Theme
+mmdc supports themes via config:
+```json
+{
+  "theme": "default"
+}
+```
+Available: `default`, `dark`, `forest`, `neutral`. Pass via `-c config.json` to mmdc.
+
+### Large Diagrams
+When a diagram exceeds ~20 nodes:
+1. Split into multiple diagrams by domain/layer
+2. Create an overview diagram linking to detail diagrams
+3. Use `graph LR` (horizontal) for wide dependency trees
+4. Use `graph TD` (vertical) for deep hierarchies
+
+### Text in Labels
+- Quote strings with special characters: `A["API (v2)"]`
+- Use `<br/>` for line breaks in labels: `A["Line 1<br/>Line 2"]`
+- Avoid `--` in labels (conflicts with Mermaid syntax)


### PR DESCRIPTION
## Summary

- Add **code-to-diagram** seed skill — generates architecture, ER, sequence, class, flowchart, state, dependency, and gantt diagrams from codebases via Mermaid.js + `mmdc` CLI
- Add **diagram** executor Docker image — Python 3.11 + Node.js 20 + Chromium + mmdc + CJK fonts
- Add **DiagramArchitect** agent preset — combines code-to-diagram + pdf skills with git/time MCP
- Fix **entrypoint.sh** to auto-sync `executors.json` on container restart (same pattern as seed_agents/seed_skills)

## Changes

| File | Change |
|------|--------|
| `seed_skills/code-to-diagram/SKILL.md` | New skill with progressive analysis workflow and rendering commands |
| `seed_skills/code-to-diagram/references/mermaid-patterns.md` | Mermaid syntax reference for 8 diagram types |
| `docker/executor/Dockerfile.diagram` | New executor image with Chromium + Node.js + mmdc |
| `config/executors.json` | Register diagram executor |
| `config/seed_agents.json` | Add DiagramArchitect agent |
| `docker/docker-compose.dev.yaml` | Add executor-diagram service (profile: diagram) |
| `docker/docker-compose.yaml` | Add executor-diagram service (profile: diagram) |
| `docker/api/entrypoint.sh` | Add executors.json to seed file sync list |

## Test plan

- [x] Built diagram executor image successfully
- [x] Verified executor health check, mmdc version, chromium version
- [x] End-to-end test: DiagramArchitect agent analyzed codebase and generated .mmd + .png + .svg (12 turns, 3 output files)
- [ ] Verify `docker compose --profile diagram up -d` starts executor correctly
- [ ] Verify executor appears in Web UI at `/executors`

Closes #87