### PR TITLE
feat: add ask_user interactive tool

### DIFF
--- a/app/agent/tools.py
+++ b/app/agent/tools.py
@@ -1227,6 +1227,37 @@ Notes:
             "required": ["query"],
         },
     },
+    # Interactive tool
+    {
+        "name": "ask_user",
+        "description": """Ask the user for a decision.
+
+Use this PROACTIVELY when:
+- You need to confirm a decision with the user — e.g., "Should I proceed with installation?"
+- You encounter multiple candidates or possibilities that the user should pick from — e.g., a search returns several matching skills, a dataset has multiple date columns, there are several files that could be the target. Present them as options instead of guessing.
+
+Examples:
+- ask_user(question="Proceed with installation?", options=["yes", "no"])
+- ask_user(question="What format would you like for the output report?")
+- ask_user(question="I found two matching skills. Which one should I use?", options=["data-analyzer", "csv-processor"])""",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "question": {
+                    "type": "string",
+                    "description": "The question to ask the user",
+                },
+                "options": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "minItems": 2,
+                    "maxItems": 6,
+                    "description": "Optional predefined answer choices (rendered as buttons). If omitted, user gets a free text input.",
+                },
+            },
+            "required": ["question"],
+        },
+    },
 ]
 
 # Legacy TOOLS list for backward compatibility (includes all MCP tools by default)
@@ -1634,6 +1665,7 @@ TOOL_REQUIRED_PARAMS: Dict[str, List[str]] = {
     "edit": ["file_path", "old_string", "new_string"],
     "web_fetch": ["url", "prompt"],
     "web_search": ["query"],
+    "ask_user": ["question"],
 }
 
 

--- a/app/core/tools_registry.py
+++ b/app/core/tools_registry.py
@@ -54,6 +54,11 @@ TOOL_CATEGORIES = {
         "description": "Tools for reporting and managing output files",
         "icon": "download",
     },
+    "user_interaction": {
+        "name": "User Interaction",
+        "description": "Tools for interactive communication with the user",
+        "icon": "message-circle",
+    },
 }
 
 
@@ -352,6 +357,44 @@ Notes:
                 },
             },
             "required": ["query"],
+        },
+    ),
+    # User Interaction Tools
+    ToolDefinition(
+        id="ask_user",
+        name="ask_user",
+        description="""Ask the user a question and wait for their response. The current agent run ends and resumes when the user replies.
+
+Supports two modes:
+- **Options mode**: Provide predefined choices for the user to select from
+- **Free input mode**: Ask an open-ended question (omit options)
+
+Use proactively when:
+- Multiple candidates or possibilities need user selection (e.g., matching skills, date columns, target files)
+- The user's request is ambiguous — clarify before proceeding
+- A destructive or irreversible action needs confirmation
+
+Examples:
+- ask_user(question="Which date column should I use for the X axis?", options=["created_at", "updated_at", "published_at"])
+- ask_user(question="This will delete 15 files. Continue?", options=["Yes, delete them", "No, cancel"])
+- ask_user(question="What format would you like for the output report?")""",
+        category="user_interaction",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "question": {
+                    "type": "string",
+                    "description": "The question to ask the user",
+                },
+                "options": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "Optional predefined answer choices (rendered as buttons). If omitted, user gets a free text input.",
+                    "minItems": 2,
+                    "maxItems": 6,
+                },
+            },
+            "required": ["question"],
         },
     ),
 ]

--- a/web/src/app/chat/page.tsx
+++ b/web/src/app/chat/page.tsx
@@ -375,6 +375,7 @@ export default function FullscreenChatPage() {
                 streamingContent={message.id === engine.streamingMessageId ? engine.streamingContent : null}
                 streamingEvents={message.id === engine.streamingMessageId ? engine.streamingEvents : undefined}
                 streamingOutputFiles={message.id === engine.streamingMessageId ? engine.currentOutputFiles : undefined}
+                onAskUserRespond={engine.handleRespond}
               />
             </div>
           ))
