### PR TITLE
Default AUTH_ENABLED to false for easier onboarding

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -69,7 +69,7 @@ class Settings(BaseSettings):
     jwt_secret_key: str = ""  # Auto-generated from database_url if empty
     jwt_access_token_expire_hours: int = 24
     jwt_refresh_token_expire_days: int = 7
-    auth_enabled: bool = True  # Set false to disable auth for development
+    auth_enabled: bool = False  # Set true to enable auth (login required)
 
     # Meta skills (internal use only, not selectable by users)
     meta_skills: list[str] = ["skill-creator", "skill-updater", "skill-evolver", "skill-finder", "trace-qa", "skills-planner", "planning-with-files", "mcp-builder"]

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -67,7 +67,7 @@ AGENT_MAX_TURNS=60
 JWT_SECRET_KEY=
 
 # Enable/disable authentication (default: true)
-AUTH_ENABLED=true
+AUTH_ENABLED=false
 
 # ------------------------------------------------------------------------------
 # Advanced Configuration


### PR DESCRIPTION
## Summary
- Change default `AUTH_ENABLED` from `true` to `false` in both `app/config.py` and `docker/.env.example`
- New installations now work without auth setup; opt in with `AUTH_ENABLED=true`

Closes #185

## Test plan
- [ ] Start without setting `AUTH_ENABLED` — should access main UI directly, no login prompt
- [ ] Set `AUTH_ENABLED=true` — login flow should work as before