### PR TITLE
Replace executor_id (UUID FK) with executor_name (string)

### DIFF
--- a/app/db/database.py
+++ b/app/db/database.py
@@ -559,12 +559,14 @@ async def _ensure_seed_agents_exist():
                             id, name, description, system_prompt,
                             skill_ids, mcp_servers, builtin_tools,
                             max_turns, model_provider, model_name,
+                            executor_name,
                             is_system, is_published, api_response_mode,
                             created_at, updated_at
                         ) VALUES (
                             :id, :name, :description, :system_prompt,
                             :skill_ids, :mcp_servers, :builtin_tools,
                             :max_turns, :model_provider, :model_name,
+                            :executor_name,
                             :is_system, :is_published, :api_response_mode,
                             :created_at, :updated_at
                         )
@@ -580,6 +582,7 @@ async def _ensure_seed_agents_exist():
                         "max_turns": agent.get("max_turns", 60),
                         "model_provider": agent.get("model_provider"),
                         "model_name": agent.get("model_name"),
+                        "executor_name": agent.get("executor_name"),
                         "is_system": agent.get("is_system", True),
                         "is_published": agent.get("is_published", False),
                         "api_response_mode": agent.get("api_response_mode"),

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -420,11 +420,6 @@ class ExecutorDB(Base):
         DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
     )
 
-    # Relationships
-    presets: Mapped[List["AgentPresetDB"]] = relationship(
-        "AgentPresetDB", back_populates="executor"
-    )
-
     def __repr__(self) -> str:
         return f"<Executor(name={self.name}, image={self.image}, is_builtin={self.is_builtin})>"
 
@@ -475,19 +470,14 @@ class AgentPresetDB(Base):
     api_response_mode: Mapped[Optional[str]] = mapped_column(
         String(32), nullable=True
     )  # "streaming" or "non_streaming", null = unpublished
-    executor_id: Mapped[Optional[str]] = mapped_column(
-        String(36), ForeignKey("executors.id"), nullable=True
-    )  # Executor to use for code execution
+    executor_name: Mapped[Optional[str]] = mapped_column(
+        String(50), nullable=True
+    )  # Executor name (e.g. "base", "ml", "cuda") for code execution
     created_at: Mapped[datetime] = mapped_column(
         DateTime, default=datetime.utcnow, nullable=False
     )
     updated_at: Mapped[datetime] = mapped_column(
         DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
-    )
-
-    # Relationships
-    executor: Mapped[Optional["ExecutorDB"]] = relationship(
-        "ExecutorDB", back_populates="presets"
     )
 
     __table_args__ = (

--- a/config/seed_agents.json
+++ b/config/seed_agents.json
@@ -72,6 +72,7 @@
       ],
       "builtin_tools": null,
       "max_turns": 90,
+      "executor_name": "base",
       "model_provider": "kimi",
       "model_name": "kimi-k2.5",
       "is_system": false,
@@ -101,6 +102,7 @@
       ],
       "builtin_tools": null,
       "max_turns": 120,
+      "executor_name": "chemscout",
       "model_provider": "kimi",
       "model_name": "kimi-k2.5",
       "is_system": false,
@@ -120,6 +122,7 @@
       ],
       "builtin_tools": null,
       "max_turns": 90,
+      "executor_name": "remotion",
       "model_provider": "kimi",
       "model_name": "kimi-k2.5",
       "is_system": false,
@@ -140,6 +143,7 @@
       ],
       "builtin_tools": null,
       "max_turns": 60,
+      "executor_name": "diagram",
       "model_provider": "kimi",
       "model_name": "kimi-k2.5",
       "is_system": false,
@@ -172,6 +176,7 @@
       ],
       "builtin_tools": null,
       "max_turns": 90,
+      "executor_name": "base",
       "model_provider": "kimi",
       "model_name": "kimi-k2.5",
       "is_system": false,
@@ -180,3 +185,4 @@
     }
   ]
 }
+

