### PR TITLE
feat: multi-Feishu-app support, channel edit UI, and service leader election

### DIFF
--- a/app/api/v1/channels.py
+++ b/app/api/v1/channels.py
@@ -12,11 +12,13 @@ Provides endpoints for:
 - Adapter connection status
 """
 
+import logging
 import re
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field, field_validator
 from sqlalchemy import select, desc, func, and_
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -24,6 +26,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.db.database import get_db
 from app.db.models import ChannelBindingDB, ChannelMessageDB, AgentPresetDB
 
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/channels", tags=["channels"])
 
@@ -85,6 +88,7 @@ class ChannelBindingResponse(BaseModel):
     external_id: str
     name: str
     agent_id: str
+    agent_name: Optional[str] = None
     trigger_pattern: Optional[str] = None
     enabled: bool
     config: Optional[Dict[str, Any]] = None
@@ -119,19 +123,40 @@ class ChannelMessageListResponse(BaseModel):
 
 
 # ---------------------------------------------------------------------------
-# Helper
+# Helpers
 # ---------------------------------------------------------------------------
 
-def _build_binding_response(binding: ChannelBindingDB) -> ChannelBindingResponse:
+def _mask_config(config: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    """Mask sensitive fields in the config dict.
+
+    Currently masks ``app_secret`` showing only last 4 chars.
+    """
+    if not config:
+        return config
+    masked = dict(config)
+    if "app_secret" in masked and masked["app_secret"]:
+        secret = str(masked["app_secret"])
+        if len(secret) > 4:
+            masked["app_secret"] = "****" + secret[-4:]
+        else:
+            masked["app_secret"] = "****"
+    return masked
+
+
+def _build_binding_response(
+    binding: ChannelBindingDB,
+    agent_name: Optional[str] = None,
+) -> ChannelBindingResponse:
     return ChannelBindingResponse(
         id=binding.id,
         channel_type=binding.channel_type,
         external_id=binding.external_id,
         name=binding.name,
         agent_id=binding.agent_id,
+        agent_name=agent_name,
         trigger_pattern=binding.trigger_pattern,
         enabled=binding.enabled,
-        config=binding.config,
+        config=_mask_config(binding.config),
         created_at=binding.created_at,
         updated_at=binding.updated_at,
     )
@@ -150,6 +175,34 @@ def _build_message_response(msg: ChannelMessageDB) -> ChannelMessageResponse:
         metadata=msg.msg_metadata,
         created_at=msg.created_at,
     )
+
+
+async def _get_agent_name(db: AsyncSession, agent_id: str) -> Optional[str]:
+    """Look up agent preset name by ID."""
+    result = await db.execute(
+        select(AgentPresetDB.name).where(AgentPresetDB.id == agent_id)
+    )
+    return result.scalar_one_or_none()
+
+
+def _merge_config(existing: Optional[Dict[str, Any]], incoming: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    """Merge incoming config into existing, preserving masked secrets."""
+    if incoming is None:
+        return existing
+    if not existing:
+        # Strip masked secrets from brand-new config
+        result = dict(incoming)
+        if "app_secret" in result and isinstance(result["app_secret"], str) and result["app_secret"].startswith("****"):
+            del result["app_secret"]
+        return result or None
+
+    merged = dict(existing)
+    for key, value in incoming.items():
+        # Skip masked secret values — preserve existing
+        if key == "app_secret" and isinstance(value, str) and value.startswith("****"):
+            continue
+        merged[key] = value
+    return merged
 
 
 # ---------------------------------------------------------------------------
@@ -176,23 +229,54 @@ async def list_channel_bindings(
     result = await db.execute(query)
     bindings = result.scalars().all()
 
+    # Batch-fetch agent names
+    agent_ids = list({b.agent_id for b in bindings})
+    agent_names: dict[str, str] = {}
+    if agent_ids:
+        agents_result = await db.execute(
+            select(AgentPresetDB.id, AgentPresetDB.name).where(
+                AgentPresetDB.id.in_(agent_ids)
+            )
+        )
+        for row in agents_result:
+            agent_names[row[0]] = row[1]
+
     return ChannelBindingListResponse(
-        bindings=[_build_binding_response(b) for b in bindings],
+        bindings=[_build_binding_response(b, agent_names.get(b.agent_id)) for b in bindings],
         total=len(bindings),
     )
 
 
 @router.get("/adapters")
-async def get_adapter_status():
+async def get_adapter_status(
+    db: AsyncSession = Depends(get_db),
+):
     """
     Get connection status of all channel adapters.
 
