### PR TITLE
fix: store session display messages in ChatMessage format

### DIFF
--- a/app/agent/agent.py
+++ b/app/agent/agent.py
@@ -1468,6 +1468,17 @@ class SkillsAgent:
                             }
                         ))
 
+                    # Add tool_results for any remaining tool_use blocks in the same
+                    # assistant message so the conversation history stays valid (every
+                    # tool_use must have a matching tool_result).
+                    current_idx = tool_calls.index(tool_call)
+                    for remaining in tool_calls[current_idx + 1:]:
+                        tool_results.append({
+                            "type": "tool_result",
+                            "tool_use_id": remaining["id"],
+                            "content": json.dumps({"status": "skipped", "reason": "ask_user interrupted"}),
+                        })
+
                     # Append tool_result to messages
                     messages.append({"role": "user", "content": tool_results})
                     # Append synthetic assistant message to maintain alternating roles in session

--- a/app/api/v1/display_builder.py
+++ b/app/api/v1/display_builder.py
@@ -1,0 +1,207 @@
+"""DisplayMessageBuilder — accumulates SSE events into ChatMessage[] format.
+
+The session `messages` column is purely for frontend display.  This builder
+maps backend streaming events to the frontend StreamEventRecord format so
+that refreshing the page renders identically to the live stream.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+
+class DisplayMessageBuilder:
+    """Accumulates streaming events into ChatMessage[] format for session display storage."""
+
+    def __init__(self):
+        self._messages: list = []           # Finalized ChatMessage dicts
+        self._current_events: list = []     # StreamEventRecords for current assistant
+        self._text_buffer: str = ""         # Accumulate text_delta chunks
+
+    def add_user_message(self, content: str, uploaded_files=None):
+        """Add user message with clean text + optional attachedFiles metadata."""
+        self._flush_assistant()
+        msg: dict = {"role": "user", "content": content}
+        if uploaded_files:
+            msg["attachedFiles"] = [
+                {"file_id": f.file_id, "filename": f.filename}
+                for f in uploaded_files
+            ]
+        self._messages.append(msg)
+
+    def add_event(self, event_type: str, turn: int, data: dict):
+        """Map a backend SSE event to a StreamEventRecord and accumulate."""
+        # Skip non-display events (but NOT text_delta — we accumulate those)
+        if event_type in ("run_started", "trace_saved", "heartbeat",
+                          "turn_complete", "context_compressed"):
+            return
+
+        # Accumulate text_delta chunks into buffer
+        if event_type == "text_delta":
+            self._text_buffer += data.get("text", "")
+            return
+
+        # Flush accumulated text as an assistant record before processing
+        # boundary events (tool_call, tool_result, turn_start, complete, etc.)
+        self._flush_text_buffer()
+
+        record = self._map_to_record(event_type, turn, data)
+        if record:
+            self._current_events.append(record)
+
+    def _map_to_record(self, event_type: str, turn: int, data: dict) -> Optional[dict]:
+        """Map backend event -> frontend StreamEventRecord (without id/timestamp)."""
+        if event_type == "turn_start":
+            return {"type": "turn_start", "data": {"turn": turn, "maxTurns": data.get("max_turns", 0)}}
+        elif event_type == "assistant":
+            content = data.get("content", "")
+            if not content:
+                return None
+            return {"type": "assistant", "data": {
+                "content": content,
+                "inputTokens": data.get("input_tokens"),
+                "outputTokens": data.get("output_tokens"),
+            }}
+        elif event_type == "tool_call":
+            return {"type": "tool_call", "data": {
+                "toolName": data.get("tool_name", ""),
+                "toolInput": data.get("tool_input"),
+            }}
+        elif event_type == "tool_result":
+            return {"type": "tool_result", "data": {
+                "toolName": data.get("tool_name", ""),
+                "toolResult": data.get("tool_result", ""),
+                "success": not data.get("is_error", False),
+            }}
+        elif event_type == "output_file":
+            return {"type": "output_file", "data": {
+                "fileId": data.get("file_id", ""),
+                "filename": data.get("filename", ""),
+                "size": data.get("size", 0),
+                "contentType": data.get("content_type", ""),
+                "downloadUrl": data.get("download_url", ""),
+                "description": data.get("description"),
+            }}
+        elif event_type == "ask_user":
+            return {"type": "ask_user", "data": {
+                "promptId": data.get("prompt_id", ""),
+                "question": data.get("question", ""),
+                "options": data.get("options"),
+            }}
+        elif event_type == "complete":
+            return {"type": "complete", "data": {
+                "success": data.get("success", False),
+                "answer": data.get("answer"),
+                "totalTurns": data.get("total_turns", 0),
+                "totalInputTokens": data.get("total_input_tokens"),
+                "totalOutputTokens": data.get("total_output_tokens"),
+            }}
+        elif event_type == "error":
+            return {"type": "error", "data": {
+                "message": data.get("message", data.get("error", "")),
+            }}
+        elif event_type == "steering_received":
+            return {"type": "steering_received", "data": {
+                "message": data.get("message", ""),
+            }}
+        return None
+
+    def _flush_text_buffer(self):
+        """Flush accumulated text_delta chunks as an assistant StreamEventRecord."""
+        if self._text_buffer:
+            self._current_events.append({"type": "assistant", "data": {
+                "content": self._text_buffer,
+            }})
+            self._text_buffer = ""
+
+    def _flush_assistant(self):
+        """Flush accumulated events as an assistant ChatMessage."""
+        self._flush_text_buffer()
+        if self._current_events:
+            self._messages.append({
+                "role": "assistant",
+                "content": "",
+                "streamEvents": self._current_events,
+            })
+            self._current_events = []
+
+    def get_messages(self) -> list:
+        """Get finalized display messages (flushes current assistant).
+
+        This is a finalizing call — it flushes pending events into an assistant
+        message.  Safe to call multiple times (idempotent after flush), but do
+        NOT call add_event() after get_messages() and expect those events to
+        merge into the same assistant block.
+        """
+        self._flush_assistant()
+        return list(self._messages)
+
+    def get_snapshot(self) -> list:
+        """Get current state including in-progress assistant (for checkpoints)."""
+        result = list(self._messages)
+        # Include both accumulated events and any buffered text
+        pending_events = list(self._current_events)
+        if self._text_buffer:
+            pending_events.append({"type": "assistant", "data": {
+                "content": self._text_buffer,
+            }})
+        if pending_events:
+            result.append({
+                "role": "assistant",
+                "content": "",
+                "streamEvents": pending_events,
+            })
+        return result
+
+    @classmethod
+    def from_agent_result(cls, result, request_text: str, uploaded_files=None) -> "DisplayMessageBuilder":
+        """Build display messages from a non-streaming AgentResult.
+
+        NOTE: This builds StreamEventRecords directly (bypassing add_event /
+        _map_to_record) because AgentResult.steps have a different shape than
+        live SSE events.  If new event types are added to _map_to_record, they
+        won't automatically appear here — update both paths.
+        """
+        builder = cls()
+        builder.add_user_message(request_text, uploaded_files)
+        # Build events from result.steps
+        for step in (result.steps or []):
+            if step.tool_name == "ask_user":
+                builder._current_events.append({"type": "tool_call", "data": {
+                    "toolName": "ask_user",
+                    "toolInput": step.tool_input,
+                }})
+                builder._current_events.append({"type": "ask_user", "data": {
+                    "promptId": "",
+                    "question": (step.tool_input or {}).get("question", ""),
+                    "options": (step.tool_input or {}).get("options"),
+                }})
+            elif step.tool_name:
+                # AgentStep doesn't carry an is_error flag, so infer failure
+                # from the step content containing common error markers.
+                content = step.content or ""
+                is_error = (
+                    step.role == "tool"
+                    and content.lstrip().startswith(("{\"error\"", "Error:", "Traceback"))
+                )
+                builder._current_events.append({"type": "tool_call", "data": {
+                    "toolName": step.tool_name,
+                    "toolInput": step.tool_input,
+                }})
+                builder._current_events.append({"type": "tool_result", "data": {
+                    "toolName": step.tool_name,
+                    "toolResult": (content[:5000] if content else ""),
+                    "success": not is_error,
+                }})
+            elif step.content:
+                builder._current_events.append({"type": "assistant", "data": {
+                    "content": step.content,
+                }})
+        # Add complete event
+        builder._current_events.append({"type": "complete", "data": {
+            "success": result.success,
+            "answer": result.answer,
+            "totalTurns": result.total_turns,
+            "totalInputTokens": result.total_input_tokens,
+            "totalOutputTokens": result.total_output_tokens,
+        }})
+        return builder

--- a/tests/test_api/test_display_builder.py
+++ b/tests/test_api/test_display_builder.py
@@ -1,0 +1,667 @@
+"""
+Unit tests for DisplayMessageBuilder (app/api/v1/display_builder.py).
+
+Tests the conversion of streaming SSE events into ChatMessage[] format
+for session display storage.
+"""
+from dataclasses import dataclass, field
+from typing import Optional, List
+
+import pytest
+
+from app.api.v1.display_builder import DisplayMessageBuilder
+
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+@dataclass
+class FakeUploadedFile:
+    file_id: str
+    filename: str
+    path: str = ""
+    content_type: str = ""
+
+
+@dataclass
+class FakeStep:
+    role: str
+    content: str
+    tool_name: Optional[str] = None
+    tool_input: Optional[dict] = None
+
+
+@dataclass
+class FakeResult:
+    success: bool = True
+    answer: str = "Done"
+    total_turns: int = 1
+    total_input_tokens: int = 100
+    total_output_tokens: int = 50
+    steps: Optional[list] = None
+    skills_used: Optional[list] = None
+
+
+# ── Basic builder tests ──────────────────────────────────────────────
+
+
+class TestDisplayMessageBuilderBasic:
+
+    def test_empty_builder(self):
+        """Empty builder returns empty list."""
+        b = DisplayMessageBuilder()
+        assert b.get_messages() == []
+
+    def test_user_message_only(self):
+        """User message without files."""
+        b = DisplayMessageBuilder()
+        b.add_user_message("Hello")
+        msgs = b.get_messages()
+        assert len(msgs) == 1
+        assert msgs[0] == {"role": "user", "content": "Hello"}
+
+    def test_user_message_with_files(self):
+        """User message with uploaded files produces attachedFiles."""
+        files = [
+            FakeUploadedFile(file_id="f1", filename="data.csv"),
+            FakeUploadedFile(file_id="f2", filename="image.png"),
+        ]
+        b = DisplayMessageBuilder()
+        b.add_user_message("Analyze this", files)
+        msgs = b.get_messages()
+        assert len(msgs) == 1
+        assert msgs[0]["role"] == "user"
+        assert msgs[0]["content"] == "Analyze this"
+        assert msgs[0]["attachedFiles"] == [
+            {"file_id": "f1", "filename": "data.csv"},
+            {"file_id": "f2", "filename": "image.png"},
+        ]
+
+    def test_user_message_no_files_no_attached(self):
+        """User message with uploaded_files=None has no attachedFiles key."""
+        b = DisplayMessageBuilder()
+        b.add_user_message("Hi", None)
+        msgs = b.get_messages()
+        assert "attachedFiles" not in msgs[0]
+
+    def test_user_message_empty_files_no_attached(self):
+        """User message with uploaded_files=[] has no attachedFiles key."""
+        b = DisplayMessageBuilder()
+        b.add_user_message("Hi", [])
+        msgs = b.get_messages()
+        assert "attachedFiles" not in msgs[0]
+
+
+class TestDisplayMessageBuilderEvents:
+
+    def test_turn_start_event(self):
+        """turn_start is mapped correctly."""
+        b = DisplayMessageBuilder()
+        b.add_user_message("Hi")
+        b.add_event("turn_start", 1, {"max_turns": 10})
+        msgs = b.get_messages()
+        assert len(msgs) == 2
+        evt = msgs[1]["streamEvents"][0]
+        assert evt["type"] == "turn_start"
+        assert evt["data"]["turn"] == 1
+        assert evt["data"]["maxTurns"] == 10
+
+    def test_assistant_event(self):
+        """assistant event maps content."""
+        b = DisplayMessageBuilder()
+        b.add_user_message("Hi")
+        b.add_event("assistant", 1, {"content": "Hello!", "input_tokens": 50, "output_tokens": 10})
+        msgs = b.get_messages()
+        evt = msgs[1]["streamEvents"][0]
+        assert evt["type"] == "assistant"
+        assert evt["data"]["content"] == "Hello!"
+        assert evt["data"]["inputTokens"] == 50
+        assert evt["data"]["outputTokens"] == 10
+
+    def test_assistant_empty_content_skipped(self):
+        """assistant event with empty content is skipped."""
+        b = DisplayMessageBuilder()
+        b.add_user_message("Hi")
+        b.add_event("assistant", 1, {"content": ""})
+        msgs = b.get_messages()
+        assert len(msgs) == 1  # Only user, no assistant
+
+    def test_tool_call_event(self):
+        """tool_call maps toolName and toolInput."""
+        b = DisplayMessageBuilder()
+        b.add_user_message("Hi")
+        b.add_event("tool_call", 1, {"tool_name": "bash", "tool_input": {"command": "ls"}})
+        msgs = b.get_messages()
+        evt = msgs[1]["streamEvents"][0]
+        assert evt["type"] == "tool_call"
+        assert evt["data"]["toolName"] == "bash"
+        assert evt["data"]["toolInput"] == {"command": "ls"}
+
+    def test_tool_result_event(self):
+        """tool_result maps success flag correctly."""
+        b = DisplayMessageBuilder()
+        b.add_user_message("Hi")
+        b.add_event("tool_result", 1, {"tool_name": "bash", "tool_result": "file.txt", "is_error": False})
+        msgs = b.get_messages()
+        evt = msgs[1]["streamEvents"][0]
+        assert evt["type"] == "tool_result"
+        assert evt["data"]["toolName"] == "bash"
+        assert evt["data"]["toolResult"] == "file.txt"
+        assert evt["data"]["success"] is True
+
+    def test_tool_result_error(self):
+        """tool_result with is_error=True produces success=False."""
+        b = DisplayMessageBuilder()
+        b.add_user_message("Hi")
+        b.add_event("tool_result", 1, {"tool_name": "bash", "tool_result": "error", "is_error": True})
+        msgs = b.get_messages()
+        evt = msgs[1]["streamEvents"][0]
+        assert evt["data"]["success"] is False
+
+    def test_output_file_event(self):
+        """output_file maps all fields."""
+        b = DisplayMessageBuilder()
+        b.add_user_message("Hi")
+        b.add_event("output_file", 1, {
+            "file_id": "uuid1", "filename": "chart.png", "size": 1024,
+            "content_type": "image/png", "download_url": "/download/uuid1",
+            "description": "A chart",
+        })
+        msgs = b.get_messages()
+        evt = msgs[1]["streamEvents"][0]
+        assert evt["type"] == "output_file"
+        assert evt["data"]["fileId"] == "uuid1"
+        assert evt["data"]["filename"] == "chart.png"
+        assert evt["data"]["size"] == 1024
+        assert evt["data"]["contentType"] == "image/png"
+        assert evt["data"]["downloadUrl"] == "/download/uuid1"
+        assert evt["data"]["description"] == "A chart"
+
+    def test_ask_user_event(self):
+        """ask_user maps promptId, question, options."""
+        b = DisplayMessageBuilder()
+        b.add_user_message("Hi")
+        b.add_event("ask_user", 1, {
+            "prompt_id": "p1", "question": "Which format?", "options": ["CSV", "JSON"],
+        })
+        msgs = b.get_messages()
+        evt = msgs[1]["streamEvents"][0]
+        assert evt["type"] == "ask_user"
+        assert evt["data"]["promptId"] == "p1"
+        assert evt["data"]["question"] == "Which format?"
+        assert evt["data"]["options"] == ["CSV", "JSON"]
+
+    def test_complete_event(self):
+        """complete maps all stats."""
+        b = DisplayMessageBuilder()
+        b.add_user_message("Hi")
+        b.add_event("complete", 1, {
+            "success": True, "answer": "Done", "total_turns": 3,
+            "total_input_tokens": 200, "total_output_tokens": 50,
+        })
+        msgs = b.get_messages()
+        evt = msgs[1]["streamEvents"][0]
+        assert evt["type"] == "complete"
+        assert evt["data"]["success"] is True
+        assert evt["data"]["answer"] == "Done"
+        assert evt["data"]["totalTurns"] == 3
+        assert evt["data"]["totalInputTokens"] == 200
+        assert evt["data"]["totalOutputTokens"] == 50
+
+    def test_error_event(self):
+        """error maps message."""
+        b = DisplayMessageBuilder()
+        b.add_user_message("Hi")
+        b.add_event("error", 1, {"message": "Something failed"})
+        msgs = b.get_messages()
+        evt = msgs[1]["streamEvents"][0]
+        assert evt["type"] == "error"
+        assert evt["data"]["message"] == "Something failed"
+
+    def test_error_event_fallback_key(self):
+        """error event with 'error' key instead of 'message'."""
+        b = DisplayMessageBuilder()
+        b.add_user_message("Hi")
+        b.add_event("error", 1, {"error": "fail reason"})
+        msgs = b.get_messages()
+        evt = msgs[1]["streamEvents"][0]
+        assert evt["data"]["message"] == "fail reason"
+
+    def test_steering_received_event(self):
+        """steering_received maps message."""
+        b = DisplayMessageBuilder()
+        b.add_user_message("Hi")
+        b.add_event("steering_received", 1, {"message": "User said: focus on X"})
+        msgs = b.get_messages()
+        evt = msgs[1]["streamEvents"][0]
+        assert evt["type"] == "steering_received"
+        assert evt["data"]["message"] == "User said: focus on X"
+
+    def test_unknown_event_type_ignored(self):
+        """Unknown event types are silently ignored."""
+        b = DisplayMessageBuilder()
+        b.add_user_message("Hi")
+        b.add_event("some_future_event", 1, {"data": "value"})
+        msgs = b.get_messages()
+        assert len(msgs) == 1  # Only user, no assistant
+
+
+class TestDisplayMessageBuilderSkippedEvents:
+
+    def test_heartbeat_skipped(self):
+        b = DisplayMessageBuilder()
+        b.add_user_message("Hi")
+        b.add_event("heartbeat", 0, {})
+        assert b.get_messages() == [{"role": "user", "content": "Hi"}]
+
+    def test_run_started_skipped(self):
+        b = DisplayMessageBuilder()
+        b.add_user_message("Hi")
+        b.add_event("run_started", 0, {"trace_id": "t1"})
+        assert b.get_messages() == [{"role": "user", "content": "Hi"}]
+
+    def test_trace_saved_skipped(self):
+        b = DisplayMessageBuilder()
+        b.add_user_message("Hi")
+        b.add_event("trace_saved", 0, {"trace_id": "t1"})
+        assert b.get_messages() == [{"role": "user", "content": "Hi"}]
+
+    def test_text_delta_accumulated(self):
+        """text_delta chunks are accumulated and flushed as assistant record."""
+        b = DisplayMessageBuilder()
+        b.add_user_message("Hi")
+        b.add_event("text_delta", 1, {"text": "Hello "})
+        b.add_event("text_delta", 1, {"text": "world!"})
+        msgs = b.get_messages()
+        assert len(msgs) == 2
+        evt = msgs[1]["streamEvents"][0]
+        assert evt["type"] == "assistant"
+        assert evt["data"]["content"] == "Hello world!"
+
+    def test_text_delta_flushed_before_tool_call(self):
+        """Accumulated text_delta is flushed as assistant before tool_call."""
+        b = DisplayMessageBuilder()
+        b.add_user_message("Hi")
+        b.add_event("text_delta", 1, {"text": "I'll run a command"})
+        b.add_event("tool_call", 1, {"tool_name": "bash", "tool_input": {"command": "ls"}})
+        msgs = b.get_messages()
+        events = msgs[1]["streamEvents"]
+        assert events[0]["type"] == "assistant"
+        assert events[0]["data"]["content"] == "I'll run a command"
+        assert events[1]["type"] == "tool_call"
+
+    def test_text_delta_only_skipped_when_empty(self):
+        """text_delta with empty text doesn't produce assistant record."""
+        b = DisplayMessageBuilder()
+        b.add_user_message("Hi")
+        b.add_event("text_delta", 1, {"text": ""})
+        b.add_event("complete", 1, {"success": True})
+        msgs = b.get_messages()
+        events = msgs[1]["streamEvents"]
+        assert len(events) == 1
+        assert events[0]["type"] == "complete"
+
+    def test_turn_complete_skipped(self):
+        b = DisplayMessageBuilder()
+        b.add_user_message("Hi")
+        b.add_event("turn_complete", 1, {"messages_snapshot": []})
+        assert b.get_messages() == [{"role": "user", "content": "Hi"}]
+
+    def test_context_compressed_skipped(self):
+        b = DisplayMessageBuilder()
+        b.add_user_message("Hi")
+        b.add_event("context_compressed", 1, {})
+        assert b.get_messages() == [{"role": "user", "content": "Hi"}]
+
+
+class TestDisplayMessageBuilderFlush:
+
+    def test_new_user_flushes_assistant(self):
+        """Adding a second user message flushes the pending assistant."""
+        b = DisplayMessageBuilder()
+        b.add_user_message("Q1")
+        b.add_event("assistant", 1, {"content": "A1"})
+        b.add_user_message("Q2")
+        b.add_event("assistant", 2, {"content": "A2"})
+        msgs = b.get_messages()
+        assert len(msgs) == 4  # user, assistant, user, assistant
+        assert msgs[0]["role"] == "user"
+        assert msgs[1]["role"] == "assistant"
+        assert msgs[1]["streamEvents"][0]["data"]["content"] == "A1"
+        assert msgs[2]["role"] == "user"
+        assert msgs[3]["role"] == "assistant"
+        assert msgs[3]["streamEvents"][0]["data"]["content"] == "A2"
+
+    def test_get_messages_flushes(self):
+        """get_messages flushes pending events."""
+        b = DisplayMessageBuilder()
+        b.add_user_message("Hi")
+        b.add_event("assistant", 1, {"content": "Hello"})
+        msgs = b.get_messages()
+        assert len(msgs) == 2
+        # After flush, _current_events should be empty
+        assert len(b._current_events) == 0
+
+
+class TestDisplayMessageBuilderSnapshot:
+
+    def test_snapshot_includes_in_progress(self):
+        """get_snapshot includes unflushed events without flushing."""
+        b = DisplayMessageBuilder()
+        b.add_user_message("Hi")
+        b.add_event("turn_start", 1, {"max_turns": 5})
+        b.add_event("tool_call", 1, {"tool_name": "bash", "tool_input": {"command": "ls"}})
+
+        snap = b.get_snapshot()
+        assert len(snap) == 2  # user + in-progress assistant
+        assert snap[1]["role"] == "assistant"
+        assert len(snap[1]["streamEvents"]) == 2
+
+        # Original builder state not modified
+        assert len(b._current_events) == 2
+        assert len(b._messages) == 1
+
+    def test_snapshot_empty_events(self):
+        """Snapshot with no pending events returns only finalized messages."""
+        b = DisplayMessageBuilder()
+        b.add_user_message("Hi")
+        snap = b.get_snapshot()
+        assert len(snap) == 1
+        assert snap[0]["role"] == "user"
+
+    def test_snapshot_after_flush(self):
+        """Snapshot after get_messages returns same as get_messages."""
+        b = DisplayMessageBuilder()
+        b.add_user_message("Hi")
+        b.add_event("assistant", 1, {"content": "Hello"})
+        msgs = b.get_messages()
+        snap = b.get_snapshot()
+        assert msgs == snap
+
+    def test_snapshot_includes_text_buffer(self):
+        """Snapshot includes unflushed text_delta buffer without consuming it."""
+        b = DisplayMessageBuilder()
+        b.add_user_message("Hi")
+        b.add_event("turn_start", 1, {"max_turns": 5})
+        b.add_event("text_delta", 1, {"text": "I'm thinking"})
+        b.add_event("text_delta", 1, {"text": "..."})
+
+        snap = b.get_snapshot()
+        assert len(snap) == 2  # user + in-progress assistant
+        events = snap[1]["streamEvents"]
+        assert len(events) == 2  # turn_start + assistant (from text buffer)
+        assert events[1]["type"] == "assistant"
+        assert events[1]["data"]["content"] == "I'm thinking..."
+
+        # Original builder state preserved
+        assert b._text_buffer == "I'm thinking..."
+        assert len(b._current_events) == 1  # only turn_start
+
+
+class TestDisplayMessageBuilderFromResult:
+
+    def test_from_result_basic(self):
+        """from_agent_result with simple assistant content."""
+        result = FakeResult(
+            steps=[FakeStep(role="assistant", content="Hello world")],
+        )
+        builder = DisplayMessageBuilder.from_agent_result(result, "Hi")
+        msgs = builder.get_messages()
+        assert len(msgs) == 2
+        assert msgs[0] == {"role": "user", "content": "Hi"}
+        events = msgs[1]["streamEvents"]
+        event_types = [e["type"] for e in events]
+        assert "assistant" in event_types
+        assert "complete" in event_types
+
+    def test_from_result_with_tools(self):
+        """from_agent_result with tool calls."""
+        result = FakeResult(
+            steps=[
+                FakeStep(role="tool", content="result text", tool_name="bash", tool_input={"command": "ls"}),
+                FakeStep(role="assistant", content="Done"),
+            ],
+        )
+        builder = DisplayMessageBuilder.from_agent_result(result, "Run ls")
+        msgs = builder.get_messages()
+        events = msgs[1]["streamEvents"]
+        event_types = [e["type"] for e in events]
+        assert "tool_call" in event_types
+        assert "tool_result" in event_types
+        assert "assistant" in event_types
+        assert "complete" in event_types
+
+    def test_from_result_with_ask_user(self):
+        """from_agent_result with ask_user tool."""
+        result = FakeResult(
+            steps=[
+                FakeStep(
+                    role="tool", content="",
+                    tool_name="ask_user",
+                    tool_input={"question": "Which format?", "options": ["CSV", "JSON"]},
+                ),
+            ],
+        )
+        builder = DisplayMessageBuilder.from_agent_result(result, "Analyze")
+        msgs = builder.get_messages()
+        events = msgs[1]["streamEvents"]
+        event_types = [e["type"] for e in events]
+        assert "tool_call" in event_types
+        assert "ask_user" in event_types
+        # Verify ask_user data
+        ask_evt = [e for e in events if e["type"] == "ask_user"][0]
+        assert ask_evt["data"]["question"] == "Which format?"
+        assert ask_evt["data"]["options"] == ["CSV", "JSON"]
+
+    def test_from_result_with_files(self):
+        """from_agent_result with uploaded files."""
+        files = [FakeUploadedFile(file_id="f1", filename="data.csv")]
+        result = FakeResult(
+            steps=[FakeStep(role="assistant", content="Analyzed")],
+        )
+        builder = DisplayMessageBuilder.from_agent_result(result, "Analyze", files)
+        msgs = builder.get_messages()
+        assert msgs[0]["attachedFiles"] == [{"file_id": "f1", "filename": "data.csv"}]
+
+    def test_from_result_complete_event_stats(self):
+        """from_agent_result complete event has correct stats."""
+        result = FakeResult(
+            success=True, answer="42", total_turns=3,
+            total_input_tokens=500, total_output_tokens=100,
+            steps=[],
+        )
+        builder = DisplayMessageBuilder.from_agent_result(result, "What is 6*7?")
+        msgs = builder.get_messages()
+        events = msgs[1]["streamEvents"]
+        complete_evt = [e for e in events if e["type"] == "complete"][0]
+        assert complete_evt["data"]["success"] is True
+        assert complete_evt["data"]["answer"] == "42"
+        assert complete_evt["data"]["totalTurns"] == 3
+        assert complete_evt["data"]["totalInputTokens"] == 500
+        assert complete_evt["data"]["totalOutputTokens"] == 100
+
+    def test_from_result_tool_result_truncated(self):
+        """from_agent_result truncates tool result content to 5000 chars."""
+        long_content = "x" * 10000
+        result = FakeResult(
+            steps=[
+                FakeStep(role="tool", content=long_content, tool_name="bash", tool_input={}),
+            ],
+        )
+        builder = DisplayMessageBuilder.from_agent_result(result, "Hi")
+        msgs = builder.get_messages()
+        events = msgs[1]["streamEvents"]
+        tr_evt = [e for e in events if e["type"] == "tool_result"][0]
+        assert len(tr_evt["data"]["toolResult"]) == 5000
+
+    def test_from_result_tool_error_detected(self):
+        """from_agent_result infers success=False from error-like content."""
+        error_contents = [
+            '{"error": "No such file"}',
+            'Error: command not found',
+            'Traceback (most recent call last):\n  File ...',
+        ]
+        for err_content in error_contents:
+            result = FakeResult(
+                steps=[FakeStep(role="tool", content=err_content, tool_name="bash", tool_input={})],
+            )
+            builder = DisplayMessageBuilder.from_agent_result(result, "Hi")
+            msgs = builder.get_messages()
+            events = msgs[1]["streamEvents"]
+            tr_evt = [e for e in events if e["type"] == "tool_result"][0]
+            assert tr_evt["data"]["success"] is False, f"Expected success=False for: {err_content[:30]}"
+
+    def test_from_result_tool_success_normal_content(self):
+        """from_agent_result marks normal tool output as success=True."""
+        result = FakeResult(
+            steps=[FakeStep(role="tool", content="file.txt\ndata.csv", tool_name="bash", tool_input={})],
+        )
+        builder = DisplayMessageBuilder.from_agent_result(result, "Hi")
+        msgs = builder.get_messages()
+        events = msgs[1]["streamEvents"]
+        tr_evt = [e for e in events if e["type"] == "tool_result"][0]
+        assert tr_evt["data"]["success"] is True
+
+
+class TestDisplayMessageBuilderFullFlow:
+
+    def test_full_streaming_flow(self):
+        """Simulate a complete streaming session."""
+        b = DisplayMessageBuilder()
+        b.add_user_message("Analyze data.csv", [
+            FakeUploadedFile(file_id="f1", filename="data.csv"),
+        ])
+
+        # Turn 1: tool call + result
+        b.add_event("turn_start", 1, {"max_turns": 60})
+        b.add_event("tool_call", 1, {"tool_name": "execute_code", "tool_input": {"code": "import pandas"}})
+        b.add_event("tool_result", 1, {"tool_name": "execute_code", "tool_result": "OK"})
+
+        # Turn 2: assistant + output file + complete
+        b.add_event("turn_start", 2, {"max_turns": 60})
+        b.add_event("assistant", 2, {"content": "Here are the results"})
+        b.add_event("output_file", 2, {
+            "file_id": "of1", "filename": "chart.png", "size": 2048,
+            "content_type": "image/png", "download_url": "/download/of1",
+        })
+        b.add_event("complete", 2, {
+            "success": True, "answer": "Here are the results",
+            "total_turns": 2, "total_input_tokens": 300, "total_output_tokens": 80,
+        })
+
+        msgs = b.get_messages()
+        assert len(msgs) == 2  # user + assistant
+        assert msgs[0]["role"] == "user"
+        assert msgs[0]["content"] == "Analyze data.csv"
+        assert msgs[0]["attachedFiles"] == [{"file_id": "f1", "filename": "data.csv"}]
+
+        events = msgs[1]["streamEvents"]
+        types = [e["type"] for e in events]
+        assert types == [
+            "turn_start", "tool_call", "tool_result",
+            "turn_start", "assistant", "output_file", "complete",
+        ]
+
+    def test_full_streaming_flow_with_text_delta(self):
+        """Simulate real-world streaming: text_delta chunks between tool calls."""
+        b = DisplayMessageBuilder()
+        b.add_user_message("Visualize this")
+
+        # Turn 1: assistant text (as deltas) + tool calls
+        b.add_event("turn_start", 1, {"max_turns": 60})
+        b.add_event("text_delta", 1, {"text": "I'll create "})
+        b.add_event("text_delta", 1, {"text": "a visualizer!"})
+        b.add_event("tool_call", 1, {"tool_name": "get_skill", "tool_input": {"skill_name": "remotion"}})
+        b.add_event("tool_result", 1, {"tool_name": "get_skill", "tool_result": "skill content"})
+
+        # Turn 2: more text + another tool
+        b.add_event("turn_start", 2, {"max_turns": 60})
+        b.add_event("text_delta", 2, {"text": "Now setting up the project"})
+        b.add_event("tool_call", 2, {"tool_name": "bash", "tool_input": {"command": "npm init"}})
+        b.add_event("tool_result", 2, {"tool_name": "bash", "tool_result": "OK"})
+
+        # Final turn: text + complete
+        b.add_event("turn_start", 3, {"max_turns": 60})
+        b.add_event("text_delta", 3, {"text": "All done!"})
+        b.add_event("complete", 3, {
+            "success": True, "answer": "All done!",
+            "total_turns": 3, "total_input_tokens": 500, "total_output_tokens": 100,
+        })
+
+        msgs = b.get_messages()
+        assert len(msgs) == 2  # user + assistant
+        events = msgs[1]["streamEvents"]
+        types = [e["type"] for e in events]
+        assert types == [
+            "turn_start",
+            "assistant",    # "I'll create a visualizer!" (flushed before tool_call)
+            "tool_call",
+            "tool_result",
+            "turn_start",
+            "assistant",    # "Now setting up the project" (flushed before tool_call)
+            "tool_call",
+            "tool_result",
+            "turn_start",
+            "assistant",    # "All done!" (flushed before complete)
+            "complete",
+        ]
+        # Verify text content
+        assistant_events = [e for e in events if e["type"] == "assistant"]
+        assert assistant_events[0]["data"]["content"] == "I'll create a visualizer!"
+        assert assistant_events[1]["data"]["content"] == "Now setting up the project"
+        assert assistant_events[2]["data"]["content"] == "All done!"
+
+    def test_ask_user_followed_by_user_response(self):
+        """ask_user event followed by user response — frontend infers selectedAnswer from message order."""
+        b = DisplayMessageBuilder()
+        b.add_user_message("Create a poster")
+
+        # Agent asks user a question
+        b.add_event("turn_start", 1, {"max_turns": 60})
+        b.add_event("text_delta", 1, {"text": "Which style?"})
+        b.add_event("ask_user", 1, {
+            "prompt_id": "p1", "question": "Choose a style",
+            "options": ["Cyberpunk", "Minimal", "Retro"],
+        })
+        b.add_event("complete", 1, {"success": True, "total_turns": 1})
+
+        # User responds (new request → new add_user_message)
+        b.add_user_message("Cyberpunk")
+
+        # Agent continues
+        b.add_event("turn_start", 2, {"max_turns": 60})
+        b.add_event("text_delta", 2, {"text": "Great choice!"})
+        b.add_event("complete", 2, {"success": True, "total_turns": 2})
+
+        msgs = b.get_messages()
+        # Structure: user, assistant(ask_user), user(response), assistant(continuation)
+        assert len(msgs) == 4
+        assert msgs[0]["role"] == "user"
+        assert msgs[0]["content"] == "Create a poster"
+        assert msgs[1]["role"] == "assistant"
+        ask_events = [e for e in msgs[1]["streamEvents"] if e["type"] == "ask_user"]
+        assert len(ask_events) == 1
+        assert ask_events[0]["data"]["options"] == ["Cyberpunk", "Minimal", "Retro"]
+        # User's response is the next message — frontend uses msgs[i+1].content as selectedAnswer
+        assert msgs[2]["role"] == "user"
+        assert msgs[2]["content"] == "Cyberpunk"
+        assert msgs[3]["role"] == "assistant"
+
+    def test_multi_turn_conversation(self):
+        """Simulate multi-turn conversation with user flushes."""
+        b = DisplayMessageBuilder()
+
+        # Turn 1
+        b.add_user_message("Q1")
+        b.add_event("assistant", 1, {"content": "A1"})
+        b.add_event("complete", 1, {"success": True, "answer": "A1", "total_turns": 1})
+
+        # Turn 2 (new user message flushes assistant)
+        b.add_user_message("Q2")
+        b.add_event("assistant", 2, {"content": "A2"})
+        b.add_event("complete", 2, {"success": True, "answer": "A2", "total_turns": 2})
+
+        msgs = b.get_messages()
+        assert len(msgs) == 4  # user, assistant, user, assistant
+        assert msgs[0]["content"] == "Q1"
+        assert msgs[2]["content"] == "Q2"

