### PR TITLE
Fix i18n language flash on page load

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -32,7 +32,6 @@
         "date-fns": "^3.2.0",
         "geist": "^1.7.0",
         "i18next": "^25.8.0",
-        "i18next-resources-to-backend": "^1.2.1",
         "lucide-react": "^0.312.0",
         "next": "^14.2.0",
         "next-themes": "^0.4.6",
@@ -5131,15 +5130,6 @@
         }
       }
     },
-    "node_modules/i18next-resources-to-backend": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/i18next-resources-to-backend/-/i18next-resources-to-backend-1.2.1.tgz",
-      "integrity": "sha512-okHbVA+HZ7n1/76MsfhPqDou0fptl2dAlhRDu2ideXloRRduzHsqDOznJBef+R3DFZnbvWoBW+KxJ7fnFjd6Yw==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.23.2"
-      }
-    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -7005,6 +6995,7 @@
       "resolved": "https://registry.npmjs.org/next/-/next-14.2.35.tgz",
       "integrity": "sha512-KhYd2Hjt/O1/1aZVX3dCwGXM1QmOV4eNM2UTacK5gipDdPN/oHHK/4oVGy7X8GMfPMsUTUEmGlsy0EY1YGAkig==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "14.2.35",
         "@swc/helpers": "0.5.5",

--- a/web/package.json
+++ b/web/package.json
@@ -34,7 +34,6 @@
     "date-fns": "^3.2.0",
     "geist": "^1.7.0",
     "i18next": "^25.8.0",
-    "i18next-resources-to-backend": "^1.2.1",
     "lucide-react": "^0.312.0",
     "next": "^14.2.0",
     "next-themes": "^0.4.6",

