### PR TITLE
Fix missing seed metadata for 3 skills

### DIFF
--- a/config/seed_skills.json
+++ b/config/seed_skills.json
@@ -89,6 +89,15 @@
     "code-to-diagram": {
       "category": "Development Tools"
     },
+    "invoice-organizer": {
+      "category": "Document Processing"
+    },
+    "slack-gif-creator": {
+      "category": "Media & Design"
+    },
+    "twitter-algorithm-optimizer": {
+      "category": "Content Creation"
+    },
     "skill-finder": {
       "category": "meta"
     },


### PR DESCRIPTION
## Summary
- Add missing entries in `config/seed_skills.json` for `invoice-organizer`, `slack-gif-creator`, and `twitter-algorithm-optimizer`
- These 3 skills existed in `seed_skills/` but had no seed metadata, so they were not getting category assignments during startup

## Changes
- `invoice-organizer` → Document Processing
- `slack-gif-creator` → Media & Design
- `twitter-algorithm-optimizer` → Content Creation

Closes #197