--- a/web/src/app/chat/page.tsx
+++ b/web/src/app/chat/page.tsx
@@ -375,7 +375,7 @@ export default function FullscreenChatPage() {
             {!showConfig && <p className="text-sm mt-1">{t('clickConfigToCustomize')}</p>}
           </div>
         ) : (
-          messages.map((message) => (
+          messages.map((message, idx) => (
             <div key={message.id} className="max-w-4xl mx-auto">
               <ChatMessageItem
                 message={message}
@@ -383,6 +383,7 @@ export default function FullscreenChatPage() {
                 streamingEvents={message.id === engine.streamingMessageId ? engine.streamingEvents : undefined}
                 streamingOutputFiles={message.id === engine.streamingMessageId ? engine.currentOutputFiles : undefined}
                 onAskUserRespond={engine.handleRespond}
+                askUserAnswer={message.role === 'assistant' && messages[idx + 1]?.role === 'user' ? messages[idx + 1].content : undefined}
               />
             </div>
           ))

--- a/web/src/app/published/[id]/page.tsx
+++ b/web/src/app/published/[id]/page.tsx
@@ -319,7 +319,7 @@ export default function PublishedChatPage() {
               <p className="text-sm mt-2">{t('published.typeToBegin')}</p>
             </div>
           ) : (
-            messages.map((message) => (
+            messages.map((message, idx) => (
               <div key={message.id} className="max-w-4xl mx-auto">
                 <ChatMessageItem
                   message={message}
@@ -328,6 +328,7 @@ export default function PublishedChatPage() {
                   streamingOutputFiles={message.id === engine.streamingMessageId ? engine.currentOutputFiles : undefined}
                   hideTraceLink
                   onAskUserRespond={engine.handleRespond}
+                  askUserAnswer={message.role === 'assistant' && messages[idx + 1]?.role === 'user' ? messages[idx + 1].content : undefined}
                 />
               </div>
             ))

--- a/web/src/app/sessions/[id]/page.tsx
+++ b/web/src/app/sessions/[id]/page.tsx
@@ -135,11 +135,12 @@ export default function SessionDetailPage() {
               {chatMessages.length === 0 ? (
                 <p className="text-center text-muted-foreground py-12">{t('detail.noMessages')}</p>
               ) : (
-                chatMessages.map((msg) => (
+                chatMessages.map((msg, idx) => (
                   <ChatMessageItem
                     key={msg.id}
                     message={msg}
                     hideTraceLink
+                    askUserAnswer={msg.role === 'assistant' && chatMessages[idx + 1]?.role === 'user' ? chatMessages[idx + 1].content : undefined}
                   />
                 ))
               )}

--- a/web/src/app/skills/evolve/page.tsx
+++ b/web/src/app/skills/evolve/page.tsx
@@ -798,7 +798,7 @@ export default function SkillEvolvePage() {
               <p className="text-lg">{t("evolve.startConversation")}</p>
             </div>
           ) : (
-            messages.map((message) => (
+            messages.map((message, idx) => (
               <div key={message.id} className="max-w-4xl mx-auto">
                 <ChatMessageItem
                   message={message}
@@ -817,6 +817,7 @@ export default function SkillEvolvePage() {
                       ? currentOutputFiles
                       : undefined
                   }
+                  askUserAnswer={message.role === 'assistant' && messages[idx + 1]?.role === 'user' ? messages[idx + 1].content : undefined}
                 />
               </div>
             ))

--- a/web/src/components/agents/agent-builder-chat.tsx
+++ b/web/src/components/agents/agent-builder-chat.tsx
@@ -185,7 +185,7 @@ export function AgentBuilderChat({
             <p className="text-sm mt-2">{t('create.describeAgentHint')}</p>
           </div>
         ) : (
-          messages.map((message) => (
+          messages.map((message, idx) => (
             <div key={message.id} className="max-w-4xl mx-auto">
               <ChatMessageItem
                 message={message}
@@ -193,6 +193,7 @@ export function AgentBuilderChat({
                 streamingEvents={engine.streamingMessageId === message.id ? engine.streamingEvents : undefined}
                 streamingOutputFiles={engine.streamingMessageId === message.id ? engine.currentOutputFiles : undefined}
                 onAskUserRespond={engine.handleRespond}
+                askUserAnswer={message.role === 'assistant' && messages[idx + 1]?.role === 'user' ? messages[idx + 1].content : undefined}
               />
             </div>
           ))

--- a/web/src/components/chat/chat-message.tsx
+++ b/web/src/components/chat/chat-message.tsx
@@ -22,6 +22,8 @@ interface ChatMessageItemProps {
   hideTraceLink?: boolean;
   /** Callback when user responds to an ask_user prompt */
   onAskUserRespond?: (promptId: string, answer: string) => void;
+  /** Pre-filled answer for ask_user events (inferred from next user message) */
+  askUserAnswer?: string;
 }
 
 export function ChatMessageItem({
@@ -31,6 +33,7 @@ export function ChatMessageItem({
   streamingEvents,
   hideTraceLink,
   onAskUserRespond,
+  askUserAnswer,
 }: ChatMessageItemProps) {
   const [showSteps, setShowSteps] = React.useState(false);
 
@@ -79,7 +82,7 @@ export function ChatMessageItem({
         ) : (
           <>
             {hasStructuredEvents ? (
-              <StreamEventsRenderer events={events} isStreaming={isStreaming} onAskUserRespond={onAskUserRespond} />
+              <StreamEventsRenderer events={events} isStreaming={isStreaming} onAskUserRespond={onAskUserRespond} askUserAnswer={askUserAnswer} />
             ) : (
               <pre className="text-sm whitespace-pre-wrap font-sans overflow-x-auto">{displayContent}</pre>
             )}

--- a/web/src/components/chat/chat-panel.tsx
+++ b/web/src/components/chat/chat-panel.tsx
@@ -483,7 +483,7 @@ export function ChatPanel({ isOpen, onClose, defaultSkills = [] }: ChatPanelProp
             <p className="text-sm mt-1">{t('multiTurnHint')}</p>
           </div>
         ) : (
-          messages.map((message) => (
+          messages.map((message, idx) => (
             <ChatMessageItem
               key={message.id}
               message={message}
@@ -491,6 +491,7 @@ export function ChatPanel({ isOpen, onClose, defaultSkills = [] }: ChatPanelProp
               streamingEvents={message.id === engine.streamingMessageId ? engine.streamingEvents : undefined}
               streamingOutputFiles={message.id === engine.streamingMessageId ? engine.currentOutputFiles : undefined}
               onAskUserRespond={engine.handleRespond}
+              askUserAnswer={message.role === 'assistant' && messages[idx + 1]?.role === 'user' ? messages[idx + 1].content : undefined}
             />
           ))
         )}

--- a/web/src/components/chat/stream-events/ask-user-card.tsx
+++ b/web/src/components/chat/stream-events/ask-user-card.tsx
@@ -10,12 +10,14 @@ import { useTranslation } from "@/i18n/client";
 interface AskUserCardProps {
   data: AskUserData;
   onRespond?: (promptId: string, answer: string) => void;
+  /** Pre-filled answer (inferred from next user message on session restore) */
+  selectedAnswer?: string;
 }
 
-export function AskUserCard({ data, onRespond }: AskUserCardProps) {
+export function AskUserCard({ data, onRespond, selectedAnswer }: AskUserCardProps) {
   const { t } = useTranslation("chat");
-  const [submitted, setSubmitted] = React.useState(false);
-  const [localAnswer, setLocalAnswer] = React.useState("");
+  const [submitted, setSubmitted] = React.useState(!!selectedAnswer);
+  const [localAnswer, setLocalAnswer] = React.useState(selectedAnswer || "");
   const inputRef = React.useRef<HTMLInputElement>(null);
 
   const handleSubmit = React.useCallback(

--- a/web/src/components/chat/stream-events/index.tsx
+++ b/web/src/components/chat/stream-events/index.tsx
@@ -20,12 +20,14 @@ interface StreamEventsRendererProps {
   isStreaming?: boolean;
   /** Callback when user responds to an ask_user prompt */
   onAskUserRespond?: (promptId: string, answer: string) => void;
+  /** Pre-filled answer for ask_user (inferred from next user message on session restore) */
+  askUserAnswer?: string;
 }
 
 /**
  * Renders a list of stream events as structured UI components
  */
-export function StreamEventsRenderer({ events, expandAll = false, isStreaming = false, onAskUserRespond }: StreamEventsRendererProps) {
+export function StreamEventsRenderer({ events, expandAll = false, isStreaming = false, onAskUserRespond, askUserAnswer }: StreamEventsRendererProps) {
   // Find the index of the last assistant event for streaming optimization
   let lastAssistantIndex = -1;
   if (isStreaming) {
@@ -71,6 +73,7 @@ export function StreamEventsRenderer({ events, expandAll = false, isStreaming = 
                 key={event.id}
                 data={event.data}
                 onRespond={onAskUserRespond}
+                selectedAnswer={askUserAnswer}
               />
             );
 

--- a/web/src/components/skill/skill-finder-chat.tsx
+++ b/web/src/components/skill/skill-finder-chat.tsx
@@ -250,7 +250,7 @@ export function SkillFinderChat({
             </div>
           </div>
         ) : (
-          messages.map((message) => (
+          messages.map((message, idx) => (
             <div key={message.id} className="max-w-4xl mx-auto">
               <ChatMessageItem
                 message={message}
@@ -258,6 +258,7 @@ export function SkillFinderChat({
                 streamingEvents={engine.streamingMessageId === message.id ? engine.streamingEvents : undefined}
                 streamingOutputFiles={engine.streamingMessageId === message.id ? engine.currentOutputFiles : undefined}
                 onAskUserRespond={engine.handleRespond}
+                askUserAnswer={message.role === 'assistant' && messages[idx + 1]?.role === 'user' ? messages[idx + 1].content : undefined}
               />
             </div>
           ))


### PR DESCRIPTION
## Summary

Closes #163. Stores session display messages in `ChatMessage[]` format with `streamEvents`, replacing the Anthropic-format-to-frontend conversion approach.

### Core changes
- **DisplayMessageBuilder** (`app/api/v1/display_builder.py`): New class that accumulates SSE streaming events into frontend `ChatMessage[]` format for session display storage
- **text_delta accumulation**: Accumulates `text_delta` chunks and flushes them as `assistant` StreamEventRecords at boundary events (tool_call, complete, etc.), fixing the bug where assistant text was invisible after page refresh
- **Simplified session-utils.ts**: Reduced from 172-line Anthropic-format parser to ~40-line pass-through since backend now stores display-ready format

### Bug fixes
- **ask_user cards reset after refresh**: Frontend now infers `selectedAnswer` from the next user message in the messages array, so ask_user cards render as already-answered on page refresh
- **ask_user with multiple tool_use blocks**: When LLM returns multiple `tool_use` blocks and one is `ask_user`, the agent now adds `tool_result` for all remaining tool_use blocks before returning, preventing "LLM stream failed" errors on subsequent requests

### Files changed (18)
- `app/api/v1/display_builder.py` — New DisplayMessageBuilder class
- `app/api/v1/agent.py` — Integrate DisplayMessageBuilder into streaming endpoint
- `app/api/v1/published.py` — Same for published agent endpoint
- `app/agent/agent.py` — Fix ask_user with multiple tool_use blocks
- `web/src/lib/session-utils.ts` — Simplified to pass-through
- `web/src/components/chat/stream-events/ask-user-card.tsx` — Accept selectedAnswer prop
- `web/src/components/chat/stream-events/index.tsx` — Thread askUserAnswer prop
- `web/src/components/chat/chat-message.tsx` — Thread askUserAnswer prop
- 5 parent components — Compute askUserAnswer from messages[i+1]
- `tests/test_api/test_display_builder.py` — 44 unit tests
- `tests/test_e2e/test_e2e_workflows.py` — 8 E2E tests
- `tests/test_e2e/test_context_compression.py` — Updated for new format

## Test plan
- [x] 44 unit tests for DisplayMessageBuilder (text_delta, ask_user, snapshots, from_agent_result)
- [x] 8 E2E tests for session display format
- [x] TypeScript compiles clean
- [x] Manual verification: page refresh preserves assistant text and ask_user answered state