### PR TITLE
fix: catch specific exceptions for JSON tool call argument parsing

### DIFF
--- a/app/llm/provider.py
+++ b/app/llm/provider.py
@@ -376,7 +376,7 @@ class LLMClient:
                 for tc in message.tool_calls:
                     try:
                         args = json.loads(tc.function.arguments)
-                    except:
+                    except (json.JSONDecodeError, TypeError):
                         args = {}
 
                     content.append(LLMToolCall(
@@ -671,7 +671,7 @@ class LLMClient:
         for tc_data in accumulated_tool_calls.values():
             try:
                 args = json.loads(tc_data["arguments"])
-            except:
+            except (json.JSONDecodeError, TypeError):
                 args = {}
 
             content.append(LLMToolCall(
@@ -885,7 +885,7 @@ class LLMClient:
         for tc_data in accumulated_tool_calls.values():
             try:
                 args = json.loads(tc_data["arguments"])
-            except:
+            except (json.JSONDecodeError, TypeError):
                 args = {}
             content.append(LLMToolCall(
                 id=tc_data["id"],


### PR DESCRIPTION
## Problem

Three sites in `app/llm/provider.py` use bare `except:` when parsing tool call arguments with `json.loads()`. This catches `BaseException` including `SystemExit` and `KeyboardInterrupt`, which can prevent clean shutdown.

## Fix

Replace `except:` with `except (json.JSONDecodeError, TypeError):` — the two exception types that `json.loads()` actually raises on invalid input.

## Locations

- Line 379: Parsing tool calls from non-streaming response
- Line 674: Parsing accumulated tool calls from streaming response  
- Line 888: Parsing accumulated tool calls from streaming response (alternate path)