### PR TITLE
Fix published chat session loading state and user message bubble style

### DIFF
--- a/web/src/app/published/[id]/page.tsx
+++ b/web/src/app/published/[id]/page.tsx
@@ -76,6 +76,7 @@ export default function PublishedChatPage() {
   // Session
   const [sessionId, setSessionId] = useState<string>(() => getOrCreateSessionId(agentId));
   const [restoringSession, setRestoringSession] = useState(false);
+  const [loadingSession, setLoadingSession] = useState(false);
 
   // Chat state (local)
   const [messages, setMessages] = useState<LocalMessage[]>([]);
@@ -207,6 +208,7 @@ export default function PublishedChatPage() {
     setMessages([]);
     setUploadedFiles([]);
     setMobileSidebarOpen(false);
+    setLoadingSession(true);
 
     try {
       const data = await publishedAgentApi.getSession(agentId, newSessionId);
@@ -215,6 +217,8 @@ export default function PublishedChatPage() {
       }
     } catch {
       // First visit or not found
+    } finally {
+      setLoadingSession(false);
     }
   }, [agentId, sessionId, isRunning]);
 
@@ -299,7 +303,12 @@ export default function PublishedChatPage() {
 
         {/* Messages */}
         <div className="flex-1 overflow-auto p-4 sm:p-6 space-y-4">
-          {messages.length === 0 ? (
+          {loadingSession ? (
+            <div className="flex flex-col items-center justify-center py-16 gap-3">
+              <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+              <p className="text-sm text-muted-foreground">{t('published.loadingSession')}</p>
+            </div>
+          ) : messages.length === 0 ? (
             <div className="text-center text-muted-foreground py-16">
               <Bot className="h-12 w-12 mx-auto mb-4 opacity-50" />
               <p className="text-lg">{t('startConversation')}</p>

--- a/web/src/components/chat/chat-message.tsx
+++ b/web/src/components/chat/chat-message.tsx
@@ -48,14 +48,14 @@ export function ChatMessageItem({
   if (message.role === "user") {
     return (
       <div className="flex justify-end">
-        <Card className="max-w-[85%] p-3 px-4 bg-primary text-primary-foreground">
+        <Card className="max-w-[85%] p-3 px-4 bg-[#f4f4f4] dark:bg-[#303030] text-foreground border-0 shadow-none rounded-2xl">
           <p className="text-sm whitespace-pre-wrap">{message.content}</p>
           {message.attachedFiles && message.attachedFiles.length > 0 && (
-            <div className="flex flex-wrap gap-1.5 mt-2 pt-2 border-t border-primary-foreground/20">
+            <div className="flex flex-wrap gap-1.5 mt-2 pt-2 border-t border-foreground/10">
               {message.attachedFiles.map((file) => (
                 <span
                   key={file.file_id}
-                  className="inline-flex items-center gap-1 text-xs opacity-80 bg-primary-foreground/10 rounded px-1.5 py-0.5"
+                  className="inline-flex items-center gap-1 text-xs opacity-70 bg-foreground/5 rounded px-1.5 py-0.5"
                 >
                   <Paperclip className="h-3 w-3" />
                   <span className="max-w-[150px] truncate">{file.filename}</span>

--- a/web/src/i18n/locales/en-US/chat.json
+++ b/web/src/i18n/locales/en-US/chat.json
@@ -113,6 +113,7 @@
     "notAvailable": "This agent is not available.",
     "sessionId": "Session",
     "sessionIdCopied": "Session ID copied",
+    "loadingSession": "Loading conversation...",
     "sidebar": {
       "title": "History",
       "noSessions": "No conversations yet",

--- a/web/src/i18n/locales/es/chat.json
+++ b/web/src/i18n/locales/es/chat.json
@@ -113,6 +113,7 @@
     "notAvailable": "Este agente no está disponible.",
     "sessionId": "Sesión",
     "sessionIdCopied": "ID de sesión copiado",
+    "loadingSession": "Cargando conversación...",
     "sidebar": {
       "title": "Historial",
       "noSessions": "Sin conversaciones",

--- a/web/src/i18n/locales/ja/chat.json
+++ b/web/src/i18n/locales/ja/chat.json
@@ -113,6 +113,7 @@
     "notAvailable": "このエージェントは利用できません。",
     "sessionId": "セッション",
     "sessionIdCopied": "セッションIDをコピーしました",
+    "loadingSession": "会話を読み込み中...",
     "sidebar": {
       "title": "履歴",
       "noSessions": "会話がありません",

--- a/web/src/i18n/locales/pt-BR/chat.json
+++ b/web/src/i18n/locales/pt-BR/chat.json
@@ -113,6 +113,7 @@
     "notAvailable": "Este agente não está disponível.",
     "sessionId": "Sessão",
     "sessionIdCopied": "ID da sessão copiado",
+    "loadingSession": "Carregando conversa...",
     "sidebar": {
       "title": "Histórico",
       "noSessions": "Nenhuma conversa",

--- a/web/src/i18n/locales/zh-CN/chat.json
+++ b/web/src/i18n/locales/zh-CN/chat.json
@@ -113,6 +113,7 @@
     "notAvailable": "此 Agent 不可用。",
     "sessionId": "会话",
     "sessionIdCopied": "会话 ID 已复制",
+    "loadingSession": "正在加载对话...",
     "sidebar": {
       "title": "历史记录",
       "noSessions": "暂无对话",


### PR DESCRIPTION
## Summary
- Add a loading spinner when switching sessions in the Published Agent chat page, replacing the misleading empty state that appeared during data fetch
- Update user message bubble from dark `bg-primary` to a soft neutral gray (`#f4f4f4` light / `#303030` dark), matching ChatGPT's visual style
- Add `published.loadingSession` i18n key across all 5 languages (en-US, zh-CN, ja, es, pt-BR)

## Test plan
- [ ] Open a Published Agent chat with existing sessions in the sidebar
- [ ] Click a session with many messages — verify a spinner with "Loading conversation..." appears instead of the empty state
- [ ] Verify messages render correctly after loading completes
- [ ] Check user message bubble color in both light and dark mode — should be a soft gray, not the old dark navy / bright white
- [ ] Switch language and verify the loading text is translated correctly

Closes #136