--- a/tests/test_api/test_published_api.py
+++ b/tests/test_api/test_published_api.py
@@ -286,7 +286,7 @@ class TestPublishedChat:
         preset = _make_preset(published=True)
         preset.model_provider = None
         preset.model_name = None
-        preset.executor_id = None
+        preset.executor_name = None
 
         # Mock agent
         MockAgent.return_value = _make_mock_agent_instance()

--- a/tests/test_e2e/test_context_compression.py
+++ b/tests/test_e2e/test_context_compression.py
@@ -755,7 +755,7 @@ class TestPublishedSessionFullMessagesE2E:
         mock_preset.system_prompt = None
         mock_preset.model_provider = None
         mock_preset.model_name = None
-        mock_preset.executor_id = None
+        mock_preset.executor_name = None
 
         saved_messages = {}
         call_idx = {"i": 0}
@@ -887,7 +887,7 @@ class TestPublishedSessionFullMessagesE2E:
         mock_preset.system_prompt = None
         mock_preset.model_provider = None
         mock_preset.model_name = None
-        mock_preset.executor_id = None
+        mock_preset.executor_name = None
 
         call_idx = {"i": 0}
 

--- a/tests/test_e2e/test_e2e_workflows.py
+++ b/tests/test_e2e/test_e2e_workflows.py
@@ -992,7 +992,7 @@ class TestPublishedAgentSessionE2E:
         mock_preset.system_prompt = None
         mock_preset.model_provider = None
         mock_preset.model_name = None
-        mock_preset.executor_id = None
+        mock_preset.executor_name = None
 
         call_idx = {"i": 0}
         results = [mock_preset, None, None, None, None]
@@ -2760,7 +2760,7 @@ class TestPublishedAgentOutputFilesE2E:
         mock_preset.system_prompt = None
         mock_preset.model_provider = None
         mock_preset.model_name = None
-        mock_preset.executor_id = None
+        mock_preset.executor_name = None
 
         call_idx = {"i": 0}
 
@@ -2827,7 +2827,7 @@ class TestPublishedAgentOutputFilesE2E:
         mock_preset.system_prompt = None
         mock_preset.model_provider = None
         mock_preset.model_name = None
-        mock_preset.executor_id = None
+        mock_preset.executor_name = None
 
         call_idx = {"i": 0}
 
@@ -3141,7 +3141,7 @@ class TestResilientStreamingE2E:
         mock_preset.system_prompt = None
         mock_preset.model_provider = None
         mock_preset.model_name = None
-        mock_preset.executor_id = None
+        mock_preset.executor_name = None
 
         call_idx = {"i": 0}
         results = [mock_preset, None, None, None, None, None]
@@ -3208,7 +3208,7 @@ class TestResilientStreamingE2E:
         mock_preset.system_prompt = None
         mock_preset.model_provider = None
         mock_preset.model_name = None
-        mock_preset.executor_id = None
+        mock_preset.executor_name = None
 
         call_idx = {"i": 0}
         results = [mock_preset, None, None, None, None, None]
@@ -3278,7 +3278,7 @@ class TestResilientStreamingE2E:
         mock_preset.system_prompt = None
         mock_preset.model_provider = None
         mock_preset.model_name = None
-        mock_preset.executor_id = None
+        mock_preset.executor_name = None
 
         call_idx = {"i": 0}
         results = [mock_preset, None, None, None, None, None]
@@ -3445,7 +3445,7 @@ class TestResilientStreamingE2E:
         mock_preset.system_prompt = None
         mock_preset.model_provider = None
         mock_preset.model_name = None
-        mock_preset.executor_id = None
+        mock_preset.executor_name = None
 
         call_idx = {"i": 0}
         results = [mock_preset, None, None, None, None, None]

--- a/web/src/app/agents/new/page.tsx
+++ b/web/src/app/agents/new/page.tsx
@@ -178,7 +178,7 @@ export default function NewAgentPage() {
       max_turns: values.max_turns,
       model_provider: values.model_provider || undefined,
       model_name: values.model_name || undefined,
-      executor_id: values.executor_id || undefined,
+      executor_name: values.executor_name || undefined,
     });
     router.push(`/agents/${preset.id}`);
   };