--- a/web/src/app/providers.tsx
+++ b/web/src/app/providers.tsx
@@ -2,16 +2,12 @@
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ThemeProvider } from 'next-themes';
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { ChatProvider } from '@/components/chat/chat-provider';
-import { initI18next } from '@/i18n/client';
+// i18next is initialized synchronously on import — no useEffect needed
+import '@/i18n/client';
 
 export function Providers({ children }: { children: React.ReactNode }) {
-  // Initialize i18next on mount
-  useEffect(() => {
-    initI18next();
-  }, []);
-
   const [queryClient] = useState(
     () =>
       new QueryClient({

--- a/web/src/i18n/index.ts
+++ b/web/src/i18n/index.ts
@@ -14,6 +14,5 @@ export {
   useTranslation,
   changeLanguage,
   getCurrentLanguage,
-  initI18next,
   setLanguageCookie
 } from './client'

--- a/web/src/i18n/resources.ts
+++ b/web/src/i18n/resources.ts
@@ -1,0 +1,175 @@
+// Static imports of all translation JSON files (15 namespaces × 5 languages)
+// Bundled at build time for synchronous i18next initialization (no flash)
+
+// en-US
+import enCommon from './locales/en-US/common.json'
+import enHome from './locales/en-US/home.json'
+import enSkills from './locales/en-US/skills.json'
+import enAgents from './locales/en-US/agents.json'
+import enChat from './locales/en-US/chat.json'
+import enTools from './locales/en-US/tools.json'
+import enMcp from './locales/en-US/mcp.json'
+import enTraces from './locales/en-US/traces.json'
+import enFiles from './locales/en-US/files.json'
+import enSettings from './locales/en-US/settings.json'
+import enBackup from './locales/en-US/backup.json'
+import enExecutors from './locales/en-US/executors.json'
+import enImport from './locales/en-US/import.json'
+import enSessions from './locales/en-US/sessions.json'
+import enTerminal from './locales/en-US/terminal.json'
+
+// zh-CN
+import zhCommon from './locales/zh-CN/common.json'
+import zhHome from './locales/zh-CN/home.json'
+import zhSkills from './locales/zh-CN/skills.json'
+import zhAgents from './locales/zh-CN/agents.json'
+import zhChat from './locales/zh-CN/chat.json'
+import zhTools from './locales/zh-CN/tools.json'
+import zhMcp from './locales/zh-CN/mcp.json'
+import zhTraces from './locales/zh-CN/traces.json'
+import zhFiles from './locales/zh-CN/files.json'
+import zhSettings from './locales/zh-CN/settings.json'
+import zhBackup from './locales/zh-CN/backup.json'
+import zhExecutors from './locales/zh-CN/executors.json'
+import zhImport from './locales/zh-CN/import.json'
+import zhSessions from './locales/zh-CN/sessions.json'
+import zhTerminal from './locales/zh-CN/terminal.json'
+
+// ja
+import jaCommon from './locales/ja/common.json'
+import jaHome from './locales/ja/home.json'
+import jaSkills from './locales/ja/skills.json'
+import jaAgents from './locales/ja/agents.json'
+import jaChat from './locales/ja/chat.json'
+import jaTools from './locales/ja/tools.json'
+import jaMcp from './locales/ja/mcp.json'
+import jaTraces from './locales/ja/traces.json'
+import jaFiles from './locales/ja/files.json'
+import jaSettings from './locales/ja/settings.json'
+import jaBackup from './locales/ja/backup.json'
+import jaExecutors from './locales/ja/executors.json'
+import jaImport from './locales/ja/import.json'
+import jaSessions from './locales/ja/sessions.json'
+import jaTerminal from './locales/ja/terminal.json'
+
+// es
+import esCommon from './locales/es/common.json'
+import esHome from './locales/es/home.json'
+import esSkills from './locales/es/skills.json'
+import esAgents from './locales/es/agents.json'
+import esChat from './locales/es/chat.json'
+import esTools from './locales/es/tools.json'
+import esMcp from './locales/es/mcp.json'
+import esTraces from './locales/es/traces.json'
+import esFiles from './locales/es/files.json'
+import esSettings from './locales/es/settings.json'
+import esBackup from './locales/es/backup.json'
+import esExecutors from './locales/es/executors.json'
+import esImport from './locales/es/import.json'
+import esSessions from './locales/es/sessions.json'
+import esTerminal from './locales/es/terminal.json'
+
+// pt-BR
+import ptCommon from './locales/pt-BR/common.json'
+import ptHome from './locales/pt-BR/home.json'
+import ptSkills from './locales/pt-BR/skills.json'
+import ptAgents from './locales/pt-BR/agents.json'
+import ptChat from './locales/pt-BR/chat.json'
+import ptTools from './locales/pt-BR/tools.json'
+import ptMcp from './locales/pt-BR/mcp.json'
+import ptTraces from './locales/pt-BR/traces.json'
+import ptFiles from './locales/pt-BR/files.json'
+import ptSettings from './locales/pt-BR/settings.json'
+import ptBackup from './locales/pt-BR/backup.json'
+import ptExecutors from './locales/pt-BR/executors.json'
+import ptImport from './locales/pt-BR/import.json'
+import ptSessions from './locales/pt-BR/sessions.json'
+import ptTerminal from './locales/pt-BR/terminal.json'
+
+export const resources = {
+  'en-US': {
+    common: enCommon,
+    home: enHome,
+    skills: enSkills,
+    agents: enAgents,
+    chat: enChat,
+    tools: enTools,
+    mcp: enMcp,
+    traces: enTraces,
+    files: enFiles,
+    settings: enSettings,
+    backup: enBackup,
+    executors: enExecutors,
+    import: enImport,
+    sessions: enSessions,
+    terminal: enTerminal,
+  },
+  'zh-CN': {
+    common: zhCommon,
+    home: zhHome,
+    skills: zhSkills,
+    agents: zhAgents,
+    chat: zhChat,
+    tools: zhTools,
+    mcp: zhMcp,
+    traces: zhTraces,
+    files: zhFiles,
+    settings: zhSettings,
+    backup: zhBackup,
+    executors: zhExecutors,
+    import: zhImport,
+    sessions: zhSessions,
+    terminal: zhTerminal,
+  },
+  ja: {
+    common: jaCommon,
+    home: jaHome,
+    skills: jaSkills,
+    agents: jaAgents,
+    chat: jaChat,
+    tools: jaTools,
+    mcp: jaMcp,
+    traces: jaTraces,
+    files: jaFiles,
+    settings: jaSettings,
+    backup: jaBackup,
+    executors: jaExecutors,
+    import: jaImport,
+    sessions: jaSessions,
+    terminal: jaTerminal,
+  },
+  es: {
+    common: esCommon,
+    home: esHome,
+    skills: esSkills,
+    agents: esAgents,
+    chat: esChat,
+    tools: esTools,
+    mcp: esMcp,
+    traces: esTraces,
+    files: esFiles,
+    settings: esSettings,
+    backup: esBackup,
+    executors: esExecutors,
+    import: esImport,
+    sessions: esSessions,
+    terminal: esTerminal,
+  },
+  'pt-BR': {
+    common: ptCommon,
+    home: ptHome,
+    skills: ptSkills,
+    agents: ptAgents,
+    chat: ptChat,
+    tools: ptTools,
+    mcp: ptMcp,
+    traces: ptTraces,
+    files: ptFiles,
+    settings: ptSettings,
+    backup: ptBackup,
+    executors: ptExecutors,
+    import: ptImport,
+    sessions: ptSessions,
+    terminal: ptTerminal,
+  },
+} as const


### PR DESCRIPTION
## Summary

- Bundle all translation JSON files statically (15 namespaces × 5 languages) and initialize i18next synchronously at module level
- Eliminates the English flash that occurred on every page load for non-English users
- Remove `i18next-resources-to-backend` dependency (no longer needed)

Closes #138

## Changes

| File | Change |
|------|--------|
| `web/src/i18n/resources.ts` | **New** — static imports of all 75 translation JSON files |
| `web/src/i18n/client.ts` | Replace async `resourcesToBackend` with static `resources`; move `i18next.init()` to module level |
| `web/src/app/providers.tsx` | Remove `useEffect(() => initI18next())` — replaced by side-effect import |
| `web/src/i18n/index.ts` | Remove `initI18next` export (no longer exists) |
| `web/package.json` | Remove `i18next-resources-to-backend` dependency |

## Trade-off

All 5 languages (~60-80KB gzipped) are included in the client bundle. Acceptable for a dashboard app.

## Test plan

- [ ] `npm run build` passes without errors
- [ ] Set language to Chinese via switcher, hard refresh — no English flash
- [ ] Navigate between pages — correct language throughout
- [ ] Switch language and reload — persists correctly
- [ ] Default (no cookie) loads in English as expected