### PR TITLE
fix: mark additional skills as meta in seed_skills.json

### DIFF
--- a/config/seed_skills.json
+++ b/config/seed_skills.json
@@ -83,20 +83,20 @@
     "copywriting": {
       "category": "Content Creation"
     },
-    "skill-finder": {
-      "category": "Development Tools"
-    },
     "code-to-diagram": {
       "category": "Development Tools"
     },
+    "skill-finder": {
+      "category": "meta"
+    },
     "planning-with-files": {
-      "category": "Automation"
+      "category": "meta"
     },
     "skills-planner": {
-      "category": "Development Tools"
+      "category": "meta"
     },
     "trace-qa": {
-      "category": "Development Tools"
+      "category": "meta"
     },
     "skill-creator": {
       "category": "meta"


### PR DESCRIPTION
## Summary
- Change category from user-facing to `meta` for: `planning-with-files`, `skill-finder`, `skills-planner`, `trace-qa`
- Now 8 total meta skills: skill-creator, skill-evolver, skill-updater, mcp-builder, planning-with-files, skill-finder, skills-planner, trace-qa