### PR TITLE
Relax Docker healthcheck settings for slower environments

### DIFF
--- a/docker/docker-compose.dev.yaml
+++ b/docker/docker-compose.dev.yaml
@@ -102,8 +102,8 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:62610/"]
       interval: 30s
       timeout: 10s
-      retries: 3
-      start_period: 10s
+      retries: 5
+      start_period: 60s
     networks:
       - skills-network
 
@@ -135,7 +135,7 @@ services:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:62600/"]
       interval: 30s
       timeout: 10s
-      retries: 3
+      retries: 5
       start_period: 30s
     networks:
       - skills-network
@@ -159,7 +159,7 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:62630/"]
       interval: 30s
       timeout: 10s
-      retries: 3
+      retries: 5
       start_period: 30s
     networks:
       - skills-network
@@ -221,8 +221,8 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:62680/health"]
       interval: 30s
       timeout: 10s
-      retries: 3
-      start_period: 10s
+      retries: 5
+      start_period: 30s
     deploy:
       resources:
         limits:
@@ -254,8 +254,8 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:62681/health"]
       interval: 30s
       timeout: 10s
-      retries: 3
-      start_period: 30s
+      retries: 5
+      start_period: 60s
     deploy:
       resources:
         limits:
@@ -288,7 +288,7 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:62682/health"]
       interval: 30s
       timeout: 10s
-      retries: 3
+      retries: 5
       start_period: 60s
     deploy:
       resources:
@@ -327,7 +327,7 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:62680/health"]
       interval: 30s
       timeout: 10s
-      retries: 3
+      retries: 5
       start_period: 30s
     deploy:
       resources:
@@ -361,7 +361,7 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:62680/health"]
       interval: 30s
       timeout: 10s
-      retries: 3
+      retries: 5
       start_period: 30s
     deploy:
       resources:
@@ -395,7 +395,7 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:62680/health"]
       interval: 30s
       timeout: 10s
-      retries: 3
+      retries: 5
       start_period: 30s
     deploy:
       resources:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -99,8 +99,8 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:62610/"]
       interval: 30s
       timeout: 10s
-      retries: 3
-      start_period: 10s
+      retries: 5
+      start_period: 60s
     networks:
       - skills-network
 
@@ -124,7 +124,7 @@ services:
       test: ["CMD", "wget", "-q", "--spider", "http://localhost:62600/"]
       interval: 30s
       timeout: 10s
-      retries: 3
+      retries: 5
       start_period: 30s
     networks:
       - skills-network
@@ -145,7 +145,7 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:62630/"]
       interval: 30s
       timeout: 10s
-      retries: 3
+      retries: 5
       start_period: 30s
     networks:
       - skills-network
@@ -195,8 +195,8 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:62680/health"]
       interval: 30s
       timeout: 10s
-      retries: 3
-      start_period: 10s
+      retries: 5
+      start_period: 30s
     deploy:
       resources:
         limits:
@@ -225,8 +225,8 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:62681/health"]
       interval: 30s
       timeout: 10s
-      retries: 3
-      start_period: 30s
+      retries: 5
+      start_period: 60s
     deploy:
       resources:
         limits:
@@ -256,7 +256,7 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:62682/health"]
       interval: 30s
       timeout: 10s
-      retries: 3
+      retries: 5
       start_period: 60s
     deploy:
       resources:
@@ -291,7 +291,7 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:62680/health"]
       interval: 30s
       timeout: 10s
-      retries: 3
+      retries: 5
       start_period: 30s
     deploy:
       resources:
@@ -321,7 +321,7 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:62680/health"]
       interval: 30s
       timeout: 10s
-      retries: 3
+      retries: 5
       start_period: 30s
     deploy:
       resources:
@@ -351,7 +351,7 @@ services:
       test: ["CMD", "curl", "-f", "http://localhost:62680/health"]
       interval: 30s
       timeout: 10s
-      retries: 3
+      retries: 5
       start_period: 30s
     deploy:
       resources:


### PR DESCRIPTION
## Summary

- Increase `start_period` for api (10s→60s), executor-base (10s→30s), and executor-ml (30s→60s) to prevent premature unhealthy marking during cold starts
- Increase `retries` from 3 to 5 across all services for better transient failure tolerance
- Applied to both `docker-compose.yaml` and `docker-compose.dev.yaml`

## Test plan

- [ ] `docker compose up -d` starts all services without unhealthy restarts
- [ ] Verify on a slow machine / cold start scenario that api doesn't restart loop

Closes #168