### PR TITLE
Fix: render markdown in ask_user question content

### DIFF
--- a/web/src/components/chat/stream-events/ask-user-card.tsx
+++ b/web/src/components/chat/stream-events/ask-user-card.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { HelpCircle, CheckCircle2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Markdown } from "@/components/ui/markdown";
 import type { AskUserData } from "@/types/stream-events";
 import { useTranslation } from "@/i18n/client";
 
@@ -37,7 +38,7 @@ export function AskUserCard({ data, onRespond, selectedAnswer }: AskUserCardProp
       {/* Header */}
       <div className="flex items-start gap-2 px-3 py-2.5">
         <HelpCircle className="h-4 w-4 text-amber-600 dark:text-amber-400 mt-0.5 shrink-0" />
-        <p className="text-sm text-foreground font-medium">{data.question}</p>
+        <div className="text-sm text-foreground font-medium min-w-0 overflow-x-auto"><Markdown>{data.question}</Markdown></div>
       </div>
 
       {/* Answer area */}


### PR DESCRIPTION
## Summary
- Replace plain `<p>` tag with `<Markdown>` component in `AskUserCard` to properly render markdown-formatted questions (tables, headers, bold, etc.)

Closes #195

## Test plan
- [ ] Trigger an agent that calls `ask_user` with markdown content (tables, headers, bold)
- [ ] Verify markdown renders correctly in the ask_user card
- [ ] Verify plain text questions still display normally
- [ ] Check dark mode rendering