### PR TITLE
Fix: allow unauthenticated file output download

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -139,6 +139,7 @@ _PUBLIC_PATHS = (
     "/api/v1/auth/refresh",
     "/api/v1/auth/status",
     "/api/v1/published/",
+    "/api/v1/files/output/download",
 )
 
 


### PR DESCRIPTION
## Summary

- Add `/api/v1/files/output/download` to `_PUBLIC_PATHS` in `AuthMiddleware`, allowing unauthenticated access to output file downloads

## Problem

Published agent users have no auth token. When the agent generates output files (images, HTML, etc.), the download URL `/api/v1/files/output/download?path=...` is blocked by `AuthMiddleware` returning 401. Additionally, `<img src>`, `<iframe src>` etc. don't carry `Authorization` headers, so inline media may fail even for authenticated users.

## Fix

One-line addition to `_PUBLIC_PATHS`. The endpoint already has its own security:
- Path allowlist (`/app/workspaces/`, `/tmp/agent_workspaces/`, uploads, project dir)
- Path traversal protection (`Path.resolve()` + `startswith()`)

## Test plan

- [ ] Published agent: generate an image/HTML output → verify inline display and download work
- [ ] Authenticated chat: verify inline images/HTML still render correctly
- [ ] Verify direct access to disallowed paths still returns 403