### PR TITLE
feat: expand chat config panel by default with collapse toggle

### DIFF
--- a/web/src/app/chat/page.tsx
+++ b/web/src/app/chat/page.tsx
@@ -42,7 +42,7 @@ export default function FullscreenChatPage() {
 
   useChatSessionRestore();
 
-  const [showConfig, setShowConfig] = React.useState(false);
+  const [showConfig, setShowConfig] = React.useState(true);
   const [showToolsPanel, setShowToolsPanel] = React.useState(false);
   const [showResetDialog, setShowResetDialog] = React.useState(false);
 
@@ -118,14 +118,14 @@ export default function FullscreenChatPage() {
     },
   });
 
-  // Fetch data — defer skills/tools/MCP until config panel is open
-  const { data: skillsData } = useQuery({ queryKey: ["registry-skills-list"], queryFn: () => skillsApi.list(), enabled: showConfig });
+  // Fetch data
+  const { data: skillsData } = useQuery({ queryKey: ["registry-skills-list"], queryFn: () => skillsApi.list() });
   const skills = (skillsData?.skills || []).filter(s => s.skill_type === 'user');
 
   const { data: toolsData } = useQuery({ queryKey: ["tools-list"], queryFn: () => toolsApi.list() });
   const tools = toolsData?.tools || [];
 
-  const { data: mcpData } = useQuery({ queryKey: ["mcp-servers"], queryFn: () => mcpApi.listServers(), enabled: showConfig });
+  const { data: mcpData } = useQuery({ queryKey: ["mcp-servers"], queryFn: () => mcpApi.listServers() });
   const mcpServers = mcpData?.servers || [];
 
   const { data: agentPresetsData, isLoading: isLoadingAgents } = useQuery({ queryKey: ["agent-presets-user"], queryFn: () => agentPresetsApi.list({ is_system: false }) });
@@ -245,10 +245,11 @@ export default function FullscreenChatPage() {
             variant={showConfig ? "default" : "outline"}
             size="sm"
             onClick={() => setShowConfig(!showConfig)}
-            title={t('config')}
+            title={showConfig ? t('hideConfig') : t('showConfig')}
           >
             <Settings className="h-4 w-4 mr-1" />
             {t('config')}
+            {showConfig ? <ChevronUp className="h-3.5 w-3.5 ml-1" /> : <ChevronDown className="h-3.5 w-3.5 ml-1" />}
           </Button>
           <Button variant="outline" size="sm" onClick={() => newSession()} disabled={messages.length === 0 || isRunning} title={t('newChat')}>
             <Plus className="h-4 w-4 mr-1" />

--- a/web/src/components/chat/chat-panel.tsx
+++ b/web/src/components/chat/chat-panel.tsx
@@ -77,7 +77,7 @@ export function ChatPanel({ isOpen, onClose, defaultSkills = [] }: ChatPanelProp
   // Restore session messages from server on mount
   useChatSessionRestore();
 
-  const [showConfigPanel, setShowConfigPanel] = React.useState(false);
+  const [showConfigPanel, setShowConfigPanel] = React.useState(true);
   const [showToolsPanel, setShowToolsPanel] = React.useState(false);
   const [showResetDialog, setShowResetDialog] = React.useState(false);
 
@@ -317,10 +317,11 @@ export function ChatPanel({ isOpen, onClose, defaultSkills = [] }: ChatPanelProp
           variant="ghost"
           size="sm"
           onClick={() => setShowConfigPanel(!showConfigPanel)}
-          className={`h-6 w-6 p-0 shrink-0 ${showConfigPanel ? 'text-primary' : ''}`}
-          title={t('config')}
+          className={`h-6 px-1 py-0 shrink-0 flex items-center gap-0.5 ${showConfigPanel ? 'text-primary' : ''}`}
+          title={showConfigPanel ? t('hideConfig') : t('showConfig')}
         >
           <Settings className="h-3.5 w-3.5" />
+          {showConfigPanel ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}
         </Button>
       </div>
 

--- a/web/src/i18n/locales/en-US/chat.json
+++ b/web/src/i18n/locales/en-US/chat.json
@@ -19,6 +19,8 @@
   "manage": "Manage",
   "home": "Home",
   "config": "Config",
+  "showConfig": "Show config",
+  "hideConfig": "Hide config",
   "startConversation": "Start a conversation",
   "typeMessageToBegin": "Type a message below to begin chatting with the agent.",
   "clickConfigToCustomize": "Click Config above to customize settings.",

--- a/web/src/i18n/locales/es/chat.json
+++ b/web/src/i18n/locales/es/chat.json
@@ -19,6 +19,8 @@
   "manage": "Gestionar",
   "home": "Inicio",
   "config": "Configurar",
+  "showConfig": "Mostrar configuración",
+  "hideConfig": "Ocultar configuración",
   "startConversation": "Iniciar una conversación",
   "typeMessageToBegin": "Escribe un mensaje abajo para comenzar a chatear con el agente.",
   "clickConfigToCustomize": "Haz clic en Configurar arriba para personalizar los ajustes.",

--- a/web/src/i18n/locales/ja/chat.json
+++ b/web/src/i18n/locales/ja/chat.json
@@ -19,6 +19,8 @@
   "manage": "管理",
   "home": "ホーム",
   "config": "設定",
+  "showConfig": "設定を表示",
+  "hideConfig": "設定を非表示",
   "startConversation": "会話を開始",
   "typeMessageToBegin": "下にメッセージを入力してエージェントとのチャットを開始してください。",
   "clickConfigToCustomize": "上の設定をクリックしてカスタマイズしてください。",

--- a/web/src/i18n/locales/pt-BR/chat.json
+++ b/web/src/i18n/locales/pt-BR/chat.json
@@ -19,6 +19,8 @@
   "manage": "Gerenciar",
   "home": "Início",
   "config": "Configurar",
+  "showConfig": "Mostrar configuração",
+  "hideConfig": "Ocultar configuração",
   "startConversation": "Iniciar uma conversa",
   "typeMessageToBegin": "Digite uma mensagem abaixo para começar a conversar com o agente.",
   "clickConfigToCustomize": "Clique em Configurar acima para personalizar as configurações.",

--- a/web/src/i18n/locales/zh-CN/chat.json
+++ b/web/src/i18n/locales/zh-CN/chat.json
@@ -19,6 +19,8 @@
   "manage": "管理",
   "home": "首页",
   "config": "配置",
+  "showConfig": "显示配置",
+  "hideConfig": "隐藏配置",
   "startConversation": "开始对话",
   "typeMessageToBegin": "在下方输入消息开始与 Agent 对话。",
   "clickConfigToCustomize": "点击上方 配置 按钮自定义设置。",


### PR DESCRIPTION
## Summary
- Change chat config panel default state from collapsed to expanded (both floating panel and fullscreen `/chat` page)
- Add ChevronUp/Down chevron indicator to the Settings toggle button for clear collapse/expand affordance
- Add dynamic tooltip that switches between "Show config" / "Hide config"
- Add i18n keys (`showConfig`, `hideConfig`) for all 5 languages

## Test plan
- [ ] Open floating chat panel → config section should be visible by default
- [ ] Open `/chat` fullscreen page → config section should be visible by default
- [ ] Click Settings button → config collapses, chevron flips to ChevronDown
- [ ] Click again → config expands, chevron flips to ChevronUp
- [ ] Hover on button → tooltip shows "Hide config" when expanded, "Show config" when collapsed
- [ ] Verify all 5 languages display correct tooltip text

Closes #144