### PR TITLE
Fix web_search tool by migrating to ddgs package

### DIFF
--- a/app/agent/tools.py
+++ b/app/agent/tools.py
@@ -881,16 +881,16 @@ def web_search(query: str) -> Dict[str, Any]:
         Search results with titles, URLs, and snippets
     """
     try:
-        from duckduckgo_search import DDGS
+        from ddgs import DDGS
 
         results = []
-        with DDGS() as ddgs:
-            for r in ddgs.text(query, max_results=10):
-                results.append({
-                    "title": r.get("title", ""),
-                    "url": r.get("href", ""),
-                    "snippet": r.get("body", "")
-                })
+        ddgs = DDGS()
+        for r in ddgs.text(query, max_results=10):
+            results.append({
+                "title": r.get("title", ""),
+                "url": r.get("href", ""),
+                "snippet": r.get("body", "")
+            })
 
         if not results:
             return {
@@ -920,7 +920,7 @@ def web_search(query: str) -> Dict[str, Any]:
     except ImportError:
         return {
             "success": False,
-            "error": "duckduckgo_search package not installed. Run: pip install duckduckgo_search"
+            "error": "ddgs package not installed. Run: pip install ddgs"
         }
     except Exception as e:
         return {

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ httpx>=0.27.0
 requests>=2.31.0
 beautifulsoup4>=4.12.0
 html2text>=2024.2.0
-duckduckgo-search>=6.0.0
+ddgs>=9.0.0
 
 # MCP (Model Context Protocol) support
 mcp>=1.0.0


### PR DESCRIPTION
## Summary
- Migrate from deprecated `duckduckgo-search` package to `ddgs` (the official successor)
- The old package was silently returning 0 results, breaking all agent web search calls
- Update import path and remove deprecated context manager pattern

## Changes
- `requirements.txt`: `duckduckgo-search>=6.0.0` → `ddgs>=9.0.0`
- `app/agent/tools.py`: Update import and instantiation

## Test plan
- [x] Verified `ddgs` v9.10.0 returns results locally
- [x] Verified rebuilt Docker API container installs `ddgs` correctly
- [ ] Run agent with `web_search` tool and confirm results are returned

Fixes #191