--- a/web/src/app/chat/page.tsx
+++ b/web/src/app/chat/page.tsx
@@ -37,7 +37,7 @@ export default function FullscreenChatPage() {
     setIsRunning, setMaxTurns, addUploadedFile, removeUploadedFile, clearUploadedFiles,
     setSelectedAgentPreset, setSystemPrompt,
     selectedModelProvider, selectedModelName, setSelectedModel,
-    selectedExecutorId, setSelectedExecutorId,
+    selectedExecutorName, setSelectedExecutorName,
   } = useChatStore();
 
   useChatSessionRestore();
@@ -83,7 +83,7 @@ export default function FullscreenChatPage() {
           const currentMcpServers = state.selectedMcpServers;
           const currentTools = state.selectedTools;
           const currentSystemPrompt = state.systemPrompt;
-          const currentExecutorId = state.selectedExecutorId;
+          const currentExecutorName = state.selectedExecutorName;
 
           agentRequest = {
             request, session_id: currentSessionId,
@@ -95,7 +95,7 @@ export default function FullscreenChatPage() {
             system_prompt: currentSystemPrompt || undefined,
             model_provider: currentModelProvider || undefined,
             model_name: currentModelName || undefined,
-            executor_id: currentExecutorId || undefined,
+            executor_name: currentExecutorName || undefined,
           };
         }
 
@@ -178,7 +178,7 @@ export default function FullscreenChatPage() {
     else setSelectedTools([]);
     setSelectedMcpServers(preset.mcp_servers || []);
     setSelectedModel(preset.model_provider || null, preset.model_name || null);
-    setSelectedExecutorId(preset.executor_id || null);
+    setSelectedExecutorName(preset.executor_name || null);
   };
 
   const currentAgentName = selectedAgentPreset
@@ -226,8 +226,8 @@ export default function FullscreenChatPage() {
               <span className="text-muted-foreground/40 select-none">|</span>
               <Server className="h-4 w-4 text-muted-foreground shrink-0" />
               <ExecutorSelect
-                value={selectedExecutorId}
-                onChange={(id) => { setSelectedExecutorId(id); setSelectedAgentPreset(null); }}
+                value={selectedExecutorName}
+                onChange={(id) => { setSelectedExecutorName(id); setSelectedAgentPreset(null); }}
                 executors={onlineExecutors}
                 size="sm"
                 className="max-w-[120px]"

--- a/web/src/components/agents/agent-config-form.tsx
+++ b/web/src/components/agents/agent-config-form.tsx
@@ -36,7 +36,7 @@ export interface AgentFormValues {
   max_turns: number;
   model_provider: string | null;
   model_name: string | null;
-  executor_id: string | null;
+  executor_name: string | null;
 }
 
 interface AgentConfigFormProps {
@@ -81,7 +81,7 @@ export function AgentConfigForm({
   const [maxTurns, setMaxTurns] = useState(initialValues?.max_turns || 60);
   const [selectedModelProvider, setSelectedModelProvider] = useState<string | null>(initialValues?.model_provider || null);
   const [selectedModelName, setSelectedModelName] = useState<string | null>(initialValues?.model_name || null);
-  const [selectedExecutorId, setSelectedExecutorId] = useState<string | null>(initialValues?.executor_id || null);
+  const [selectedExecutorName, setSelectedExecutorName] = useState<string | null>(initialValues?.executor_name || null);
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [internalHasChanges, setInternalHasChanges] = useState(false);
 
@@ -170,7 +170,7 @@ export function AgentConfigForm({
       setMaxTurns(initialValues.max_turns || 60);
       setSelectedModelProvider(initialValues.model_provider || null);
       setSelectedModelName(initialValues.model_name || null);
-      setSelectedExecutorId(initialValues.executor_id || null);
+      setSelectedExecutorName(initialValues.executor_name || null);
     }
   }, [initialValues]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -235,7 +235,7 @@ export function AgentConfigForm({
       max_turns: maxTurns,
       model_provider: selectedModelProvider,
       model_name: selectedModelName,
-      executor_id: selectedExecutorId,
+      executor_name: selectedExecutorName,
     });
   };
 
@@ -397,8 +397,8 @@ export function AgentConfigForm({
         <div className="space-y-2">
           <Label>{t('create.executorLabel')}</Label>
           <ExecutorSelect
-            value={selectedExecutorId}
-            onChange={(id) => handleFieldChange(setSelectedExecutorId, id)}
+            value={selectedExecutorName}
+            onChange={(id) => handleFieldChange(setSelectedExecutorName, id)}
             executors={executors}
             placeholder={t('create.executorLocal')}
             disabled={isProcessing}

--- a/web/src/components/agents/publish-card.tsx
+++ b/web/src/components/agents/publish-card.tsx
@@ -1,11 +1,17 @@
 'use client';
 
 import { useState } from 'react';
-import { Globe, Copy, Check, ExternalLink, ChevronDown, Loader2 } from 'lucide-react';
+import { Globe, Copy, Check, ExternalLink, ChevronDown, Loader2, AlertTriangle } from 'lucide-react';
 import { useTranslation } from '@/i18n/client';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
 
 interface PublishCardProps {
   preset: {
@@ -15,11 +21,13 @@ interface PublishCardProps {
     api_response_mode?: string | null;
   };
   isUnpublishing?: boolean;
+  executorOffline?: boolean;
+  executorName?: string;
   onPublish: () => void;
   onUnpublish: () => void;
 }
 
-export function PublishCard({ preset, isUnpublishing, onPublish, onUnpublish }: PublishCardProps) {
+export function PublishCard({ preset, isUnpublishing, executorOffline, executorName, onPublish, onUnpublish }: PublishCardProps) {
   const { t } = useTranslation('agents');
   const [copiedUrl, setCopiedUrl] = useState<string | null>(null);
   const [showApiUsage, setShowApiUsage] = useState(false);
@@ -164,11 +172,38 @@ export function PublishCard({ preset, isUnpublishing, onPublish, onUnpublish }: 
             <h3 className="font-semibold">{t('publish.title')}</h3>
             <p className="text-sm text-muted-foreground">{t('detail.publishDescription')}</p>
           </div>
-          <Button onClick={onPublish}>
-            <Globe className="mr-2 h-4 w-4" />
-            {t('publish.title')}
-          </Button>
+          {executorOffline ? (
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span tabIndex={0}>
+                    <Button disabled>
+                      <Globe className="mr-2 h-4 w-4" />
+                      {t('publish.title')}
+                    </Button>
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent side="top" className="max-w-xs">
+                  <div className="flex items-start gap-2">
+                    <AlertTriangle className="h-4 w-4 text-destructive shrink-0 mt-0.5" />
+                    <p className="text-xs">{t('publish.executorOfflineWarning', { name: executorName })}</p>
+                  </div>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          ) : (
+            <Button onClick={onPublish}>
+              <Globe className="mr-2 h-4 w-4" />
+              {t('publish.title')}
+            </Button>
+          )}
         </div>
+        {executorOffline && (
+          <p className="text-xs text-destructive mt-2 flex items-center gap-1">
+            <AlertTriangle className="h-3 w-3" />
+            {t('publish.executorOfflineWarning', { name: executorName })}
+          </p>
+        )}
       </CardContent>
     </Card>
   );

--- a/web/src/components/chat/selects.tsx
+++ b/web/src/components/chat/selects.tsx
@@ -143,7 +143,7 @@ export const AgentPresetSelect = React.memo(function AgentPresetSelect({
 
 interface ExecutorSelectProps {
   value: string | null;
-  onChange: (executorId: string | null) => void;
+  onChange: (executorName: string | null) => void;
   executors: Executor[];
   size?: SelectSize;
   className?: string;
@@ -178,8 +178,8 @@ export const ExecutorSelect = React.memo(function ExecutorSelect({
         <SelectItem value="__local__">{placeholder}</SelectItem>
         {executors.map((executor) => (
           <SelectItem
-            key={executor.id}
-            value={executor.id}
+            key={executor.name}
+            value={executor.name}
             disabled={!showAll && executor.status !== 'online'}
           >
             {executor.name}

--- a/web/src/i18n/locales/en-US/agents.json
+++ b/web/src/i18n/locales/en-US/agents.json
@@ -171,6 +171,7 @@
       "sessionIdNote": "The session_id is a client-generated UUID. Use the same ID across requests to maintain conversation context.",
       "docsLink": "Full documentation on Published Agent API"
     },
+    "executorOfflineWarning": "Cannot publish: executor \"{{name}}\" is offline. Start the executor first.",
     "dialogDescription": "Select the model that this published agent will use. Users will interact with this model when using your agent.",
     "modelHelp": "This model will be used for all conversations with the published agent.",
     "noModelWarning": "No model selected. The default model (Kimi K2.5) will be used."
@@ -188,6 +189,11 @@
     "user": "User",
     "meta": "Meta",
     "system": "System"
+  },
+  "executor": {
+    "label": "Executor",
+    "offline": "offline",
+    "online": "online"
   },
   "model": {
     "title": "Model",

--- a/web/src/i18n/locales/en-US/chat.json
+++ b/web/src/i18n/locales/en-US/chat.json
@@ -54,7 +54,8 @@
     "selectModel": "Select model",
     "executor": "Executor",
     "executorLocal": "Local",
-    "executorDescription": "Select execution environment for code"
+    "executorDescription": "Select execution environment for code",
+    "executorOfflineWarning": "Executor \"{{name}}\" is offline. Code execution will fail."
   },
   "files": {
     "title": "Files",

--- a/web/src/i18n/locales/es/agents.json
+++ b/web/src/i18n/locales/es/agents.json
@@ -171,6 +171,7 @@
       "sessionIdNote": "El session_id es un UUID generado por el cliente. Use el mismo ID en las solicitudes para mantener el contexto de la conversación.",
       "docsLink": "Documentación completa de la API de Published Agent"
     },
+    "executorOfflineWarning": "No se puede publicar: el ejecutor \"{{name}}\" está fuera de línea. Inicia el ejecutor primero.",
     "dialogDescription": "Selecciona el modelo que usará este agente publicado. Los usuarios interactuarán con este modelo al usar tu agente.",
     "modelHelp": "Este modelo se usará para todas las conversaciones con el agente publicado.",
     "noModelWarning": "No se seleccionó modelo. Se usará el modelo por defecto (Kimi K2.5)."
@@ -188,6 +189,11 @@
     "user": "Usuario",
     "meta": "Meta",
     "system": "Sistema"
+  },
+  "executor": {
+    "label": "Ejecutor",
+    "offline": "fuera de línea",
+    "online": "en línea"
   },
   "model": {
     "title": "Modelo",

--- a/web/src/i18n/locales/es/chat.json
+++ b/web/src/i18n/locales/es/chat.json
@@ -54,7 +54,8 @@
     "selectModel": "Seleccionar modelo",
     "executor": "Ejecutor",
     "executorLocal": "Local",
-    "executorDescription": "Seleccionar entorno de ejecución de código"
+    "executorDescription": "Seleccionar entorno de ejecución de código",
+    "executorOfflineWarning": "El ejecutor \"{{name}}\" está fuera de línea. La ejecución de código fallará."
   },
   "files": {
     "title": "Archivos",

--- a/web/src/i18n/locales/ja/agents.json
+++ b/web/src/i18n/locales/ja/agents.json
@@ -171,6 +171,7 @@
       "sessionIdNote": "session_id はクライアント側で生成する UUID です。会話コンテキストを維持するため、リクエスト間で同じ ID を使用してください。",
       "docsLink": "Published Agent API の完全なドキュメント"
     },
+    "executorOfflineWarning": "公開できません: エクゼキューター \"{{name}}\" がオフラインです。先にエクゼキューターを起動してください。",
     "dialogDescription": "この公開エージェントが使用するモデルを選択してください。ユーザーはこのモデルを通じてエージェントと対話します。",
     "modelHelp": "このモデルは公開エージェントのすべての会話に使用されます。",
     "noModelWarning": "モデルが選択されていません。デフォルトモデル (Kimi K2.5) が使用されます。"
@@ -188,6 +189,11 @@
     "user": "ユーザー",
     "meta": "メタ",
     "system": "システム"
+  },
+  "executor": {
+    "label": "エクゼキューター",
+    "offline": "オフライン",
+    "online": "オンライン"
   },
   "model": {
     "title": "モデル",

--- a/web/src/i18n/locales/ja/chat.json
+++ b/web/src/i18n/locales/ja/chat.json
@@ -54,7 +54,8 @@
     "selectModel": "モデルを選択",
     "executor": "エグゼキューター",
     "executorLocal": "ローカル",
-    "executorDescription": "コード実行環境を選択"
+    "executorDescription": "コード実行環境を選択",
+    "executorOfflineWarning": "エクゼキューター \"{{name}}\" がオフラインです。コード実行は失敗します。"
   },
   "files": {
     "title": "ファイル",

--- a/web/src/i18n/locales/pt-BR/agents.json
+++ b/web/src/i18n/locales/pt-BR/agents.json
@@ -171,6 +171,7 @@
       "sessionIdNote": "O session_id é um UUID gerado pelo cliente. Use o mesmo ID nas requisições para manter o contexto da conversa.",
       "docsLink": "Documentação completa da API de Published Agent"
     },
+    "executorOfflineWarning": "Não é possível publicar: o executor \"{{name}}\" está offline. Inicie o executor primeiro.",
     "dialogDescription": "Selecione o modelo que este agente publicado usará. Os usuários interagirão com este modelo ao usar seu agente.",
     "modelHelp": "Este modelo será usado para todas as conversas com o agente publicado.",
     "noModelWarning": "Nenhum modelo selecionado. O modelo padrão (Kimi K2.5) será usado."
@@ -188,6 +189,11 @@
     "user": "Usuário",
     "meta": "Meta",
     "system": "Sistema"
+  },
+  "executor": {
+    "label": "Executor",
+    "offline": "offline",
+    "online": "online"
   },
   "model": {
     "title": "Modelo",

--- a/web/src/i18n/locales/pt-BR/chat.json
+++ b/web/src/i18n/locales/pt-BR/chat.json
@@ -54,7 +54,8 @@
     "selectModel": "Selecionar modelo",
     "executor": "Executor",
     "executorLocal": "Local",
-    "executorDescription": "Selecionar ambiente de execução de código"
+    "executorDescription": "Selecionar ambiente de execução de código",
+    "executorOfflineWarning": "O executor \"{{name}}\" está offline. A execução de código falhará."
   },
   "files": {
     "title": "Arquivos",

--- a/web/src/i18n/locales/zh-CN/agents.json
+++ b/web/src/i18n/locales/zh-CN/agents.json
@@ -171,6 +171,7 @@
       "sessionIdNote": "session_id 是客户端生成的 UUID。在多次请求中使用相同的 ID 以保持对话上下文。",
       "docsLink": "Published Agent API 完整文档"
     },
+    "executorOfflineWarning": "无法发布：执行器 \"{{name}}\" 已离线。请先启动执行器。",
     "dialogDescription": "选择此已发布代理将使用的模型。用户将通过此模型与你的代理交互。",
     "modelHelp": "此模型将用于已发布代理的所有对话。",
     "noModelWarning": "未选择模型。将使用默认模型 (Kimi K2.5)。"
@@ -188,6 +189,11 @@
     "user": "用户",
     "meta": "元",
     "system": "系统"
+  },
+  "executor": {
+    "label": "执行器",
+    "offline": "离线",
+    "online": "在线"
   },
   "model": {
     "title": "模型",

--- a/web/src/i18n/locales/zh-CN/chat.json
+++ b/web/src/i18n/locales/zh-CN/chat.json
@@ -54,7 +54,8 @@
     "selectModel": "选择模型",
     "executor": "执行器",
     "executorLocal": "本地",
-    "executorDescription": "选择代码执行环境"
+    "executorDescription": "选择代码执行环境",
+    "executorOfflineWarning": "执行器 \"{{name}}\" 已离线。代码执行将会失败。"
   },
   "files": {
     "title": "文件",

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -687,7 +687,7 @@ export interface AgentRequest {
   uploaded_files?: AgentUploadedFile[];  // Uploaded files available to the agent
   equipped_mcp_servers?: string[];  // Optional list of MCP servers to enable (undefined = all)
   system_prompt?: string;  // Custom system prompt to append to base prompt
-  executor_id?: string;  // Executor ID for code execution (custom mode only)
+  executor_name?: string;  // Executor name for code execution (custom mode only)
 }
 
 export interface StepInfo {
@@ -1153,7 +1153,7 @@ export interface AgentPreset {
   max_turns: number;
   model_provider: string | null;
   model_name: string | null;
-  executor_id: string | null;
+  executor_name: string | null;
   is_system: boolean;
   is_published: boolean;
   api_response_mode: 'streaming' | 'non_streaming' | null;
@@ -1176,7 +1176,7 @@ export interface AgentPresetCreateRequest {
   max_turns?: number;
   model_provider?: string;
   model_name?: string;
-  executor_id?: string;
+  executor_name?: string;
 }
 
 export interface AgentPresetUpdateRequest {
@@ -1189,7 +1189,7 @@ export interface AgentPresetUpdateRequest {
   max_turns?: number;
   model_provider?: string | null;
   model_name?: string | null;
-  executor_id?: string | null;
+  executor_name?: string | null;
   is_published?: boolean;
 }
 


### PR DESCRIPTION
## Summary

- Replace ephemeral `executor_id` (UUID FK to `executors.id`) with stable `executor_name` (VARCHAR(50) string) in `agent_presets` table
- Backup/restore now **preserves executor associations** (was previously lost due to UUID regeneration)
- Simplify `_resolve_agent_config()` and `_resolve_published_config()` — no more `ExecutorDB` queries, direct name-based status checks
- Simplify seed agent loading — no more name→UUID resolution at startup

## Changes

**Backend (6 files)**
- `models.py`: Drop `executor_id` FK column + relationship, add `executor_name` VARCHAR(50)
- `agent.py`: Simplify `_resolve_agent_config()`, remove all `ExecutorDB` imports/lookups
- `agents.py`: Update Pydantic models + CRUD + publish validation
- `published.py`: Simplify `_resolve_published_config()`, remove `ExecutorDB` lookup
- `backup.py`: Serialize `executor_name`, preserve across backup/restore
- `database.py`: Simplify seed loading (direct `executor_name` from JSON)

**Frontend (12 files)**
- `api.ts`: Update TypeScript interfaces (`executor_id` → `executor_name`)
- `chat-store.ts`: Rename `selectedExecutorId` → `selectedExecutorName`, bump persist version 10→11
- `agent-config-form.tsx`, `selects.tsx`, `chat-panel.tsx`: Use executor name as value
- Agent pages (`page.tsx`, `[id]/page.tsx`, `new/page.tsx`): Update executor references
- `publish-card.tsx`: Update executor field name

**Tests (3 files)**: Update `mock_preset.executor_id = None` → `mock_preset.executor_name = None`

**i18n (10 files)**: No label changes needed, existing keys use generic "executor" terms

## Test plan

- [x] Unit tests: 423 passed, 0 failed
- [x] E2E mock tests: 180 passed, 0 failed
- [x] Frontend build: success (all 25 pages)
- [x] Docker redeploy: all containers healthy
- [x] Live API: create/update/delete agent with `executor_name`
- [x] Live API: publish with online executor (OK) / offline executor (409)
- [x] Live API: agent run with `executor_name` (online→OK, offline→503)
- [x] Live API: published agent chat with executor
- [x] Live API: backup contains `executor_name`, no `executor_id`

Closes #124