### PR TITLE
Fix session loading freeze with 50+ messages

### DIFF
--- a/web/src/app/chat/page.tsx
+++ b/web/src/app/chat/page.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { useQuery } from "@tanstack/react-query";
 import {
   RotateCcw, Paperclip, X, Wrench, Plug, ChevronDown, ChevronUp, Square, Bot, Cpu, Server,
-  MessageSquare, Home, Settings, Plus,
+  MessageSquare, Home, Settings, Plus, Loader2,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
@@ -31,7 +31,7 @@ export default function FullscreenChatPage() {
 
   const {
     messages, selectedSkills, selectedTools, selectedMcpServers, isRunning, maxTurns,
-    uploadedFiles, selectedAgentPreset, systemPrompt,
+    uploadedFiles, selectedAgentPreset, systemPrompt, isRestoringSession,
     addMessage, updateMessage, removeMessages, newSession, resetAll,
     setSessionId, setSelectedSkills, setSelectedTools, setSelectedMcpServers,
     setIsRunning, setMaxTurns, addUploadedFile, removeUploadedFile, clearUploadedFiles,
@@ -360,7 +360,12 @@ export default function FullscreenChatPage() {
 
       {/* Messages */}
       <div className="flex-1 overflow-auto p-6 space-y-4">
-        {messages.length === 0 ? (
+        {isRestoringSession ? (
+          <div className="flex flex-col items-center justify-center py-16 gap-3">
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+            <p className="text-sm text-muted-foreground">{t('session.restoring')}</p>
+          </div>
+        ) : messages.length === 0 ? (
           <div className="text-center text-muted-foreground py-16">
             <MessageSquare className="h-12 w-12 mx-auto mb-4 opacity-50" />
             <p className="text-lg">{t('startConversation')}</p>

--- a/web/src/components/chat/chat-message.tsx
+++ b/web/src/components/chat/chat-message.tsx
@@ -24,7 +24,7 @@ interface ChatMessageItemProps {
   onAskUserRespond?: (promptId: string, answer: string) => void;
 }
 
-export function ChatMessageItem({
+export const ChatMessageItem = React.memo(function ChatMessageItem({
   message,
   streamingContent,
   streamingOutputFiles,
@@ -148,7 +148,7 @@ export function ChatMessageItem({
       </Card>
     </div>
   );
-}
+});
 
 export function TraceIdDisplay({ traceId }: { traceId: string }) {
   const [copied, setCopied] = React.useState(false);

--- a/web/src/components/chat/chat-panel.tsx
+++ b/web/src/components/chat/chat-panel.tsx
@@ -3,7 +3,7 @@
 import React from "react";
 import Link from "next/link";
 import { useQuery } from "@tanstack/react-query";
-import { RotateCcw, Paperclip, X, Wrench, Plug, ChevronDown, ChevronUp, Square, Bot, Cpu, Maximize2, Server, Plus, Settings, AlertTriangle } from "lucide-react";
+import { RotateCcw, Paperclip, X, Wrench, Plug, ChevronDown, ChevronUp, Square, Bot, Cpu, Maximize2, Server, Plus, Settings, AlertTriangle, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Input } from "@/components/ui/input";
@@ -46,6 +46,7 @@ export function ChatPanel({ isOpen, onClose, defaultSkills = [] }: ChatPanelProp
     selectedTools,
     selectedMcpServers,
     isRunning,
+    isRestoringSession,
     maxTurns,
     uploadedFiles,
     selectedAgentPreset,
@@ -473,7 +474,12 @@ export function ChatPanel({ isOpen, onClose, defaultSkills = [] }: ChatPanelProp
 
       {/* Messages */}
       <div className="flex-1 overflow-auto p-4 space-y-4">
-        {messages.length === 0 ? (
+        {isRestoringSession ? (
+          <div className="flex flex-col items-center justify-center py-8 gap-3">
+            <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+            <p className="text-sm text-muted-foreground">{t('session.restoring')}</p>
+          </div>
+        ) : messages.length === 0 ? (
           <div className="text-center text-muted-foreground py-8">
             <p>{t('startConversation')}.</p>
             <p className="text-sm mt-2">{t('selectSkillsHint')}</p>

--- a/web/src/components/chat/stream-events/index.tsx
+++ b/web/src/components/chat/stream-events/index.tsx
@@ -25,7 +25,7 @@ interface StreamEventsRendererProps {
 /**
  * Renders a list of stream events as structured UI components
  */
-export function StreamEventsRenderer({ events, expandAll = false, isStreaming = false, onAskUserRespond }: StreamEventsRendererProps) {
+export const StreamEventsRenderer = React.memo(function StreamEventsRenderer({ events, expandAll = false, isStreaming = false, onAskUserRespond }: StreamEventsRendererProps) {
   // Find the index of the last assistant event for streaming optimization
   let lastAssistantIndex = -1;
   if (isStreaming) {
@@ -85,7 +85,7 @@ export function StreamEventsRenderer({ events, expandAll = false, isStreaming = 
       })}
     </div>
   );
-}
+});
 
 // Re-export individual components for direct usage
 export { TurnDivider } from "./turn-divider";

--- a/web/src/components/chat/stream-events/thinking-block.tsx
+++ b/web/src/components/chat/stream-events/thinking-block.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { MessageSquare } from "lucide-react";
-import { Markdown } from "@/components/ui/markdown";
+import { LazyMarkdown } from "@/components/ui/lazy-markdown";
 import type { AssistantData } from "@/types/stream-events";
 
 interface ThinkingBlockProps {
@@ -18,7 +18,7 @@ export function ThinkingBlock({ data, isStreaming }: ThinkingBlockProps) {
         {isStreaming ? (
           <pre className="whitespace-pre-wrap font-sans">{data.content}</pre>
         ) : (
-          <Markdown>{data.content}</Markdown>
+          <LazyMarkdown>{data.content}</LazyMarkdown>
         )}
       </div>
     </div>

--- a/web/src/components/ui/lazy-markdown.tsx
+++ b/web/src/components/ui/lazy-markdown.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import React, { useRef, useState, useEffect } from "react";
+import { Markdown } from "./markdown";
+
+interface LazyMarkdownProps {
+  children: string;
+  className?: string;
+}
+
+/**
+ * Renders plain <pre> until the element scrolls into view (200px margin),
+ * then upgrades to full <Markdown> (ReactMarkdown + Prism syntax highlighting).
+ * This avoids paying the Markdown parsing cost for off-screen messages.
+ */
+export function LazyMarkdown({ children, className }: LazyMarkdownProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setVisible(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin: "200px" }
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div ref={ref}>
+      {visible ? (
+        <Markdown className={className}>{children}</Markdown>
+      ) : (
+        <pre className={`whitespace-pre-wrap font-sans text-sm ${className ?? ""}`}>{children}</pre>
+      )}
+    </div>
+  );
+}

--- a/web/src/i18n/locales/en-US/chat.json
+++ b/web/src/i18n/locales/en-US/chat.json
@@ -108,6 +108,10 @@
     "button": "Steer",
     "label": "Steering"
   },
+  "session": {
+    "restoring": "Restoring session...",
+    "switching": "Loading conversation..."
+  },
   "published": {
     "typeToBegin": "Type a message below to begin.",
     "notAvailable": "This agent is not available.",

--- a/web/src/i18n/locales/es/chat.json
+++ b/web/src/i18n/locales/es/chat.json
@@ -108,6 +108,10 @@
     "button": "Dirigir",
     "label": "Dirección"
   },
+  "session": {
+    "restoring": "Restaurando sesión...",
+    "switching": "Cargando conversación..."
+  },
   "published": {
     "typeToBegin": "Escribe un mensaje abajo para comenzar.",
     "notAvailable": "Este agente no está disponible.",

--- a/web/src/i18n/locales/ja/chat.json
+++ b/web/src/i18n/locales/ja/chat.json
@@ -108,6 +108,10 @@
     "button": "操舵",
     "label": "ステアリング"
   },
+  "session": {
+    "restoring": "セッションを復元中...",
+    "switching": "会話を読み込み中..."
+  },
   "published": {
     "typeToBegin": "下にメッセージを入力して開始してください。",
     "notAvailable": "このエージェントは利用できません。",

--- a/web/src/i18n/locales/pt-BR/chat.json
+++ b/web/src/i18n/locales/pt-BR/chat.json
@@ -108,6 +108,10 @@
     "button": "Direcionar",
     "label": "Direcionamento"
   },
+  "session": {
+    "restoring": "Restaurando sessão...",
+    "switching": "Carregando conversa..."
+  },
   "published": {
     "typeToBegin": "Digite uma mensagem abaixo para começar.",
     "notAvailable": "Este agente não está disponível.",

--- a/web/src/i18n/locales/zh-CN/chat.json
+++ b/web/src/i18n/locales/zh-CN/chat.json
@@ -108,6 +108,10 @@
     "button": "引导",
     "label": "引导消息"
   },
+  "session": {
+    "restoring": "正在恢复会话...",
+    "switching": "正在加载对话..."
+  },
   "published": {
     "typeToBegin": "在下方输入消息开始。",
     "notAvailable": "此 Agent 不可用。",

--- a/web/src/stores/chat-store.ts
+++ b/web/src/stores/chat-store.ts
@@ -32,6 +32,7 @@ interface ChatState {
   selectedTools: string[] | null;  // null = not initialized, will auto-select all tools
   selectedMcpServers: string[] | null;  // null = not initialized, will auto-select default_enabled
   isRunning: boolean;
+  isRestoringSession: boolean;  // True while restoring session messages from server
   maxTurns: number;
   uploadedFiles: UploadedFile[];
   selectedAgentPreset: string | null;  // Currently selected agent preset ID
@@ -42,9 +43,11 @@ interface ChatState {
 
   // Actions
   addMessage: (message: ChatMessage) => void;
+  setMessages: (messages: ChatMessage[]) => void;  // Batch replace all messages (avoids N re-renders)
   updateMessage: (id: string, updates: Partial<ChatMessage>) => void;
   removeMessages: (ids: string[]) => void;
   clearMessages: () => void;
+  setIsRestoringSession: (restoring: boolean) => void;
   setSessionId: (id: string | null) => void;
   newSession: () => void;  // Clear messages + sessionId + files, keep config
   setSelectedSkills: (skills: string[]) => void;
@@ -77,6 +80,7 @@ export const useChatStore = create<ChatState>()(
       selectedTools: null,  // null = not initialized, will auto-select all tools
       selectedMcpServers: null,  // null = not initialized, will auto-select default_enabled
       isRunning: false,
+      isRestoringSession: false,
       maxTurns: 60,
       uploadedFiles: [],
       selectedAgentPreset: null,
@@ -89,6 +93,8 @@ export const useChatStore = create<ChatState>()(
         set((state) => ({
           messages: [...state.messages, message],
         })),
+
+      setMessages: (messages) => set({ messages }),
 
       updateMessage: (id, updates) =>
         set((state) => ({
@@ -103,6 +109,8 @@ export const useChatStore = create<ChatState>()(
         })),
 
       clearMessages: () => set({ messages: [] }),
+
+      setIsRestoringSession: (restoring) => set({ isRestoringSession: restoring }),
 
       setSessionId: (id) => set({ sessionId: id }),
 
@@ -174,6 +182,7 @@ export const useChatStore = create<ChatState>()(
         maxTurns: 60,
         uploadedFiles: [],
         isRunning: false,
+        isRestoringSession: false,
         selectedAgentPreset: null,
         systemPrompt: null,
         selectedModelProvider: null,


### PR DESCRIPTION
## Summary

- **Batch state update**: Replace one-by-one `addMessage()` loop with single `setMessages()` call in Zustand store, eliminating N re-renders when restoring a session
- **Loading indicators**: Add `isRestoringSession` flag and loading spinners across all chat views (Published page, fullscreen `/chat`, floating panel) so users see a spinner instead of a blank screen
- **React.memo**: Memoize `ChatMessageItem` and `StreamEventsRenderer` to prevent cascade re-renders when the messages array changes
- **LazyMarkdown**: New `IntersectionObserver`-based component that renders plain `<pre>` for off-screen messages and upgrades to full Markdown (ReactMarkdown + Prism) when scrolled into view
- **Session switching**: Published Agent sidebar session switches now show a loading indicator during fetch + render via `startTransition`
- **i18n**: Added `session.restoring` and `session.switching` keys in all 5 languages

## Test plan

- [ ] Open a Published Agent session with 50+ messages — verify spinner shows during restore and messages appear without freeze
- [ ] Open `/chat` fullscreen with existing session — verify "Restoring session..." loading state
- [ ] Open floating chat panel with existing session — same loading indicator
- [ ] Switch sessions in Published page sidebar — verify "Loading conversation..." indicator
- [ ] Verify active streaming still works (real-time updates, auto-scroll)
- [ ] Scroll up in a long conversation — verify LazyMarkdown upgrades off-screen messages to full Markdown
- [ ] Test language switching for new i18n keys (en-US, zh-CN, ja, es, pt-BR)

Closes #134