### PR TITLE
Add env vars to executors and sync missing executor services

### DIFF
--- a/app/agent/agent.py
+++ b/app/agent/agent.py
@@ -559,6 +559,9 @@ Your workspace is `{workspace_dir}`. All tools share this directory — relative
 - **Accessing project files:** Use absolute paths (e.g., `read(file_path="{skills_dir}/my-skill/SKILL.md")`, `bash(command="python {skills_dir}/my-skill/scripts/main.py")`).
 - `glob` and `grep` default to the skills directory when no path is specified.
 
+## Skills Directory
+The skills directory is `{skills_dir}`. All SKILL.md files, references, scripts, assets, etc. are stored in this directory.
+
 ## Important Notes
 - Always read skill documentation before writing code
 - Variables, imports, and state persist across execute_code calls within the same session

--- a/docker/docker-compose.dev.yaml
+++ b/docker/docker-compose.dev.yaml
@@ -211,6 +211,9 @@ services:
     environment:
       - EXECUTOR_NAME=base
       - EXECUTOR_PORT=62680
+      - SKILLS_DIR=/app/skills
+      - UPLOADS_DIR=/app/uploads
+      - DATA_DIR=/app/data
       - TZ=${TZ:-UTC}
     networks:
       - skills-network
@@ -241,6 +244,9 @@ services:
     environment:
       - EXECUTOR_NAME=ml
       - EXECUTOR_PORT=62681
+      - SKILLS_DIR=/app/skills
+      - UPLOADS_DIR=/app/uploads
+      - DATA_DIR=/app/data
       - TZ=${TZ:-UTC}
     networks:
       - skills-network
@@ -271,6 +277,9 @@ services:
     environment:
       - EXECUTOR_NAME=cuda
       - EXECUTOR_PORT=62682
+      - SKILLS_DIR=/app/skills
+      - UPLOADS_DIR=/app/uploads
+      - DATA_DIR=/app/data
       - TZ=${TZ:-UTC}
       - NVIDIA_VISIBLE_DEVICES=all
     networks:
@@ -308,6 +317,9 @@ services:
     environment:
       - EXECUTOR_NAME=chemscout
       - EXECUTOR_PORT=62680
+      - SKILLS_DIR=/app/skills
+      - UPLOADS_DIR=/app/uploads
+      - DATA_DIR=/app/data
       - TZ=${TZ:-UTC}
     networks:
       - skills-network
@@ -339,6 +351,9 @@ services:
     environment:
       - EXECUTOR_NAME=remotion
       - EXECUTOR_PORT=62680
+      - SKILLS_DIR=/app/skills
+      - UPLOADS_DIR=/app/uploads
+      - DATA_DIR=/app/data
       - TZ=${TZ:-UTC}
     networks:
       - skills-network
@@ -370,6 +385,9 @@ services:
     environment:
       - EXECUTOR_NAME=diagram
       - EXECUTOR_PORT=62680
+      - SKILLS_DIR=/app/skills
+      - UPLOADS_DIR=/app/uploads
+      - DATA_DIR=/app/data
       - TZ=${TZ:-UTC}
     networks:
       - skills-network

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -185,6 +185,9 @@ services:
     environment:
       - EXECUTOR_NAME=base
       - EXECUTOR_PORT=62680
+      - SKILLS_DIR=/app/skills
+      - UPLOADS_DIR=/app/uploads
+      - DATA_DIR=/app/data
       - TZ=${TZ:-UTC}
     networks:
       - skills-network
@@ -212,6 +215,9 @@ services:
     environment:
       - EXECUTOR_NAME=ml
       - EXECUTOR_PORT=62681
+      - SKILLS_DIR=/app/skills
+      - UPLOADS_DIR=/app/uploads
+      - DATA_DIR=/app/data
       - TZ=${TZ:-UTC}
     networks:
       - skills-network
@@ -239,6 +245,9 @@ services:
     environment:
       - EXECUTOR_NAME=cuda
       - EXECUTOR_PORT=62682
