### PR TITLE
feat: Feishu file upload/download support

### DIFF
--- a/app/channels/base.py
+++ b/app/channels/base.py
@@ -23,6 +23,7 @@ class InboundMessage:
     external_message_id: Optional[str] = None
     metadata: Optional[dict] = None
     timestamp: datetime = field(default_factory=datetime.utcnow)
+    media: list[str] = field(default_factory=list)  # local file paths of downloaded media
 
 
 @dataclass
@@ -31,6 +32,7 @@ class OutboundMessage:
     external_id: str  # Chat/group ID to send to
     content: str
     message_type: str = "text"
+    media: list[str] = field(default_factory=list)  # local file paths to upload & send
 
 
 MessageHandler = Callable[[InboundMessage], Awaitable[None]]


### PR DESCRIPTION
## Summary

- Add `media` field to `InboundMessage` / `OutboundMessage` base classes for cross-adapter file support
- Extend Feishu adapter to handle image, file, audio, media, and rich-text (post) message types
- Download inbound media via lark SDK `GetMessageResourceRequest`, upload outbound files via `CreateImageRequest` / `CreateFileRequest`
- Wire media to agent pipeline: images → base64 vision blocks, non-image files → prompt path injection, output files → Feishu upload
- Add message deduplication with bounded OrderedDict cache (cap 1000)
- Skip trigger pattern check for media messages so images/files always reach the agent

## Test plan

- [x] Unit tests pass (577 passed)
- [x] E2E workflow tests pass (191 passed)
- [x] Compression tests pass (55 passed)
- [ ] Manual: send text in Feishu → agent replies (existing flow, should still work)
- [ ] Manual: send image in Feishu → agent describes image via vision
- [ ] Manual: send file in Feishu → agent acknowledges file path
- [ ] Manual: ask agent to generate a chart → file sent back to Feishu
- [ ] Manual: rapidly send same message → only processed once (dedup)

> **Note:** Feishu app requires `im:resource` scope for media download/upload to work.

Closes #211