### PR TITLE
feat: add remaining seed skills to seed_skills.json

### DIFF
--- a/config/seed_skills.json
+++ b/config/seed_skills.json
@@ -88,6 +88,15 @@
     },
     "code-to-diagram": {
       "category": "Development Tools"
+    },
+    "planning-with-files": {
+      "category": "Automation"
+    },
+    "skills-planner": {
+      "category": "Development Tools"
+    },
+    "trace-qa": {
+      "category": "Development Tools"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add 3 missing seed skills to `config/seed_skills.json`:
  - `planning-with-files` (Automation) — Manus-style file-based planning for complex tasks
  - `skills-planner` (Development Tools) — Plan and compose skills for agent workflows
  - `trace-qa` (Development Tools) — Analyze and debug agent execution traces

Meta skills (skill-creator, skill-evolver, skill-updater, mcp-builder) are intentionally excluded as they are system-managed.