### PR TITLE
Replace pgvector/pgvector:pg16 with standard postgres:16

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,7 +57,7 @@ GEMINI_API_KEY=
 UNSTRUCTURED_API_KEY=
 
 # ------------------------------------------------------------------------------
-# Database Configuration (PostgreSQL + pgvector)
+# Database Configuration (PostgreSQL)
 # ------------------------------------------------------------------------------
 DB_USER=skills
 DB_PASSWORD=skills123

--- a/app/db/database.py
+++ b/app/db/database.py
@@ -108,8 +108,6 @@ async def init_db():
     from sqlalchemy import text
 
     async with engine.begin() as conn:
-        # Enable pgvector extension
-        await conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
         await conn.run_sync(Base.metadata.create_all)
 
     # Run migrations for existing databases
@@ -127,6 +125,9 @@ async def _run_migrations():
     from sqlalchemy import text
 
     async with engine.begin() as conn:
+        # Remove unused pgvector extension (migrated to plain postgres:16)
+        await conn.execute(text("DROP EXTENSION IF EXISTS vector"))
+
         # Safely add columns using DO blocks (ignores duplicate_column errors)
         await conn.execute(text("""
             DO $$ BEGIN

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -19,7 +19,7 @@ GEMINI_API_KEY=
 UNSTRUCTURED_API_KEY=
 
 # ------------------------------------------------------------------------------
-# Database Configuration (PostgreSQL + pgvector)
+# Database Configuration (PostgreSQL)
 # ------------------------------------------------------------------------------
 DB_USER=skills
 DB_PASSWORD=skills123

--- a/docker/db/init-test-db.sql
+++ b/docker/db/init-test-db.sql
@@ -5,6 +5,5 @@
 SELECT 'CREATE DATABASE skills_api_test OWNER skills'
 WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'skills_api_test')\gexec
 
--- Connect to test database and enable pgvector extension
+-- Connect to test database
 \c skills_api_test
-CREATE EXTENSION IF NOT EXISTS vector;

--- a/docker/docker-compose.dev.yaml
+++ b/docker/docker-compose.dev.yaml
@@ -21,10 +21,10 @@ name: skills-api
 
 services:
   # ============================================================================
-  # Database Service - PostgreSQL + pgvector
+  # Database Service - PostgreSQL
   # ============================================================================
   db:
-    image: pgvector/pgvector:pg16  # PostgreSQL 16 with pgvector extension pre-installed
+    image: postgres:16
     container_name: skills-db
     restart: unless-stopped
     environment:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -24,10 +24,10 @@ name: skills-api
 
 services:
   # ============================================================================
-  # Database Service - PostgreSQL + pgvector
+  # Database Service - PostgreSQL
   # ============================================================================
   db:
-    image: pgvector/pgvector:pg16
+    image: postgres:16
     container_name: skills-db
     restart: unless-stopped
     environment:

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,11 +24,10 @@ duckduckgo-search>=6.0.0
 # MCP (Model Context Protocol) support
 mcp>=1.0.0
 
-# Database (PostgreSQL + pgvector)
+# Database (PostgreSQL)
 sqlalchemy[asyncio]>=2.0.0
 asyncpg>=0.29.0
 psycopg2-binary>=2.9.0
-pgvector>=0.3.0
 aiosqlite>=0.20.0
 
 # Schema validation

--- a/tests/README.md
+++ b/tests/README.md
@@ -74,15 +74,13 @@ Production: postgresql+asyncpg://skills:skills123@localhost:62620/skills_api
 Test:       postgresql+asyncpg://skills:skills123@localhost:62620/skills_api_test
 ```
 
-pgvector extension is also enabled in the test database to ensure full ORM model compatibility.
-
 ### Test Isolation Strategy
 
 Each test case runs independently without interference:
 
 ```
 Test starts
-  → CREATE EXTENSION IF NOT EXISTS vector
+
   → Base.metadata.create_all()     # Create tables
   → Run test
   → Base.metadata.drop_all()       # Drop tables
@@ -222,4 +220,3 @@ markers = ["slow: slow tests"]
 1. **Streaming tests use mock session**: `/agent/run/stream` endpoint directly uses `AsyncSessionLocal`, tests use mock replacement, actual trace writing not verified
 2. **E2E tests require running services**: Playwright tests need frontend and backend services running on localhost:62600/62610
 3. **No real LLM calls**: All Agent tests mock Claude API, actual LLM interaction quality not verified
-4. **pgvector features not deeply tested**: Vector search related features not covered in unit tests

--- a/tests/TESTING_GUIDE.md
+++ b/tests/TESTING_GUIDE.md
@@ -22,7 +22,7 @@ Developer-oriented testing operations guide, including environment setup, runnin
 ### 1.1 Prerequisites
 
 - Python 3.10+
-- Docker (for PostgreSQL + pgvector)
+- Docker (for PostgreSQL)
 - Node.js 18+ (only needed for E2E tests)
 
 ### 1.2 Install Test Dependencies
@@ -52,8 +52,6 @@ cd docker && docker compose up -d db
 # Create test database
 docker exec skills-db psql -U skills -d postgres -c "CREATE DATABASE skills_api_test OWNER skills;"
 
-# Enable pgvector extension
-docker exec skills-db psql -U skills -d skills_api_test -c "CREATE EXTENSION IF NOT EXISTS vector;"
 ```
 
 ### 1.4 Verify Environment
@@ -494,7 +492,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: pgvector/pgvector:pg16
+        image: postgres:16
         env:
           POSTGRES_USER: skills
           POSTGRES_PASSWORD: skills123
@@ -517,11 +515,6 @@ jobs:
         run: |
           pip install -e ".[dev]"
           pip install pytest-cov
-
-      - name: Enable pgvector
-        run: |
-          PGPASSWORD=skills123 psql -h localhost -U skills -d skills_api_test \
-            -c "CREATE EXTENSION IF NOT EXISTS vector;"
 
       - name: Run tests
         env:
@@ -576,16 +569,6 @@ asyncpg.InvalidCatalogNameError: database "skills_api_test" does not exist
 ```bash
 bash tests/scripts/setup_test_db.sh
 ```
-
-### 8.3 pgvector Extension Issue
-
-```
-sqlalchemy.exc.ProgrammingError: extension "vector" is not available
-```
-
-**Cause**: Docker image doesn't include pgvector.
-
-**Solution**: Ensure you're using `pgvector/pgvector:pg16` image instead of plain `postgres` image.
 
 ### 8.4 Event Loop Conflict
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@
 Root test configuration.
 
 Sets up:
-- PostgreSQL test database (skills_api_test) with pgvector
+- PostgreSQL test database (skills_api_test)
 - AsyncClient for FastAPI testing
 - Database session fixtures with per-test table creation/teardown
 - Lifespan is skipped in tests (no init_db / filesystem sync)
@@ -21,7 +21,7 @@ import pytest_asyncio
 # Auto-create test database if it doesn't exist (runs once per session)
 # ---------------------------------------------------------------------------
 def _ensure_test_database():
-    """Create skills_api_test database + pgvector extension if missing.
+    """Create skills_api_test database if missing.
 
     Uses psycopg2 (sync) to connect to the default 'postgres' database and
     create the test DB.  This runs before any async engine is created.
@@ -39,16 +39,6 @@ def _ensure_test_database():
         cur.execute("CREATE DATABASE skills_api_test OWNER skills")
     cur.close()
     conn.close()
-
-    # Enable pgvector in the test database
-    conn2 = psycopg2.connect(
-        host="localhost", port=62620, user="skills", password="skills123", dbname="skills_api_test",
-    )
-    conn2.set_isolation_level(ISOLATION_LEVEL_AUTOCOMMIT)
-    cur2 = conn2.cursor()
-    cur2.execute("CREATE EXTENSION IF NOT EXISTS vector")
-    cur2.close()
-    conn2.close()
 
 
 # Run at import time (before any fixture or test)
@@ -145,7 +135,6 @@ async def db_session():
     )
 
     async with engine.begin() as conn:
-        await conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
         await conn.run_sync(Base.metadata.create_all)
 
     session = async_sessionmaker(

--- a/tests/scripts/setup_test_db.sh
+++ b/tests/scripts/setup_test_db.sh
@@ -22,8 +22,5 @@ docker exec -i "$DB_CONTAINER" psql -U "$DB_USER" -d postgres -c \
 docker exec -i "$DB_CONTAINER" psql -U "$DB_USER" -d postgres -c \
     "CREATE DATABASE ${DB_NAME} OWNER ${DB_USER};"
 
-docker exec -i "$DB_CONTAINER" psql -U "$DB_USER" -d "$DB_NAME" -c \
-    "CREATE EXTENSION IF NOT EXISTS vector;"
-
 echo "Test database '${DB_NAME}' is ready."
 echo "Connection string: postgresql+asyncpg://${DB_USER}:${DB_PASSWORD}@localhost:5432/${DB_NAME}"

--- a/tests/test_api/test_sessions.py
+++ b/tests/test_api/test_sessions.py
@@ -51,7 +51,6 @@ async def session_env():
     engine = create_async_engine(TEST_DATABASE_URL, echo=False, pool_size=3)
 
     async with engine.begin() as conn:
-        await conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
         await conn.run_sync(Base.metadata.create_all)
 
     factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)

--- a/tests/test_e2e/conftest.py
+++ b/tests/test_e2e/conftest.py
@@ -140,7 +140,6 @@ async def e2e_db_session():
     )
 
     async with engine.begin() as conn:
-        await conn.execute(text("CREATE EXTENSION IF NOT EXISTS vector"))
         await conn.run_sync(Base.metadata.create_all)
 
     session_factory = async_sessionmaker(


### PR DESCRIPTION
## Summary
- Switch Docker image from `pgvector/pgvector:pg16` to `postgres:16` for broader cloud platform compatibility
- Remove unused `pgvector` Python package and all `CREATE EXTENSION IF NOT EXISTS vector` statements
- Add `DROP EXTENSION IF EXISTS vector` migration for backward compatibility with existing deployments

## Changes (13 files)
- **Docker**: `docker-compose.yaml`, `docker-compose.dev.yaml` — image `postgres:16`
- **Python deps**: `requirements.txt` — remove `pgvector>=0.3.0`
- **DB init**: `database.py` — remove extension creation, add cleanup migration
- **Tests**: `conftest.py`, `test_e2e/conftest.py`, `test_api/test_sessions.py` — remove extension setup
- **Scripts**: `init-test-db.sql`, `setup_test_db.sh` — remove extension commands
- **Docs**: `README.md`, `TESTING_GUIDE.md`, `.env.example` files — update references

## Backward compatibility
Existing deployments that had `vector` extension installed will have it cleanly dropped on next startup via the migration in `_run_migrations()`. No data loss since no Vector columns were ever created.

Closes #149