### PR TITLE
Fix: steering fails at max_turns boundary and race on completion

### DIFF
--- a/app/agent/agent.py
+++ b/app/agent/agent.py
@@ -1366,6 +1366,8 @@ class SkillsAgent:
                             "role": "user",
                             "content": f"[User Steering Message]: {steering_msg}"
                         })
+                        # Grant an extra turn so the LLM can process this steering
+                        self.max_turns = max(self.max_turns, turns + 1)
                         continue  # Don't finish, loop back to LLM with steering message
 
                 final_answer = response.text_content
@@ -1606,6 +1608,8 @@ class SkillsAgent:
                         "role": "user",
                         "content": f"[User Steering Message]: {steering_msg}"
                     })
+                    # Grant an extra turn so the LLM can process this steering
+                    self.max_turns = max(self.max_turns, turns + 1)
 
             # Emit turn_complete checkpoint (all tool_use/tool_result pairs matched)
             if streaming:


### PR DESCRIPTION
## Summary
- Steering at turn boundary (e.g. `max_turns=1`): agent appends message but loop condition `turns < max_turns` is already false — steering never reaches the LLM. Fix: bump `max_turns` when consuming steering to guarantee at least one extra turn.
- Race condition (agent completes before steering arrives): steer API returns 409, message is lost. Fix: frontend catches 409, rolls back optimistic insert, re-submits as a new chat message after a brief delay.

Closes #176