### PR TITLE
Fix: prevent Enter from sending message during IME composition

### DIFF
--- a/web/src/hooks/use-chat-engine.ts
+++ b/web/src/hooks/use-chat-engine.ts
@@ -444,7 +444,7 @@ export function useChatEngine(options: ChatEngineOptions): ChatEngineReturn {
   handleSubmitRef.current = handleSubmit;
 
   const handleKeyDown = React.useCallback((e: React.KeyboardEvent) => {
-    if (e.key === "Enter" && !e.shiftKey) {
+    if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing) {
       e.preventDefault();
       handleSubmit();
     }


### PR DESCRIPTION
## Summary

- Added `isComposing` check to `handleKeyDown` in `useChatEngine` hook to prevent Enter key from triggering message send during IME composition

Closes #142

## Test plan

- [ ] Open chat with a CJK IME (e.g. Chinese pinyin)
- [ ] Type pinyin (e.g. "pdf"), verify candidates appear
- [ ] Press Enter — should confirm the candidate word, NOT send the message
- [ ] Press Enter again — should send the message normally
- [ ] Verify Shift+Enter still creates a new line
- [ ] Verify non-IME Enter still sends immediately