@@ -422,12 +423,12 @@ export default function FullscreenChatPage() {
                 <Button onClick={engine.handleStop} variant="destructive" size="sm">
                   <Square className="h-4 w-4 mr-1" />{t('stop')}
                 </Button>
-                <Button onClick={engine.handleSubmit} disabled={!engine.input.trim()} size="sm">
+                <Button onClick={() => engine.handleSubmit()} disabled={!engine.input.trim()} size="sm">
                   {t('send')}
                 </Button>
               </div>
             ) : (
-              <Button onClick={engine.handleSubmit} disabled={!engine.input.trim()}>{t('send')}</Button>
+              <Button onClick={() => engine.handleSubmit()} disabled={!engine.input.trim()}>{t('send')}</Button>
             )}
           </div>
         </div>

--- a/web/src/app/published/[id]/page.tsx
+++ b/web/src/app/published/[id]/page.tsx
@@ -314,6 +314,7 @@ export default function PublishedChatPage() {
                   streamingEvents={message.id === engine.streamingMessageId ? engine.streamingEvents : undefined}
                   streamingOutputFiles={message.id === engine.streamingMessageId ? engine.currentOutputFiles : undefined}
                   hideTraceLink
+                  onAskUserRespond={engine.handleRespond}
                 />
               </div>
             ))
@@ -361,12 +362,12 @@ export default function PublishedChatPage() {
                   <Button onClick={engine.handleStop} variant="destructive" size="sm">
                     <Square className="h-4 w-4 mr-1" />{t('stop')}
                   </Button>
-                  <Button onClick={engine.handleSubmit} disabled={!engine.input.trim()} size="sm">
+                  <Button onClick={() => engine.handleSubmit()} disabled={!engine.input.trim()} size="sm">
                     {t('send')}
                   </Button>
                 </div>
               ) : (
-                <Button onClick={engine.handleSubmit} disabled={!engine.input.trim()}>{t('send')}</Button>
+                <Button onClick={() => engine.handleSubmit()} disabled={!engine.input.trim()}>{t('send')}</Button>
               )}
             </div>
           </div>

--- a/web/src/components/agents/agent-builder-chat.tsx
+++ b/web/src/components/agents/agent-builder-chat.tsx
@@ -192,6 +192,7 @@ export function AgentBuilderChat({
                 streamingContent={engine.streamingMessageId === message.id ? engine.streamingContent : undefined}
                 streamingEvents={engine.streamingMessageId === message.id ? engine.streamingEvents : undefined}
                 streamingOutputFiles={engine.streamingMessageId === message.id ? engine.currentOutputFiles : undefined}
+                onAskUserRespond={engine.handleRespond}
               />
             </div>
           ))
@@ -257,12 +258,12 @@ export function AgentBuilderChat({
                 <Button onClick={engine.handleStop} variant="destructive" size="sm">
                   <Square className="h-4 w-4 mr-1" />{tc('stop')}
                 </Button>
-                <Button onClick={engine.handleSubmit} disabled={!engine.input.trim()} size="sm">
+                <Button onClick={() => engine.handleSubmit()} disabled={!engine.input.trim()} size="sm">
                   {tc('send')}
                 </Button>
               </div>
             ) : (
-              <Button onClick={engine.handleSubmit} disabled={!engine.input.trim()}>
+              <Button onClick={() => engine.handleSubmit()} disabled={!engine.input.trim()}>
                 {tc('send')}
               </Button>
             )}