-    Returns a mapping of adapter name to its connected status.
+    With multiple uvicorn workers, only the leader worker holds live adapters.
+    If this request hits a non-leader worker, adapter status is derived from
+    DB bindings (connected status assumed ``True``).
     """
     try:
-        from app.services.channel_manager import ChannelManager
+        from app.services.channel_manager import ChannelManager, adapter_key_for_binding
         manager = ChannelManager()
-        return {name: adapter.is_connected() for name, adapter in manager._adapters.items()}
+
+        # Leader worker: return real status
+        if manager._is_leader:
+            return {name: adapter.is_connected() for name, adapter in manager._adapters.items()}
+
+        # Non-leader worker: derive expected adapters from enabled bindings
+        result = await db.execute(
+            select(ChannelBindingDB).where(ChannelBindingDB.enabled == True)
+        )
+        bindings = result.scalars().all()
+        adapters: dict[str, bool] = {}
+        for b in bindings:
+            key = adapter_key_for_binding(b)
+            if key and key not in adapters:
+                adapters[key] = True
+        return adapters
     except ImportError:
         raise HTTPException(
             status_code=501,
@@ -209,12 +293,23 @@ async def get_adapter_status():
 async def restart_adapter(adapter_type: str):
     """
     Restart a specific channel adapter.
