### PR TITLE
Fix session missing last assistant message after refresh

### DIFF
--- a/app/api/v1/published.py
+++ b/app/api/v1/published.py
@@ -604,12 +604,14 @@ async def published_chat(agent_id: str, request: PublishedChatRequest):
                     final_msgs = last_complete_event.get("final_messages")
 
                     # Compute new display messages (only the new turns from this request)
+                    # Priority: final_messages > pre-compression snapshot
+                    # turn_complete snapshots miss the final assistant text (emitted before last LLM turn)
                     new_display = None
-                    if last_snapshot_for_display and history_len is not None:
-                        # Use pre-compression snapshot for accurate display extraction
-                        new_display = last_snapshot_for_display[history_len:]
-                    elif final_msgs and not compression_happened and history_len is not None:
+                    if final_msgs and not compression_happened and history_len is not None:
                         new_display = final_msgs[history_len:]
+                    elif last_snapshot_for_display and history_len is not None:
+                        # Compression happened — use pre-compression snapshot for correct offset
+                        new_display = last_snapshot_for_display[history_len:]
                     # else: fallback to simple user+assistant pair (handled by save_session_messages)
 
                     await save_session_messages(


### PR DESCRIPTION
## Summary

- Fix streaming session persistence losing the final assistant message by swapping priority of `final_messages` over `last_snapshot_for_display`
- Affects both chat panel (`agent.py`) and published agent (`published.py`) streaming paths

Fixes #108

## Root Cause

`turn_complete` snapshots are emitted after tool execution but before the final text-only LLM response. The save logic incorrectly prioritized these incomplete snapshots over the complete `final_messages` from the `complete` event.

## Changes

- `app/api/v1/agent.py`: Swap condition order — prefer `final_msgs` when no compression happened
- `app/api/v1/published.py`: Same fix for published agent streaming path

## Test plan

- [ ] Send a message to a published agent that triggers tool calls
- [ ] Verify the trace and session both contain the final assistant message
- [ ] Refresh the page and confirm the last message is still displayed
- [ ] Test with context compression scenario (long conversation)