### PR TITLE
Show agent references on skill cards

### DIFF
--- a/web/src/components/skill/skill-card.tsx
+++ b/web/src/components/skill/skill-card.tsx
@@ -21,11 +21,13 @@ import {
   Blocks,
   ClipboardList,
   Pin,
+  Bot,
   type LucideIcon,
 } from 'lucide-react';
 import { Card, CardHeader, CardContent } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
 import { formatRelativeTime } from '@/lib/utils';
 import { useTogglePin } from '@/hooks/use-skills';
 import { useTranslation } from '@/i18n/client';
@@ -34,6 +36,7 @@ import type { Skill } from '@/types/skill';
 interface SkillCardProps {
   skill: Skill;
   hasGithubUpdate?: boolean;
+  agentNames?: string[];
 }
 
 const MAX_VISIBLE_TAGS = 3;
@@ -74,7 +77,7 @@ function getIconUrl(iconUrl: string | null, updatedAt?: string): string | null {
   return url;
 }
 
-export function SkillCard({ skill, hasGithubUpdate }: SkillCardProps) {
+export function SkillCard({ skill, hasGithubUpdate, agentNames }: SkillCardProps) {
   const { t } = useTranslation('skills');
   const togglePin = useTogglePin();
   const isMeta = skill.skill_type === 'meta';  // undefined defaults to user
@@ -174,6 +177,19 @@ export function SkillCard({ skill, hasGithubUpdate }: SkillCardProps) {
               <Clock className="h-3 w-3" />
               <span>{formatRelativeTime(skill.updated_at)}</span>
             </div>
+            {!isMeta && agentNames && agentNames.length > 0 && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <div className="flex items-center gap-1 ml-auto px-1.5 py-0.5 rounded-full bg-primary/10 text-primary text-xs font-medium">
+                    <Bot className="h-3 w-3" />
+                    <span>{agentNames.length}</span>
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent className="max-w-xs">
+                  <p>{t('card.usedByAgents', { count: agentNames.length })}: {agentNames.join(', ')}</p>
+                </TooltipContent>
+              </Tooltip>
+            )}
           </div>
         </CardContent>
       </Card>

--- a/web/src/components/skill/skill-list-item.tsx
+++ b/web/src/components/skill/skill-list-item.tsx
@@ -7,10 +7,12 @@ import {
   Tag,
   Settings2,
   Pin,
+  Bot,
 } from 'lucide-react';
 import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
 import { formatRelativeTime } from '@/lib/utils';
 import { useTogglePin } from '@/hooks/use-skills';
 import { useTranslation } from '@/i18n/client';
@@ -19,11 +21,12 @@ import type { Skill } from '@/types/skill';
 interface SkillListItemProps {
   skill: Skill;
   hasGithubUpdate?: boolean;
+  agentNames?: string[];
 }
 
 const MAX_VISIBLE_TAGS = 2;
 
-export function SkillListItem({ skill, hasGithubUpdate }: SkillListItemProps) {
+export function SkillListItem({ skill, hasGithubUpdate, agentNames }: SkillListItemProps) {
   const { t } = useTranslation('skills');
   const togglePin = useTogglePin();
   const isMeta = skill.skill_type === 'meta';
@@ -103,6 +106,21 @@ export function SkillListItem({ skill, hasGithubUpdate }: SkillListItemProps) {
             <Clock className="h-3 w-3" />
             <span>{formatRelativeTime(skill.updated_at)}</span>
           </div>
+
+          {/* Agent references */}
+          {!isMeta && agentNames && agentNames.length > 0 && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <div className="flex items-center gap-1 px-1.5 py-0.5 rounded-full bg-primary/10 text-primary text-xs font-medium flex-shrink-0">
+                  <Bot className="h-3 w-3" />
+                  <span>{agentNames.length}</span>
+                </div>
+              </TooltipTrigger>
+              <TooltipContent className="max-w-xs">
+                <p>{t('card.usedByAgents', { count: agentNames.length })}: {agentNames.join(', ')}</p>
+              </TooltipContent>
+            </Tooltip>
+          )}
 
           {/* Pin button */}
           {!isMeta && (

--- a/web/src/i18n/locales/en-US/skills.json
+++ b/web/src/i18n/locales/en-US/skills.json
@@ -81,7 +81,9 @@
     "noTags": "No tags",
     "pin": "Pin to top",
     "unpin": "Unpin",
-    "githubUpdateAvailable": "New version available on GitHub"
+    "githubUpdateAvailable": "New version available on GitHub",
+    "usedByAgents": "Used by {{count}} agent",
+    "usedByAgents_other": "Used by {{count}} agents"
   },
   "detail": {
     "overview": "Overview",

--- a/web/src/i18n/locales/es/skills.json
+++ b/web/src/i18n/locales/es/skills.json
@@ -81,7 +81,9 @@
     "noTags": "Sin etiquetas",
     "pin": "Fijar arriba",
     "unpin": "Desfijar",
-    "githubUpdateAvailable": "Nueva versión disponible en GitHub"
+    "githubUpdateAvailable": "Nueva versión disponible en GitHub",
+    "usedByAgents": "Usado por {{count}} agente",
+    "usedByAgents_other": "Usado por {{count}} agentes"
   },
   "detail": {
     "overview": "Resumen",

--- a/web/src/i18n/locales/ja/skills.json
+++ b/web/src/i18n/locales/ja/skills.json
@@ -81,7 +81,8 @@
     "noTags": "タグなし",
     "pin": "トップに固定",
     "unpin": "固定を解除",
-    "githubUpdateAvailable": "GitHub に新しいバージョンがあります"
+    "githubUpdateAvailable": "GitHub に新しいバージョンがあります",
+    "usedByAgents": "{{count}} つのエージェントで使用中"
   },
   "detail": {
     "overview": "概要",

--- a/web/src/i18n/locales/pt-BR/skills.json
+++ b/web/src/i18n/locales/pt-BR/skills.json
@@ -81,7 +81,9 @@
     "noTags": "Sem tags",
     "pin": "Fixar no topo",
     "unpin": "Desafixar",
-    "githubUpdateAvailable": "Nova versão disponível no GitHub"
+    "githubUpdateAvailable": "Nova versão disponível no GitHub",
+    "usedByAgents": "Usado por {{count}} agente",
+    "usedByAgents_other": "Usado por {{count}} agentes"
   },
   "detail": {
     "overview": "Visão Geral",

--- a/web/src/i18n/locales/zh-CN/skills.json
+++ b/web/src/i18n/locales/zh-CN/skills.json
@@ -81,7 +81,8 @@
     "noTags": "无标签",
     "pin": "置顶",
     "unpin": "取消置顶",
-    "githubUpdateAvailable": "GitHub 上有新版本可用"
+    "githubUpdateAvailable": "GitHub 上有新版本可用",
+    "usedByAgents": "被 {{count}} 个 Agent 使用"
   },
   "detail": {
     "overview": "概览",


### PR DESCRIPTION
## Summary

- Display a Bot icon + count badge on skill cards (grid) and list items to show how many user agents reference each skill
- Hovering the badge shows a tooltip listing agent names (e.g. "Used by 3 agents: Agent1, Agent2, Agent3")
- Meta agents excluded from count; meta skills don't show the indicator
- Frontend-only change — fetches agents via existing API, computes map via `useMemo`
- i18n keys added for all 5 languages (en-US, zh-CN, ja, es, pt-BR)

## Test plan

- [x] `npm run build` passes with no TypeScript errors
- [x] Verified API returns correct agent → skill mappings
- [x] Skills page loads successfully (HTTP 200)
- [ ] Visual check: grid view shows Bot badge on referenced skills
- [ ] Visual check: list view shows Bot badge before pin button
- [ ] Tooltip displays correct agent names on hover
- [ ] Meta skills do not show the indicator
- [ ] Skills with no agent references show no indicator

Closes #128