--- a/web/src/components/chat/chat-message.tsx
+++ b/web/src/components/chat/chat-message.tsx
@@ -20,6 +20,8 @@ interface ChatMessageItemProps {
   streamingEvents?: StreamEventRecord[];
   /** Hide trace link (for published pages where traces aren't accessible) */
   hideTraceLink?: boolean;
+  /** Callback when user responds to an ask_user prompt */
+  onAskUserRespond?: (promptId: string, answer: string) => void;
 }
 
 export function ChatMessageItem({
@@ -28,6 +30,7 @@ export function ChatMessageItem({
   streamingOutputFiles,
   streamingEvents,
   hideTraceLink,
+  onAskUserRespond,
 }: ChatMessageItemProps) {
   const [showSteps, setShowSteps] = React.useState(false);
 
@@ -76,7 +79,7 @@ export function ChatMessageItem({
         ) : (
           <>
             {hasStructuredEvents ? (
-              <StreamEventsRenderer events={events} isStreaming={isStreaming} />
+              <StreamEventsRenderer events={events} isStreaming={isStreaming} onAskUserRespond={onAskUserRespond} />
             ) : (
               <pre className="text-sm whitespace-pre-wrap font-sans overflow-x-auto">{displayContent}</pre>
             )}

--- a/web/src/components/chat/chat-panel.tsx
+++ b/web/src/components/chat/chat-panel.tsx
@@ -462,6 +462,7 @@ export function ChatPanel({ isOpen, onClose, defaultSkills = [] }: ChatPanelProp
               streamingContent={message.id === engine.streamingMessageId ? engine.streamingContent : null}
               streamingEvents={message.id === engine.streamingMessageId ? engine.streamingEvents : undefined}
               streamingOutputFiles={message.id === engine.streamingMessageId ? engine.currentOutputFiles : undefined}
+              onAskUserRespond={engine.handleRespond}
             />
           ))
         )}
@@ -508,12 +509,12 @@ export function ChatPanel({ isOpen, onClose, defaultSkills = [] }: ChatPanelProp
                 <Square className="h-4 w-4 mr-1" />
                 {t('stop')}
               </Button>
-              <Button onClick={engine.handleSubmit} disabled={!engine.input.trim()} size="sm">
+              <Button onClick={() => engine.handleSubmit()} disabled={!engine.input.trim()} size="sm">
                 {t('send')}
               </Button>
             </div>
           ) : (
-            <Button onClick={engine.handleSubmit} disabled={!engine.input.trim()}>
+            <Button onClick={() => engine.handleSubmit()} disabled={!engine.input.trim()}>
               {t('send')}
             </Button>
           )}

--- a/web/src/components/chat/stream-events/ask-user-card.tsx
+++ b/web/src/components/chat/stream-events/ask-user-card.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import React from "react";
+import { HelpCircle, CheckCircle2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import type { AskUserData } from "@/types/stream-events";
+import { useTranslation } from "@/i18n/client";
+
+interface AskUserCardProps {
+  data: AskUserData;
+  onRespond?: (promptId: string, answer: string) => void;
+}
+
+export function AskUserCard({ data, onRespond }: AskUserCardProps) {
+  const { t } = useTranslation("chat");
+  const [submitted, setSubmitted] = React.useState(false);
+  const [localAnswer, setLocalAnswer] = React.useState("");
+  const inputRef = React.useRef<HTMLInputElement>(null);
+
+  const handleSubmit = React.useCallback(
+    (answer: string) => {
+      if (!answer.trim() || submitted) return;
+      setSubmitted(true);
+      setLocalAnswer(answer.trim());
+      onRespond?.(data.promptId, answer.trim());
+    },
+    [data.promptId, submitted, onRespond]
+  );
+
+  const displayAnswer = localAnswer;
+
+  return (
+    <div className="border border-amber-300 dark:border-amber-700 rounded-lg my-2 overflow-hidden bg-amber-50/50 dark:bg-amber-950/20">
+      {/* Header */}
+      <div className="flex items-start gap-2 px-3 py-2.5">
+        <HelpCircle className="h-4 w-4 text-amber-600 dark:text-amber-400 mt-0.5 shrink-0" />
+        <p className="text-sm text-foreground font-medium">{data.question}</p>
+      </div>
+
+      {/* Answer area */}
+      <div className="px-3 pb-3">
+        {submitted ? (
+          /* Answered state */
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <CheckCircle2 className="h-3.5 w-3.5 text-green-600 dark:text-green-400 shrink-0" />
+            <span>
+              {t("askUser.answered")}: <span className="font-medium text-foreground">{displayAnswer}</span>
+            </span>
+          </div>
+        ) : data.options ? (
+          /* Options mode: buttons */
+          <div className="flex flex-wrap gap-2">
+            {data.options.map((option) => (
+              <Button
+                key={option}
+                variant="outline"
+                size="sm"
+                className="text-xs border-amber-300 dark:border-amber-700 hover:bg-amber-100 dark:hover:bg-amber-900/40"
+                onClick={() => handleSubmit(option)}
+              >
+                {option}
+              </Button>
+            ))}
+          </div>
+        ) : (
+          /* Free input mode */
+          <div className="flex gap-2">
+            <Input
+              ref={inputRef}
+              value={localAnswer}
+              onChange={(e) => setLocalAnswer(e.target.value)}
+              placeholder={t("askUser.typeAnswer")}
+              className="text-sm h-8 border-amber-300 dark:border-amber-700"
+              onKeyDown={(e) => {
+                if (e.key === "Enter" && !e.shiftKey) {
+                  e.preventDefault();
+                  handleSubmit(localAnswer);
+                }
+              }}
+            />
+            <Button
+              size="sm"
+              className="h-8 text-xs"
+              onClick={() => handleSubmit(localAnswer)}
+              disabled={!localAnswer.trim()}
+            >
+              {t("askUser.submit")}
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/chat/stream-events/index.tsx
+++ b/web/src/components/chat/stream-events/index.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import React from "react";
 import type { StreamEventRecord } from "@/types/stream-events";
 import { TurnDivider } from "./turn-divider";
 import { ThinkingBlock } from "./thinking-block";
@@ -9,6 +10,7 @@ import { OutputFileCard } from "./output-file-card";
 import { CompleteBanner } from "./complete-banner";
 import { ErrorBanner } from "./error-banner";
 import { SteeringMessage } from "./steering-message";
+import { AskUserCard } from "./ask-user-card";
 
 interface StreamEventsRendererProps {
   events: StreamEventRecord[];
@@ -16,12 +18,14 @@ interface StreamEventsRendererProps {
   expandAll?: boolean;
   /** When true, the last assistant block uses plain text instead of Markdown for performance */
   isStreaming?: boolean;
+  /** Callback when user responds to an ask_user prompt */
+  onAskUserRespond?: (promptId: string, answer: string) => void;
 }
 
 /**
  * Renders a list of stream events as structured UI components
  */
-export function StreamEventsRenderer({ events, expandAll = false, isStreaming = false }: StreamEventsRendererProps) {
+export function StreamEventsRenderer({ events, expandAll = false, isStreaming = false, onAskUserRespond }: StreamEventsRendererProps) {
   // Find the index of the last assistant event for streaming optimization
   let lastAssistantIndex = -1;
   if (isStreaming) {
@@ -61,6 +65,15 @@ export function StreamEventsRenderer({ events, expandAll = false, isStreaming = 
           case 'steering_received':
             return <SteeringMessage key={event.id} data={event.data} />;
 
+          case 'ask_user':
+            return (
+              <AskUserCard
+                key={event.id}
+                data={event.data}
+                onRespond={onAskUserRespond}
+              />
+            );
+
           // run_started and trace_saved don't have visible UI
           case 'run_started':
           case 'trace_saved':
@@ -83,3 +96,4 @@ export { OutputFileCard } from "./output-file-card";
 export { CompleteBanner } from "./complete-banner";
 export { ErrorBanner } from "./error-banner";
 export { SteeringMessage } from "./steering-message";
+export { AskUserCard } from "./ask-user-card";

--- a/web/src/components/skill/skill-finder-chat.tsx
+++ b/web/src/components/skill/skill-finder-chat.tsx
@@ -257,6 +257,7 @@ export function SkillFinderChat({
                 streamingContent={engine.streamingMessageId === message.id ? engine.streamingContent : undefined}
                 streamingEvents={engine.streamingMessageId === message.id ? engine.streamingEvents : undefined}
                 streamingOutputFiles={engine.streamingMessageId === message.id ? engine.currentOutputFiles : undefined}
+                onAskUserRespond={engine.handleRespond}
               />
             </div>
           ))
@@ -305,12 +306,12 @@ export function SkillFinderChat({
                 <Button onClick={engine.handleStop} variant="destructive" size="sm">
                   <Square className="h-4 w-4 mr-1" />{tc('stop')}
                 </Button>
-                <Button onClick={engine.handleSubmit} disabled={!engine.input.trim()} size="sm">
+                <Button onClick={() => engine.handleSubmit()} disabled={!engine.input.trim()} size="sm">
                   {tc('send')}
                 </Button>
               </div>
             ) : (
-              <Button onClick={engine.handleSubmit} disabled={!engine.input.trim()}>
+              <Button onClick={() => engine.handleSubmit()} disabled={!engine.input.trim()}>
                 {tc('send')}
               </Button>
             )}

--- a/web/src/i18n/locales/en-US/chat.json
+++ b/web/src/i18n/locales/en-US/chat.json
@@ -127,5 +127,12 @@
       "messagesCount": "{{count}} msg",
       "messagesCount_other": "{{count}} msgs"
     }
+  },
+  "askUser": {
+    "waitingForResponse": "Waiting for your response...",
+    "answered": "Answered",
+    "typeAnswer": "Type your answer...",
+    "submit": "Submit",
+    "timedOut": "Response timed out"
   }
 }

--- a/web/src/i18n/locales/es/chat.json
+++ b/web/src/i18n/locales/es/chat.json
@@ -127,5 +127,12 @@
       "messagesCount": "{{count}} msg",
       "messagesCount_other": "{{count}} msgs"
     }
+  },
+  "askUser": {
+    "waitingForResponse": "Esperando tu respuesta...",
+    "answered": "Respondido",
+    "typeAnswer": "Escribe tu respuesta...",
+    "submit": "Enviar",
+    "timedOut": "Tiempo de respuesta agotado"
   }
 }

--- a/web/src/i18n/locales/ja/chat.json
+++ b/web/src/i18n/locales/ja/chat.json
@@ -127,5 +127,12 @@
       "messagesCount": "{{count}} 件",
       "messagesCount_other": "{{count}} 件"
     }
+  },
+  "askUser": {
+    "waitingForResponse": "回答をお待ちしています...",
+    "answered": "回答済み",
+    "typeAnswer": "回答を入力...",
+    "submit": "送信",
+    "timedOut": "回答がタイムアウトしました"
   }
 }

--- a/web/src/i18n/locales/pt-BR/chat.json
+++ b/web/src/i18n/locales/pt-BR/chat.json
@@ -127,5 +127,12 @@
       "messagesCount": "{{count}} msg",
       "messagesCount_other": "{{count}} msgs"
     }
+  },
+  "askUser": {
+    "waitingForResponse": "Aguardando sua resposta...",
+    "answered": "Respondido",
+    "typeAnswer": "Digite sua resposta...",
+    "submit": "Enviar",
+    "timedOut": "Tempo de resposta esgotado"
   }
 }

