### PR TITLE
Fix: persist steering messages in session for refresh recovery

### DIFF
--- a/app/agent/agent.py
+++ b/app/agent/agent.py
@@ -1356,6 +1356,12 @@ class SkillsAgent:
                 if event_stream and event_stream.has_injection():
                     steering_msg = event_stream.get_injection_nowait()
                     if steering_msg:
+                        # Emit steering_received so DisplayMessageBuilder records it
+                        await event_stream.push(StreamEvent(
+                            event_type="steering_received",
+                            turn=turns,
+                            data={"message": steering_msg},
+                        ))
                         messages.append({
                             "role": "user",
                             "content": f"[User Steering Message]: {steering_msg}"
@@ -1590,6 +1596,12 @@ class SkillsAgent:
             if event_stream and event_stream.has_injection():
                 steering_msg = event_stream.get_injection_nowait()
                 if steering_msg:
+                    # Emit steering_received so DisplayMessageBuilder records it
+                    await event_stream.push(StreamEvent(
+                        event_type="steering_received",
+                        turn=turns,
+                        data={"message": steering_msg},
+                    ))
                     messages.append({
                         "role": "user",
                         "content": f"[User Steering Message]: {steering_msg}"


### PR DESCRIPTION
## Summary
- Agent consumed steering messages but never emitted `steering_received` SSE events, so `DisplayMessageBuilder` never recorded them in the session
- Frontend steering was purely optimistic local inserts — lost on page refresh
- Emit `steering_received` StreamEvent at both consumption points in `agent.py`
- Deduplicate in frontend `handleStreamEvent` to prevent double display from optimistic insert + SSE echo

Closes #176