+      - SKILLS_DIR=/app/skills
+      - UPLOADS_DIR=/app/uploads
+      - DATA_DIR=/app/data
       - TZ=${TZ:-UTC}
       - NVIDIA_VISIBLE_DEVICES=all
     networks:
@@ -259,6 +268,66 @@ services:
               count: 1
               capabilities: [gpu]
 
+  executor-chemscout:
+    image: skillcompose/executor-chemscout:latest
+    container_name: skills-executor-chemscout
+    restart: unless-stopped
+    profiles:
+      - chemscout
+    volumes:
+      - workspaces:/app/workspaces
+      - skills:/app/skills:ro
+      - uploads:/app/uploads:ro
+    environment:
+      - EXECUTOR_NAME=chemscout
+      - EXECUTOR_PORT=62680
+      - SKILLS_DIR=/app/skills
+      - UPLOADS_DIR=/app/uploads
+      - DATA_DIR=/app/data
+      - TZ=${TZ:-UTC}
+    networks:
+      - skills-network
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:62680/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    deploy:
+      resources:
+        limits:
+          memory: 4G
+
+  executor-remotion:
+    image: skillcompose/executor-remotion:latest
+    container_name: skills-executor-remotion
+    restart: unless-stopped
+    profiles:
+      - remotion
+    volumes:
+      - workspaces:/app/workspaces
+      - skills:/app/skills:ro
+      - uploads:/app/uploads:ro
+    environment:
+      - EXECUTOR_NAME=remotion
+      - EXECUTOR_PORT=62680
+      - SKILLS_DIR=/app/skills
+      - UPLOADS_DIR=/app/uploads
+      - DATA_DIR=/app/data
+      - TZ=${TZ:-UTC}
+    networks:
+      - skills-network
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:62680/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    deploy:
+      resources:
+        limits:
+          memory: 8G
+
   executor-diagram:
     image: skillcompose/executor-diagram:latest
     container_name: skills-executor-diagram
@@ -272,6 +341,9 @@ services:
     environment:
       - EXECUTOR_NAME=diagram
       - EXECUTOR_PORT=62680
+      - SKILLS_DIR=/app/skills
+      - UPLOADS_DIR=/app/uploads
+      - DATA_DIR=/app/data
       - TZ=${TZ:-UTC}
     networks:
       - skills-network

--- a/seed_skills/skill-creator/SKILL.md
+++ b/seed_skills/skill-creator/SKILL.md
@@ -265,7 +265,7 @@ When creating a new skill from scratch, always run the `init_skill.py` script. T
 Usage:
 
 ```bash
-scripts/init_skill.py <skill-name> --path <output-directory>
+python skills/skill-creator/scripts/init_skill.py <skill-name> --path <output-directory>
 ```
 
 The script:
@@ -323,13 +323,13 @@ Write instructions for using the skill and its bundled resources.
 Once development of the skill is complete, it must be packaged into a distributable .skill file that gets shared with the user. The packaging process automatically validates the skill first to ensure it meets all requirements:
 
 ```bash
-scripts/package_skill.py <path/to/skill-folder>
+python skills/skill-creator/scripts/package_skill.py <path/to/skill-folder>
 ```
 
 Optional output directory specification:
 
 ```bash
-scripts/package_skill.py <path/to/skill-folder> ./dist
+python skills/skill-creator/scripts/package_skill.py <path/to/skill-folder> ./dist
 ```
 
 The packaging script will:


### PR DESCRIPTION
## Summary
- Add `SKILLS_DIR`, `UPLOADS_DIR`, `DATA_DIR` environment variables to all executor containers in both `docker-compose.yaml` and `docker-compose.dev.yaml`
- Add missing `executor-chemscout` and `executor-remotion` services to production `docker-compose.yaml`
- Add skills directory info to agent system prompt (`agent.py`)
- Sync `skill-creator` SKILL.md from Docker volume to local repo

## Test plan
- [ ] Verify all executors in both compose files have the new env vars
- [ ] `docker compose config` passes for both compose files
- [ ] Executor containers can access `SKILLS_DIR`, `UPLOADS_DIR`, `DATA_DIR` at runtime

Closes #101