--- a/web/src/i18n/locales/zh-CN/chat.json
+++ b/web/src/i18n/locales/zh-CN/chat.json
@@ -127,5 +127,12 @@
       "messagesCount": "{{count}} 条消息",
       "messagesCount_other": "{{count}} 条消息"
     }
+  },
+  "askUser": {
+    "waitingForResponse": "等待您的回复...",
+    "answered": "已回答",
+    "typeAnswer": "输入您的回答...",
+    "submit": "提交",
+    "timedOut": "回复超时"
   }
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -711,7 +711,7 @@ const AGENT_API_BASE = BACKEND_API_BASE;
 
 // Stream event types
 export interface StreamEvent {
-  event_type: 'run_started' | 'turn_start' | 'text_delta' | 'assistant' | 'tool_call' | 'tool_result' | 'output_file' | 'complete' | 'error' | 'trace_saved' | 'steering_received';
+  event_type: 'run_started' | 'turn_start' | 'text_delta' | 'assistant' | 'tool_call' | 'tool_result' | 'output_file' | 'complete' | 'error' | 'trace_saved' | 'steering_received' | 'ask_user';
   turn: number;
   // For turn_start
   max_turns?: number;
@@ -746,6 +746,10 @@ export interface StreamEvent {
   content_type?: string;
   download_url?: string;
   description?: string;
+  // For ask_user
+  prompt_id?: string;
+  question?: string;
+  options?: string[];
 }
 
 // Output file info for display

--- a/web/src/lib/stream-utils.ts
+++ b/web/src/lib/stream-utils.ts
@@ -15,6 +15,7 @@ import type {
   RunStartedRecord,
   TraceSavedRecord,
   SteeringReceivedRecord,
+  AskUserRecord,
 } from '@/types/stream-events';
 
 let eventIdCounter = 0;
@@ -145,6 +146,18 @@ export function mapEventToRecord(event: StreamEvent): StreamEventRecord | null {
         },
       } as SteeringReceivedRecord;
 