+
+    Only works when the request hits the leader worker that holds live
+    adapter connections. Non-leader workers cannot restart adapters.
     """
     try:
         from app.services.channel_manager import ChannelManager
         manager = ChannelManager()
 
         if adapter_type not in manager._adapters:
+            # Could be a non-leader worker — don't 404
+            if not manager._is_leader:
+                return JSONResponse(
+                    status_code=202,
+                    content={
+                        "message": f"Restart request for '{adapter_type}' received. The adapter is managed by the service leader worker.",
+                    },
+                )
             raise HTTPException(
                 status_code=404,
                 detail=f"Adapter '{adapter_type}' not found",
@@ -257,7 +352,8 @@ async def get_channel_binding(
     if not binding:
         raise HTTPException(status_code=404, detail="Channel binding not found")
 
-    return _build_binding_response(binding)
+    agent_name = await _get_agent_name(db, binding.agent_id)
+    return _build_binding_response(binding, agent_name)
 
 
 @router.post("", response_model=ChannelBindingResponse)
@@ -275,7 +371,8 @@ async def create_channel_binding(
     agent_result = await db.execute(
         select(AgentPresetDB).where(AgentPresetDB.id == data.agent_id)
     )
-    if not agent_result.scalar_one_or_none():
+    agent = agent_result.scalar_one_or_none()
+    if not agent:
         raise HTTPException(status_code=400, detail="Agent preset not found for the given agent_id")
 
     # 2. Check unique constraint (channel_type + external_id)
@@ -308,7 +405,15 @@ async def create_channel_binding(
     await db.commit()
     await db.refresh(binding)
 
-    return _build_binding_response(binding)
+    # 4. Hot-reload: start adapter if needed
+    try:
+        from app.services.channel_manager import ChannelManager
+        manager = ChannelManager()
+        await manager.on_binding_created(binding.id)
+    except Exception as e:
+        logger.warning(f"Hot-reload on_binding_created failed: {e}")
+
+    return _build_binding_response(binding, agent.name)
 
 
 @router.put("/{binding_id}", response_model=ChannelBindingResponse)
@@ -328,6 +433,9 @@ async def update_channel_binding(
     if not binding:
         raise HTTPException(status_code=404, detail="Channel binding not found")
 
+    # Save old config for hot-reload comparison
+    old_config = dict(binding.config) if binding.config else None
+
     fields_set = data.model_fields_set
 
     if "name" in fields_set and data.name is not None:
@@ -346,12 +454,22 @@ async def update_channel_binding(
         binding.trigger_pattern = data.trigger_pattern
 
     if "config" in fields_set:
-        binding.config = data.config
+        # Merge config instead of replacing — preserves masked secrets
+        binding.config = _merge_config(binding.config, data.config)
 
     await db.commit()
     await db.refresh(binding)
 
-    return _build_binding_response(binding)
+    # Hot-reload: adjust adapters if config changed
+    try:
+        from app.services.channel_manager import ChannelManager
+        manager = ChannelManager()
+        await manager.on_binding_updated(binding.id, old_config)
+    except Exception as e:
+        logger.warning(f"Hot-reload on_binding_updated failed: {e}")
+
+    agent_name = await _get_agent_name(db, binding.agent_id)
+    return _build_binding_response(binding, agent_name)
 
 
 @router.delete("/{binding_id}")
@@ -370,8 +488,19 @@ async def delete_channel_binding(
     if not binding:
         raise HTTPException(status_code=404, detail="Channel binding not found")
 
+    # Save config before deletion for hot-reload
+    binding_config = dict(binding.config) if binding.config else None
+
     await db.delete(binding)
     await db.commit()
+
+    # Hot-reload: stop adapter if no remaining bindings use this app_id
+    try:
+        from app.services.channel_manager import ChannelManager
+        manager = ChannelManager()
+        await manager.on_binding_deleted(binding_id, binding_config)
+    except Exception as e:
+        logger.warning(f"Hot-reload on_binding_deleted failed: {e}")
 
     return {"message": "Channel binding deleted successfully"}
 
@@ -396,7 +525,8 @@ async def toggle_channel_binding(
     await db.commit()
     await db.refresh(binding)
 
-    return _build_binding_response(binding)
+    agent_name = await _get_agent_name(db, binding.agent_id)
+    return _build_binding_response(binding, agent_name)
 
 
 @router.get("/{binding_id}/messages", response_model=ChannelMessageListResponse)

--- a/web/src/app/channels/[id]/page.tsx
+++ b/web/src/app/channels/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useRouter, useParams } from 'next/navigation';
 import Link from 'next/link';
 import {
@@ -10,13 +10,23 @@ import {
   Trash2,
   ChevronLeft,
   ChevronRight,
+  Pencil,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Spinner } from '@/components/ui/spinner';
 import { ErrorBanner } from '@/components/ui/error-banner';
 import { EmptyState } from '@/components/ui/empty-state';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -41,10 +51,13 @@ import {
   useChannelBinding,
   useToggleChannelBinding,
   useDeleteChannelBinding,
+  useUpdateChannelBinding,
   useChannelMessages,
 } from '@/hooks/use-channels';
+import { useAgentPresets } from '@/hooks/use-agents';
 import { useTranslation } from '@/i18n/client';
 import { formatDateTime } from '@/lib/formatters';
+import type { ChannelBindingUpdateRequest } from '@/lib/api';
 
 const PAGE_SIZE = 20;
 
@@ -59,6 +72,18 @@ export default function ChannelDetailPage() {
   const { data: binding, isLoading, error } = useChannelBinding(bindingId);
   const toggleBinding = useToggleChannelBinding();
   const deleteBinding = useDeleteChannelBinding();
+  const updateBinding = useUpdateChannelBinding(bindingId);
+  const { data: agentsData } = useAgentPresets();
+
+  const agents = agentsData?.presets || [];
+
+  // Edit mode state
+  const [isEditing, setIsEditing] = useState(false);
+  const [editName, setEditName] = useState('');
+  const [editAgentId, setEditAgentId] = useState('');
+  const [editTriggerPattern, setEditTriggerPattern] = useState('');
+  const [editAppId, setEditAppId] = useState('');
+  const [editAppSecret, setEditAppSecret] = useState('');
 
   const [messageOffset, setMessageOffset] = useState(0);
   const { data: messagesData, isLoading: messagesLoading } = useChannelMessages(bindingId, {
@@ -70,6 +95,21 @@ export default function ChannelDetailPage() {
   const totalMessages = messagesData?.total || 0;
   const totalPages = Math.ceil(totalMessages / PAGE_SIZE);
   const currentPage = Math.floor(messageOffset / PAGE_SIZE) + 1;
+
+  // Populate edit fields only when entering edit mode (not on binding refetch)
+  const prevIsEditing = useRef(false);
+  useEffect(() => {
+    if (isEditing && !prevIsEditing.current && binding) {
+      setEditName(binding.name);
+      setEditAgentId(binding.agent_id);
+      setEditTriggerPattern(binding.trigger_pattern || '');
+      setEditAppId((binding.config?.app_id as string) || '');
+      setEditAppSecret('');
+    }
+    prevIsEditing.current = isEditing;
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- binding is read inside but we
+  // intentionally use binding?.id (stable across refetches) to avoid overwriting form state.
+  }, [isEditing, binding?.id]);
 
   const handleToggle = async () => {
     if (!binding) return;
@@ -87,6 +127,43 @@ export default function ChannelDetailPage() {
       await deleteBinding.mutateAsync(binding.id);
       toast.success(t('messages.deleted'));
       router.push('/channels');
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : tc('errors.generic'));
+    }
+  };
+
+  const handleSave = async () => {
+    if (!binding) return;
+    if (!editName.trim()) { toast.error('Name is required'); return; }
+    if (!editAgentId) { toast.error('Agent is required'); return; }
+
+    try {
+      const updateData: ChannelBindingUpdateRequest = {
+        name: editName.trim(),
+        agent_id: editAgentId,
+        trigger_pattern: editTriggerPattern.trim() || null,
+      };
+
+      // Build config for Feishu bindings
+      if (binding.channel_type === 'feishu') {
+        const config: Record<string, string> = {};
+        if (editAppId.trim()) {
+          config.app_id = editAppId.trim();
+        }
+        if (editAppSecret.trim()) {
+          config.app_secret = editAppSecret.trim();
+        } else if (binding.config?.app_secret) {
+          // Send the masked value to preserve existing secret
+          config.app_secret = binding.config.app_secret as string;
+        }
+        if (Object.keys(config).length > 0) {
+          updateData.config = config;
+        }
+      }
+
+      await updateBinding.mutateAsync(updateData);
+      toast.success(t('messages.updated'));
+      setIsEditing(false);
     } catch (err) {
       toast.error(err instanceof Error ? err.message : tc('errors.generic'));
     }
@@ -139,95 +216,202 @@ export default function ChannelDetailPage() {
                 </p>
               </div>
               <div className="flex items-center gap-2">
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={handleToggle}
-                  disabled={toggleBinding.isPending}
-                >
-                  {toggleBinding.isPending ? (
-                    <Spinner size="sm" className="mr-2" />
-                  ) : binding.enabled ? (
-                    <ToggleRight className="mr-2 h-4 w-4 text-green-500" />
-                  ) : (
-                    <ToggleLeft className="mr-2 h-4 w-4 text-muted-foreground" />
-                  )}
-                  {binding.enabled ? t('actions.disable') : t('actions.enable')}
-                </Button>
-                <AlertDialog>
-                  <AlertDialogTrigger asChild>
-                    <Button variant="destructive" size="sm">
-                      <Trash2 className="mr-2 h-4 w-4" />
-                      {tc('actions.delete')}
+                {isEditing ? (
+                  <>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setIsEditing(false)}
+                    >
+                      {tc('actions.cancel')}
                     </Button>
-                  </AlertDialogTrigger>
-                  <AlertDialogContent>
-                    <AlertDialogHeader>
-                      <AlertDialogTitle>{tc('actions.delete')}</AlertDialogTitle>
-                      <AlertDialogDescription>
-                        {t('messages.confirmDelete')}
-                      </AlertDialogDescription>
-                    </AlertDialogHeader>
-                    <AlertDialogFooter>
-                      <AlertDialogCancel>{tc('actions.cancel')}</AlertDialogCancel>
-                      <AlertDialogAction
-                        onClick={(e) => {
-                          e.preventDefault();
-                          handleDelete();
-                        }}
-                        className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                      >
-                        {tc('actions.delete')}
-                      </AlertDialogAction>
-                    </AlertDialogFooter>
-                  </AlertDialogContent>
-                </AlertDialog>
+                    <Button
+                      size="sm"
+                      onClick={handleSave}
+                      disabled={updateBinding.isPending}
+                    >
+                      {updateBinding.isPending && <Spinner size="sm" className="mr-2" />}
+                      {t('actions.save')}
+                    </Button>
+                  </>
+                ) : (
+                  <>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => setIsEditing(true)}
+                    >
+                      <Pencil className="mr-2 h-4 w-4" />
+                      {t('actions.edit')}
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={handleToggle}
+                      disabled={toggleBinding.isPending}
+                    >
+                      {toggleBinding.isPending ? (
+                        <Spinner size="sm" className="mr-2" />
+                      ) : binding.enabled ? (
+                        <ToggleRight className="mr-2 h-4 w-4 text-green-500" />
+                      ) : (
+                        <ToggleLeft className="mr-2 h-4 w-4 text-muted-foreground" />
+                      )}
+                      {binding.enabled ? t('actions.disable') : t('actions.enable')}
+                    </Button>
+                    <AlertDialog>
+                      <AlertDialogTrigger asChild>
+                        <Button variant="destructive" size="sm">
+                          <Trash2 className="mr-2 h-4 w-4" />
+                          {tc('actions.delete')}
+                        </Button>
+                      </AlertDialogTrigger>
+                      <AlertDialogContent>
+                        <AlertDialogHeader>
+                          <AlertDialogTitle>{tc('actions.delete')}</AlertDialogTitle>
+                          <AlertDialogDescription>
+                            {t('messages.confirmDelete')}
+                          </AlertDialogDescription>
+                        </AlertDialogHeader>
+                        <AlertDialogFooter>
+                          <AlertDialogCancel>{tc('actions.cancel')}</AlertDialogCancel>
+                          <AlertDialogAction
+                            onClick={(e) => {
+                              e.preventDefault();
+                              handleDelete();
+                            }}
+                            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                          >
+                            {tc('actions.delete')}
+                          </AlertDialogAction>
+                        </AlertDialogFooter>
+                      </AlertDialogContent>
+                    </AlertDialog>
+                  </>
+                )}
               </div>
             </div>
           </CardHeader>
           <CardContent>
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-              <div>
-                <span className="text-sm font-medium text-muted-foreground">{t('fields.channelType')}</span>
-                <div className="mt-1">
-                  <Badge variant={binding.channel_type === 'feishu' ? 'info' : binding.channel_type === 'telegram' ? 'purple' : 'default'}>
-                    {t(`channelTypes.${binding.channel_type}`) || binding.channel_type}
-                  </Badge>
+            {isEditing ? (
+              /* Edit Form */
+              <div className="space-y-4">
+                <div className="space-y-2">
+                  <Label htmlFor="edit-name">{t('fields.name')}</Label>
+                  <Input
+                    id="edit-name"
+                    value={editName}
+                    onChange={(e) => setEditName(e.target.value)}
+                    required
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="edit-agent">{t('fields.agent')}</Label>
+                  <Select value={editAgentId} onValueChange={setEditAgentId}>
+                    <SelectTrigger id="edit-agent">
+                      <SelectValue placeholder={t('fields.agent')} />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {agents.map((agent) => (
+                        <SelectItem key={agent.id} value={agent.id}>
+                          {agent.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="edit-trigger">
+                    {t('fields.triggerPattern')}
+                    <span className="text-muted-foreground text-xs ml-1">({tc('status.optional')})</span>
+                  </Label>
+                  <Input
+                    id="edit-trigger"
+                    value={editTriggerPattern}
+                    onChange={(e) => setEditTriggerPattern(e.target.value)}
+                    placeholder="@bot|/ask"
+                  />
+                </div>
+                {binding.channel_type === 'feishu' && (
+                  <div className="space-y-4 rounded-lg border p-4 bg-muted/30">
+                    <div className="text-sm font-medium">{t('credentials.title')}</div>
+                    <div className="space-y-2">
+                      <Label htmlFor="edit-app-id">{t('fields.appId')}</Label>
+                      <Input
+                        id="edit-app-id"
+                        value={editAppId}
+                        onChange={(e) => setEditAppId(e.target.value)}
+                        placeholder="cli_xxxxxxxxxxxx"
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor="edit-app-secret">{t('fields.appSecret')}</Label>
+                      <Input
+                        id="edit-app-secret"
+                        type="password"
+                        value={editAppSecret}
+                        onChange={(e) => setEditAppSecret(e.target.value)}
+                        placeholder={
+                          binding.config?.app_secret
+                            ? t('credentials.keepExisting')
+                            : 'xxxxxxxxxxxxxxxxxxxxxxxx'
+                        }
+                      />
+                    </div>
+                  </div>
+                )}
+              </div>
+            ) : (
+              /* Read-only display */
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div>
+                  <span className="text-sm font-medium text-muted-foreground">{t('fields.channelType')}</span>
+                  <div className="mt-1">
+                    <Badge variant={binding.channel_type === 'feishu' ? 'info' : binding.channel_type === 'telegram' ? 'purple' : 'default'}>
+                      {t(`channelTypes.${binding.channel_type}`) || binding.channel_type}
+                    </Badge>
+                  </div>
+                </div>
+                <div>
+                  <span className="text-sm font-medium text-muted-foreground">{t('fields.externalId')}</span>
+                  <p className="mt-1 font-mono text-sm">{binding.external_id}</p>
+                </div>
+                <div>
+                  <span className="text-sm font-medium text-muted-foreground">{t('fields.agent')}</span>
+                  <p className="mt-1 text-sm">{binding.agent_name || binding.agent_id}</p>
+                </div>
+                <div>
+                  <span className="text-sm font-medium text-muted-foreground">{t('fields.enabled')}</span>
+                  <div className="mt-1">
+                    <Badge variant={binding.enabled ? 'success' : 'secondary'}>
+                      {binding.enabled ? t('actions.enable') : t('actions.disable')}
+                    </Badge>
+                  </div>
+                </div>
+                {binding.trigger_pattern && (
+                  <div className="sm:col-span-2">
+                    <span className="text-sm font-medium text-muted-foreground">{t('fields.triggerPattern')}</span>
+                    <p className="mt-1">
+                      <code className="text-sm bg-muted px-2 py-1 rounded">{binding.trigger_pattern}</code>
+                    </p>
+                  </div>
+                )}
+                {binding.channel_type === 'feishu' && typeof binding.config?.app_id === 'string' && (
+                  <div className="sm:col-span-2">
+                    <span className="text-sm font-medium text-muted-foreground">{t('fields.appId')}</span>
+                    <p className="mt-1 font-mono text-sm">{binding.config.app_id}</p>
+                  </div>
+                )}
+                <div>
+                  <span className="text-sm font-medium text-muted-foreground">{tc('fields.createdAt')}</span>
+                  <p className="mt-1 text-sm">{formatDateTime(binding.created_at)}</p>
+                </div>
+                <div>
+                  <span className="text-sm font-medium text-muted-foreground">{tc('fields.updatedAt')}</span>
+                  <p className="mt-1 text-sm">{formatDateTime(binding.updated_at)}</p>
                 </div>
               </div>
-              <div>
-                <span className="text-sm font-medium text-muted-foreground">{t('fields.externalId')}</span>
-                <p className="mt-1 font-mono text-sm">{binding.external_id}</p>
-              </div>
-              <div>
-                <span className="text-sm font-medium text-muted-foreground">{t('fields.agent')}</span>
-                <p className="mt-1 text-sm">{binding.agent_id}</p>
-              </div>
-              <div>
-                <span className="text-sm font-medium text-muted-foreground">{t('fields.enabled')}</span>
-                <div className="mt-1">
-                  <Badge variant={binding.enabled ? 'success' : 'secondary'}>
-                    {binding.enabled ? t('actions.enable') : t('actions.disable')}
-                  </Badge>
-                </div>
-              </div>
-              {binding.trigger_pattern && (
-                <div className="sm:col-span-2">
-                  <span className="text-sm font-medium text-muted-foreground">{t('fields.triggerPattern')}</span>
-                  <p className="mt-1">
-                    <code className="text-sm bg-muted px-2 py-1 rounded">{binding.trigger_pattern}</code>
-                  </p>
-                </div>
-              )}
-              <div>
-                <span className="text-sm font-medium text-muted-foreground">{tc('fields.createdAt')}</span>
-                <p className="mt-1 text-sm">{formatDateTime(binding.created_at)}</p>
-              </div>
-              <div>
-                <span className="text-sm font-medium text-muted-foreground">{tc('fields.updatedAt')}</span>
-                <p className="mt-1 text-sm">{formatDateTime(binding.updated_at)}</p>
-              </div>
-            </div>
+            )}
           </CardContent>
         </Card>
 

--- a/web/src/app/channels/page.tsx
+++ b/web/src/app/channels/page.tsx
@@ -120,28 +120,40 @@ export default function ChannelsPage() {
               <Spinner size="sm" />
             ) : adapterStatus && Object.keys(adapterStatus).length > 0 ? (
               <div className="flex flex-wrap gap-3">
-                {Object.entries(adapterStatus).map(([name, connected]) => (
-                  <div key={name} className="flex items-center gap-2 rounded-lg border px-3 py-2">
-                    {connected ? (
-                      <Wifi className="h-4 w-4 text-green-500" />
-                    ) : (
-                      <WifiOff className="h-4 w-4 text-red-500" />
-                    )}
-                    <span className="text-sm font-medium capitalize">{name}</span>
-                    <Badge variant={connected ? 'success' : 'error'} className="text-xs">
-                      {connected ? t('adapters.connected') : t('adapters.disconnected')}
-                    </Badge>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      className="h-6 w-6 p-0"
-                      onClick={() => handleRestartAdapter(name)}
-                      title={t('adapters.restart')}
-                    >
-                      <RefreshCw className="h-3 w-3" />
-                    </Button>
-                  </div>
-                ))}
+                {Object.entries(adapterStatus).map(([key, connected]) => {
+                  // Parse adapter key: "feishu:cli_xxx" → "Feishu (cli_xxx...)"
+                  let displayName = key;
+                  if (key.startsWith('feishu:')) {
+                    const appId = key.slice(7);
+                    const truncated = appId.length > 12 ? appId.slice(0, 12) + '...' : appId;
+                    displayName = `Feishu (${truncated})`;
+                  } else {
+                    displayName = key.charAt(0).toUpperCase() + key.slice(1);
+                  }
+
+                  return (
+                    <div key={key} className="flex items-center gap-2 rounded-lg border px-3 py-2">
+                      {connected ? (
+                        <Wifi className="h-4 w-4 text-green-500" />
+                      ) : (
+                        <WifiOff className="h-4 w-4 text-red-500" />
+                      )}
+                      <span className="text-sm font-medium">{displayName}</span>
+                      <Badge variant={connected ? 'success' : 'error'} className="text-xs">
+                        {connected ? t('adapters.connected') : t('adapters.disconnected')}
+                      </Badge>
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-6 w-6 p-0"
+                        onClick={() => handleRestartAdapter(key)}
+                        title={t('adapters.restart')}
+                      >
+                        <RefreshCw className="h-3 w-3" />
+                      </Button>
+                    </div>
+                  );
+                })}
               </div>
             ) : (
               <p className="text-sm text-muted-foreground">{t('adapters.noAdapters')}</p>

--- a/web/src/i18n/locales/en-US/channels.json
+++ b/web/src/i18n/locales/en-US/channels.json
@@ -11,7 +11,9 @@
     "agent": "Agent",
     "triggerPattern": "Trigger Pattern",
     "enabled": "Enabled",
-    "config": "Configuration"
+    "config": "Configuration",
+    "appId": "App ID",
+    "appSecret": "App Secret"
   },
   "channelTypes": {
     "feishu": "Feishu (Lark)",
@@ -21,7 +23,9 @@
   "actions": {
     "toggle": "Toggle",
     "enable": "Enabled",
-    "disable": "Disabled"
+    "disable": "Disabled",
+    "edit": "Edit",
+    "save": "Save"
   },
   "adapters": {
     "title": "Adapter Status",
@@ -48,7 +52,8 @@
     "configured": "configured",
     "alreadyConnected": "Adapter is already connected. Leave fields empty to keep existing credentials.",
     "keepExisting": "Leave empty to keep current value",
-    "hint": "Credentials are saved as environment variables and used to connect the adapter."
+    "hint": "Credentials are saved as environment variables and used to connect the adapter.",
+    "configHint": "Credentials are stored with this binding and used to connect the adapter."
   },
   "hints": {
     "externalId": "The chat or group ID on the external platform",

--- a/web/src/i18n/locales/es/channels.json
+++ b/web/src/i18n/locales/es/channels.json
@@ -11,7 +11,9 @@
     "agent": "Agente",
     "triggerPattern": "Patron de activacion",
     "enabled": "Habilitado",
-    "config": "Configuracion"
+    "config": "Configuracion",
+    "appId": "App ID",
+    "appSecret": "App Secret"
   },
   "channelTypes": {
     "feishu": "Feishu (Lark)",
@@ -21,7 +23,9 @@
   "actions": {
     "toggle": "Alternar",
     "enable": "Habilitado",
-    "disable": "Deshabilitado"
+    "disable": "Deshabilitado",
+    "edit": "Editar",
+    "save": "Guardar"
   },
   "adapters": {
     "title": "Estado del adaptador",
@@ -48,7 +52,8 @@
     "configured": "configurado",
     "alreadyConnected": "El adaptador ya esta conectado. Deje los campos vacios para mantener las credenciales existentes.",
     "keepExisting": "Dejar vacio para mantener el valor actual",
-    "hint": "Las credenciales se guardan como variables de entorno y se usan para conectar el adaptador."
+    "hint": "Las credenciales se guardan como variables de entorno y se usan para conectar el adaptador.",
+    "configHint": "Las credenciales se almacenan con esta vinculacion y se usan para conectar el adaptador."
   },
   "hints": {
     "externalId": "El ID del chat o grupo en la plataforma externa",

--- a/web/src/i18n/locales/ja/channels.json
+++ b/web/src/i18n/locales/ja/channels.json
@@ -11,7 +11,9 @@
     "agent": "エージェント",
     "triggerPattern": "トリガーパターン",
     "enabled": "有効",
-    "config": "設定"
+    "config": "設定",
+    "appId": "App ID",
+    "appSecret": "App Secret"
   },
   "channelTypes": {
     "feishu": "Feishu (Lark)",
@@ -21,7 +23,9 @@
   "actions": {
     "toggle": "切替",
     "enable": "有効",
-    "disable": "無効"
+    "disable": "無効",
+    "edit": "編集",
+    "save": "保存"
   },
   "adapters": {
     "title": "アダプターステータス",
@@ -48,7 +52,8 @@
     "configured": "設定済み",
     "alreadyConnected": "アダプターは既に接続されています。既存の資格情報を保持するにはフィールドを空のままにしてください。",
     "keepExisting": "現在の値を保持するには空のまま",
-    "hint": "資格情報は環境変数として保存され、アダプターの接続に使用されます。"
+    "hint": "資格情報は環境変数として保存され、アダプターの接続に使用されます。",
+    "configHint": "資格情報はこのバインディングと一緒に保存され、アダプターの接続に使用されます。"
   },
   "hints": {
     "externalId": "外部プラットフォームのチャットまたはグループID",

--- a/web/src/i18n/locales/pt-BR/channels.json
+++ b/web/src/i18n/locales/pt-BR/channels.json
@@ -11,7 +11,9 @@
     "agent": "Agente",
     "triggerPattern": "Padrao de ativacao",
     "enabled": "Habilitado",
-    "config": "Configuracao"
+    "config": "Configuracao",
+    "appId": "App ID",
+    "appSecret": "App Secret"
   },
   "channelTypes": {
     "feishu": "Feishu (Lark)",
@@ -21,7 +23,9 @@
   "actions": {
     "toggle": "Alternar",
     "enable": "Habilitado",
-    "disable": "Desabilitado"
+    "disable": "Desabilitado",
+    "edit": "Editar",
+    "save": "Salvar"
   },
   "adapters": {
     "title": "Status do adaptador",
@@ -48,7 +52,8 @@
     "configured": "configurado",
     "alreadyConnected": "O adaptador ja esta conectado. Deixe os campos vazios para manter as credenciais existentes.",
     "keepExisting": "Deixe vazio para manter o valor atual",
-    "hint": "As credenciais sao salvas como variaveis de ambiente e usadas para conectar o adaptador."
+    "hint": "As credenciais sao salvas como variaveis de ambiente e usadas para conectar o adaptador.",
+    "configHint": "As credenciais sao armazenadas com esta vinculacao e usadas para conectar o adaptador."
   },
   "hints": {
     "externalId": "O ID do chat ou grupo na plataforma externa",

--- a/web/src/i18n/locales/zh-CN/channels.json
+++ b/web/src/i18n/locales/zh-CN/channels.json
@@ -11,7 +11,9 @@
     "agent": "Agent",
     "triggerPattern": "触发模式",
     "enabled": "已启用",
-    "config": "配置"
+    "config": "配置",
+    "appId": "App ID",
+    "appSecret": "App Secret"
   },
   "channelTypes": {
     "feishu": "飞书",
@@ -21,7 +23,9 @@
   "actions": {
     "toggle": "切换",
     "enable": "已启用",
-    "disable": "已禁用"
+    "disable": "已禁用",
+    "edit": "编辑",
+    "save": "保存"
   },
   "adapters": {
     "title": "适配器状态",
@@ -48,7 +52,8 @@
     "configured": "已配置",
     "alreadyConnected": "适配器已连接。留空以保留现有凭证。",
     "keepExisting": "留空以保留当前值",
-    "hint": "凭证将保存为环境变量，用于连接适配器。"
+    "hint": "凭证将保存为环境变量，用于连接适配器。",
+    "configHint": "凭证将随此绑定一起存储，用于连接适配器。"
   },
   "hints": {
     "externalId": "外部平台上的聊天或群组 ID",

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2058,6 +2058,7 @@ export interface ChannelBinding {
   external_id: string;
   name: string;
   agent_id: string;
+  agent_name: string | null;
   trigger_pattern: string | null;
   enabled: boolean;
   config: Record<string, unknown> | null;


### PR DESCRIPTION
## Summary
- **Multi-Feishu-app support**: Each unique `app_id` gets its own WebSocket adapter (`feishu:{app_id}` keying). Multiple bindings sharing the same app reuse one connection.
- **Channel edit UI**: Full CRUD for channel bindings with config editing (app_id/app_secret), secret masking (`****<last4>`), and adapter status/restart controls.
- **Service leader election**: Only 1 of 8 uvicorn workers runs ChannelManager + Scheduler via `fcntl.flock`, preventing duplicate event processing and duplicate scheduled task execution across workers. Hot-reload hooks are guarded by `_is_leader` flag so non-leader workers never start adapters.
- **Thread-safe event loop proxy**: Module-level `_LoopProxy` replaces the lark SDK's module-level `loop` variable so multiple WS clients in separate threads each use their own event loop. Uses `get_event_loop_policy().get_event_loop()` to avoid Python 3.10+ deprecation warnings.
- **Hot-reload hooks**: Creating/updating/deleting bindings automatically starts/stops adapters without restart (leader-only, with `exc_info=True` logging for debuggability).
- **Adapter API DB fallback**: Non-leader workers derive adapter status from DB bindings. Leader detection uses explicit `_is_leader` flag (not empty `_adapters` check). Non-leader restart returns 202 Accepted.
- **i18n**: All 5 languages updated for new channel UI strings.

## Test plan
- [x] All 213 existing tests pass
- [x] E2E tests added for multi-app adapter lifecycle, hot-reload, and secret masking
- [x] Verified both SciClaw and TechClaw bots receive messages via standalone WebSocket test
- [x] Confirmed service leader election works across 8 workers (only 1 starts adapters)
- [x] Tested adapter status/restart endpoints from non-leader workers

🤖 Generated with [Claude Code](https://claude.com/claude-code)