### PR TITLE
feat: add code-to-diagram to seed skills

### DIFF
--- a/config/seed_skills.json
+++ b/config/seed_skills.json
@@ -85,6 +85,9 @@
     },
     "skill-finder": {
       "category": "Development Tools"
+    },
+    "code-to-diagram": {
+      "category": "Development Tools"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add `code-to-diagram` skill to `config/seed_skills.json` under the "Development Tools" category
- The skill already exists in `seed_skills/code-to-diagram/` with SKILL.md and references