### PR TITLE
Fix: improve steering robustness with ID-based dedup and event-driven resubmit

### DIFF
--- a/app/agent/agent.py
+++ b/app/agent/agent.py
@@ -596,6 +596,15 @@ def _build_mcp_tools_section(tools: list) -> str:
     return "\n".join(lines)
 
 
+def _make_steering_event(turn: int, message: str) -> StreamEvent:
+    """Create a steering_received StreamEvent with a unique steering_id."""
+    return StreamEvent(
+        event_type="steering_received",
+        turn=turn,
+        data={"message": message, "steering_id": f"steer-{uuid.uuid4().hex[:12]}"},
+    )
+
+
 class SkillsAgent:
     """Agent that uses skills and tools to complete tasks."""
 
@@ -1356,12 +1365,7 @@ class SkillsAgent:
                 if event_stream and event_stream.has_injection():
                     steering_msg = event_stream.get_injection_nowait()
                     if steering_msg:
-                        # Emit steering_received so DisplayMessageBuilder records it
-                        await event_stream.push(StreamEvent(
-                            event_type="steering_received",
-                            turn=turns,
-                            data={"message": steering_msg},
-                        ))
+                        await event_stream.push(_make_steering_event(turns, steering_msg))
                         messages.append({
                             "role": "user",
                             "content": f"[User Steering Message]: {steering_msg}"
@@ -1598,12 +1602,7 @@ class SkillsAgent:
             if event_stream and event_stream.has_injection():
                 steering_msg = event_stream.get_injection_nowait()
                 if steering_msg:
-                    # Emit steering_received so DisplayMessageBuilder records it
-                    await event_stream.push(StreamEvent(
-                        event_type="steering_received",
-                        turn=turns,
-                        data={"message": steering_msg},
-                    ))
+                    await event_stream.push(_make_steering_event(turns, steering_msg))
                     messages.append({
                         "role": "user",
                         "content": f"[User Steering Message]: {steering_msg}"

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -38,7 +38,7 @@ const API_BASE = `${BACKEND_API_BASE}/registry`;
 // Export for pages that need direct API access
 export { BACKEND_API_BASE };
 
-class ApiError extends Error {
+export class ApiError extends Error {
   constructor(
     public status: number,
     message: string
@@ -863,6 +863,8 @@ export interface StreamEvent {
   content_type?: string;
   download_url?: string;
   description?: string;
+  // For steering_received
+  steering_id?: string;
   // For ask_user
   prompt_id?: string;
   question?: string;
@@ -968,7 +970,7 @@ export const agentApi = {
     );
     if (!response.ok) {
       const error = await response.json().catch(() => ({}));
-      throw new Error(error.detail || `Steer failed: ${response.statusText}`);
+      throw new ApiError(response.status, error.detail || `Steer failed: ${response.statusText}`);
     }
   },
 
@@ -1531,7 +1533,7 @@ export const publishedAgentApi = {
     );
     if (!response.ok) {
       const error = await response.json().catch(() => ({}));
-      throw new Error(error.detail || `Steer failed: ${response.statusText}`);
+      throw new ApiError(response.status, error.detail || `Steer failed: ${response.statusText}`);
     }
   },
 
@@ -2047,5 +2049,3 @@ export const authApi = {
     }
   },
 };
-
-export { ApiError };

--- a/web/src/types/stream-events.ts
+++ b/web/src/types/stream-events.ts
@@ -118,6 +118,7 @@ export interface TraceSavedRecord extends StreamEventRecordBase {
 // Steering received event data
 export interface SteeringReceivedData {
   message: string;
+  steeringId?: string;
 }
 
 export interface SteeringReceivedRecord extends StreamEventRecordBase {


### PR DESCRIPTION
## Summary
- Steering dedup now uses unique `steering_id` (UUID) instead of message text matching — fixes duplicate-content messages being incorrectly skipped
- 409 detection uses `ApiError.status === 409` instead of brittle `err.message.includes("already completed")` string matching
- 409 resubmit uses `pendingSteerResubmitRef` (processed in `handleSubmit` finally block) instead of hardcoded `setTimeout(500)` — message is resubmitted only after the current run actually completes

## Test plan
- [x] `test_steering_event_contains_steering_id` — verify unique steering_id per event
- [x] `test_steer_409_response_body` — verify 409 response format
- [x] `test_steering_received_event_with_id` — EventStream end-to-end with steering_id
- [x] `test_duplicate_steering_messages_get_unique_ids` — uniqueness of IDs for identical content
- [x] Full unit test suite passes (547 passed, 0 failed)

Closes #179