+    case 'ask_user':
+      if (!event.prompt_id || !event.question) return null;
+      return {
+        ...base,
+        type: 'ask_user',
+        data: {
+          promptId: event.prompt_id,
+          question: event.question,
+          options: event.options,
+        },
+      } as AskUserRecord;
+
     default:
       return null;
   }
@@ -236,6 +249,13 @@ export function serializeEventsToText(events: StreamEventRecord[]): string {
 
       case 'steering_received':
         result += `\n🎯 Steering: ${event.data.message}\n`;
+        break;
+
+      case 'ask_user':
+        result += `\n❓ Question: ${event.data.question}\n`;
+        if (event.data.options) {
+          result += `   Options: ${event.data.options.join(' | ')}\n`;
+        }
         break;
 
       // run_started and trace_saved don't produce visible text

--- a/web/src/types/stream-events.ts
+++ b/web/src/types/stream-events.ts
@@ -125,6 +125,18 @@ export interface SteeringReceivedRecord extends StreamEventRecordBase {
   data: SteeringReceivedData;
 }
 
+// Ask user event data (agent run ends, resumes when user replies)
+export interface AskUserData {
+  promptId: string;
+  question: string;
+  options?: string[];
+}
+
+export interface AskUserRecord extends StreamEventRecordBase {
+  type: 'ask_user';
+  data: AskUserData;
+}
+
 // Union type of all stream event records
 export type StreamEventRecord =
   | TurnStartRecord
@@ -136,7 +148,8 @@ export type StreamEventRecord =
   | ErrorRecord
   | RunStartedRecord
   | TraceSavedRecord
-  | SteeringReceivedRecord;
+  | SteeringReceivedRecord
+  | AskUserRecord;
 
 // Type guard functions
 export function isTurnStartRecord(record: StreamEventRecord): record is TurnStartRecord {


### PR DESCRIPTION
## Summary
- Adds a new `ask_user` tool that lets the agent ask the user questions during execution
- Uses end-turn approach: agent run ends on `ask_user`, user's answer starts a new run with full history
- Supports both streaming (SSE event) and non-streaming (sync result) modes
- Frontend renders options as buttons or free text input via `AskUserCard` component
- System prompt encourages proactive usage (multiple candidates, ambiguous requests, destructive actions)
- Race condition handling via `pendingAskUserResponseRef` for responses during active run completion

## Test plan
- [x] `TestAskUserE2E` — 4 tests (tool definition, stream end-turn, endpoint 404, non-streaming)
- [x] Full E2E suite — 180/180 tests pass
- [x] Docker redeploy — all services healthy
- [x] Manual test: trigger ask_user → options render → click option → new message → agent continues

Closes #114