### PR TITLE
feat: add inline preview for HTML output files in chat

### DIFF
--- a/app/api/v1/files.py
+++ b/app/api/v1/files.py
@@ -179,6 +179,17 @@ async def download_output_file_by_path(
 
     content_type = mimetypes.guess_type(filepath.name)[0] or "application/octet-stream"
 
+    # Use inline disposition for browser-renderable types (HTML, images, etc.)
+    # so they can be displayed in iframes and img tags instead of triggering download
+    inline_types = {"text/html", "image/png", "image/jpeg", "image/gif", "image/svg+xml",
+                    "image/webp", "video/mp4", "video/webm", "audio/mpeg", "audio/wav"}
+    if content_type in inline_types:
+        return FileResponse(
+            path=str(filepath),
+            media_type=content_type,
+            headers={"Content-Disposition": f'inline; filename="{filepath.name}"'},
+        )
+
     return FileResponse(
         path=str(filepath),
         filename=filepath.name,

--- a/web/src/components/chat/stream-events/output-file-card.tsx
+++ b/web/src/components/chat/stream-events/output-file-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Download, FileText } from "lucide-react";
+import { Download, FileText, Maximize2, Minimize2 } from "lucide-react";
 import { formatFileSize } from "@/lib/formatters";
 import {
   Dialog,
@@ -28,6 +28,9 @@ const AUDIO_TYPES = new Set([
 function isImage(ct: string) { return IMAGE_TYPES.has(ct); }
 function isVideo(ct: string) { return VIDEO_TYPES.has(ct); }
 function isAudio(ct: string) { return AUDIO_TYPES.has(ct); }
+function isHtml(ct: string, filename: string) {
+  return ct === "text/html" || filename.endsWith(".html") || filename.endsWith(".htm");
+}
 
 function FileInfo({ filename, size, downloadUrl }: { filename: string; size: number; downloadUrl: string }) {
   return (
@@ -102,6 +105,54 @@ export function OutputFileCard({ data }: OutputFileCardProps) {
           <source src={url} type={ct} />
         </audio>
       </div>
+    );
+  }
+
+  if (isHtml(ct, data.filename)) {
+    return (
+      <>
+        <div className="my-1.5">
+          <div className="relative border rounded-lg overflow-hidden bg-black">
+            <iframe
+              src={url}
+              title={data.filename}
+              sandbox="allow-scripts allow-same-origin"
+              className="w-full border-0"
+              style={{ height: 480, maxWidth: "100%" }}
+            />
+            <button
+              onClick={() => setLightboxOpen(true)}
+              className="absolute top-2 right-2 p-1.5 rounded-md bg-black/60 hover:bg-black/80 text-white transition-colors"
+              title="Fullscreen"
+            >
+              <Maximize2 className="h-4 w-4" />
+            </button>
+          </div>
+          <FileInfo filename={data.filename} size={data.size} downloadUrl={url} />
+        </div>
+        <Dialog open={lightboxOpen} onOpenChange={setLightboxOpen}>
+          <DialogContent className="max-w-[95vw] max-h-[95vh] w-[95vw] h-[90vh] p-0 border-none bg-black">
+            <VisuallyHidden>
+              <DialogTitle>{data.filename}</DialogTitle>
+            </VisuallyHidden>
+            <div className="relative w-full h-full">
+              <iframe
+                src={url}
+                title={data.filename}
+                sandbox="allow-scripts allow-same-origin"
+                className="w-full h-full border-0"
+              />
+              <button
+                onClick={() => setLightboxOpen(false)}
+                className="absolute top-3 right-3 p-1.5 rounded-md bg-black/60 hover:bg-black/80 text-white transition-colors"
+                title="Exit fullscreen"
+              >
+                <Minimize2 className="h-4 w-4" />
+              </button>
+            </div>
+          </DialogContent>
+        </Dialog>
+      </>
     );
   }
 


### PR DESCRIPTION
## Summary

- **Backend**: Return `Content-Disposition: inline` for browser-renderable MIME types (HTML, images, video, audio) in the output file download endpoint, allowing iframes and img tags to display content directly instead of triggering downloads
- **Frontend**: Add HTML-specific rendering path in `OutputFileCard` with sandboxed iframe preview and fullscreen dialog

## Changes

| File | Change |
|------|--------|
| `app/api/v1/files.py` | Add inline disposition for `text/html`, `image/*`, `video/*`, `audio/*` types |
| `web/src/components/chat/stream-events/output-file-card.tsx` | Add `isHtml()` detection, iframe preview (480px), fullscreen expand/collapse with `Maximize2`/`Minimize2` |

## How it works

1. Agent generates an HTML file (e.g., self-contained animation, data visualization)
2. `file_scanner` detects the new file and emits an `output_file` SSE event
3. Frontend receives the event, `OutputFileCard` detects `text/html` content type
4. Instead of showing a download card, renders the file in a sandboxed iframe
5. User can click the expand button to view fullscreen, or download via the link below

## Test plan

- [ ] Agent generates HTML output file → renders inline in iframe (not download card)
- [ ] Click fullscreen button → expands to 95vw/90vh dialog with iframe
- [ ] Click minimize button → closes fullscreen dialog
- [ ] Download link below iframe still triggers file download
- [ ] Image output files still render inline (regression check)
- [ ] Non-HTML/non-media files still show download card (regression check)
- [ ] Path traversal attempts on download endpoint still return 403

Closes #91