### PR TITLE
Fix critical bugs in task scheduler and channel system

### DIFF
--- a/app/api/v1/scheduler.py
+++ b/app/api/v1/scheduler.py
@@ -214,7 +214,8 @@ async def create_scheduled_task(
         updated_at=now,
     )
     db.add(task)
-    await db.flush()
+    await db.commit()
+    await db.refresh(task)
 
     return _task_to_response(task)
 
@@ -260,7 +261,8 @@ async def update_scheduled_task(
         setattr(task, key, value)
 
     task.updated_at = datetime.utcnow()
-    await db.flush()
+    await db.commit()
+    await db.refresh(task)
 
     return _task_to_response(task)
 
@@ -279,6 +281,7 @@ async def delete_scheduled_task(
         raise HTTPException(status_code=404, detail="Scheduled task not found")
 
     await db.delete(task)
+    await db.commit()
 
 
 @router.post("/{task_id}/run-now")
@@ -319,6 +322,8 @@ async def pause_task(
 
     task.status = "paused"
     task.updated_at = datetime.utcnow()
+    await db.commit()
+    await db.refresh(task)
 
     return _task_to_response(task)
 
@@ -344,6 +349,8 @@ async def resume_task(
     task.status = "active"
     task.next_run = _calculate_next_run(task.schedule_type, task.schedule_value)
     task.updated_at = datetime.utcnow()
+    await db.commit()
+    await db.refresh(task)
 
     return _task_to_response(task)
 

--- a/app/channels/feishu.py
+++ b/app/channels/feishu.py
@@ -137,13 +137,13 @@ class FeishuAdapter(ChannelAdapter):
                     import time
                     time.sleep(5)  # reconnect backoff
 
+        self._connected = True
         self._ws_thread = threading.Thread(
             target=_run_ws,
             daemon=True,
             name="feishu-ws",
         )
         self._ws_thread.start()
-        self._connected = True
         logger.info("Feishu adapter connected via WebSocket")
 
     async def disconnect(self) -> None:

--- a/app/services/channel_manager.py
+++ b/app/services/channel_manager.py
@@ -124,8 +124,11 @@ class ChannelManager:
                 # Check trigger pattern (skip for media messages — images/files
                 # should always be processed regardless of text trigger)
                 if binding.trigger_pattern and not msg.media:
-                    if not re.search(binding.trigger_pattern, msg.content):
-                        return
+                    try:
+                        if not re.search(binding.trigger_pattern, msg.content):
+                            return
+                    except re.error:
+                        logger.warning(f"Invalid trigger pattern '{binding.trigger_pattern}' for binding {binding.id}, processing anyway")
 
                 # Record inbound message
                 inbound_record = ChannelMessageDB(


### PR DESCRIPTION
## Summary

Fixes 9 critical/high-severity bugs introduced in PR #210 (Task Scheduler and Channel Messaging System).

Closes #213

## Changes

1. **Fix SkillsAgent import path and constructor params** — wrong module path (`app.agent.run_agent` doesn't exist) and all 5 constructor parameter names were wrong, causing every scheduled task to crash
2. **Add missing `db.commit()`** to all scheduler API write endpoints (create/update/delete/pause/resume) — data was never persisted
3. **Fix `_connected` race condition** in Feishu adapter — set flag before `thread.start()` so WS thread doesn't exit immediately
4. **Fix timestamp parsing** — remove double `.replace()` that stripped timezone info
5. **Replace unbounded thread creation** with `ThreadPoolExecutor(max_workers=5)`, initialized eagerly in `__new__` for thread-safety
6. **Add regex validation** — validate `trigger_pattern` on save via Pydantic `field_validator`, catch `re.error` on execution
7. **Fix `_execute_task` crash bugs** — `result.model` → `agent.model` (AgentResult has no `model` field), `result.messages` → `result.final_messages`
8. **Serialize dataclass objects for JSONB** — `result.steps` / `result.llm_calls` are dataclass lists, need `asdict()` before DB insertion
9. **Fix MissingGreenlet risk** — capture `task.id` / `task.name` before `session.commit()` to avoid accessing expired attributes

## Test plan

- [x] Existing test suite passes (22 tests in `test_scheduler.py` + `test_channels.py`)
- [ ] Verify scheduled task execution works end-to-end (was completely broken before)
- [ ] Verify scheduler API endpoints persist data after create/update/pause/resume
- [ ] Verify Feishu WS connection stays alive after connect()
- [ ] Verify invalid regex in trigger_pattern is rejected at API level