### PR TITLE
Add language switcher to published agent page

### DIFF
--- a/web/src/app/published/[id]/page.tsx
+++ b/web/src/app/published/[id]/page.tsx
@@ -18,6 +18,7 @@ import { sessionMessagesToChatMessages } from "@/lib/session-utils";
 import { SessionSidebar } from "@/components/published/session-sidebar";
 import { useQueryClient } from "@tanstack/react-query";
 import { publishedSessionKeys } from "@/hooks/use-published-sessions";
+import { LanguageSwitcher } from "@/components/layout/language-switcher";
 
 type LocalMessage = ChatMessage;
 
@@ -297,6 +298,7 @@ export default function PublishedChatPage() {
             {agentDescription && <p className="text-sm text-muted-foreground truncate">{agentDescription}</p>}
           </div>
           <SessionIdBadge sessionId={sessionId} label={t('published.sessionId')} copiedText={t('published.sessionIdCopied')} />
+          <LanguageSwitcher />
           <Button variant="outline" size="sm" onClick={handleNewChat} disabled={isRunning} title={t('newChat')}>
             <MessageSquarePlus className="h-4 w-4 sm:mr-1" />
             <span className="hidden sm:inline">{t('newChat')}</span>


### PR DESCRIPTION
## Summary

- Add `LanguageSwitcher` component to the published agent page's custom header, between the session ID badge and "New Chat" button
- Users on `/published/[id]` can now switch languages via the globe icon

Closes #157

## Test plan

- [ ] Open a published agent page
- [ ] Verify the globe icon appears in the header bar
- [ ] Click the globe icon and switch languages
- [ ] Verify the page reloads with the selected language applied
- [ ] Verify language persists on page refresh