### PR TITLE
feat: add channel delivery option to scheduled tasks

### DIFF
--- a/web/src/app/scheduled-tasks/[id]/page.tsx
+++ b/web/src/app/scheduled-tasks/[id]/page.tsx
@@ -10,6 +10,7 @@ import {
   Zap,
   ExternalLink,
   Clock,
+  Send,
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -279,6 +280,22 @@ export default function ScheduledTaskDetailPage() {
               <div>
                 <span className="text-sm font-medium text-muted-foreground">{t('fields.runCount')}</span>
                 <p className="mt-1 text-sm">{task.run_count}</p>
+              </div>
+              <div>
+                <span className="text-sm font-medium text-muted-foreground">{t('fields.channelBinding')}</span>
+                <div className="mt-1 text-sm">
+                  {task.channel_binding_id ? (
+                    <Link
+                      href={`/channels/${task.channel_binding_id}`}
+                      className="inline-flex items-center gap-1 text-blue-500 hover:text-blue-600"
+                    >
+                      <Send className="h-3 w-3" />
+                      {task.channel_binding_name || task.channel_binding_id}
+                    </Link>
+                  ) : (
+                    <span className="text-muted-foreground">-</span>
+                  )}
+                </div>
               </div>
               <div>
                 <span className="text-sm font-medium text-muted-foreground">{t('fields.nextRun')}</span>

--- a/web/src/app/scheduled-tasks/new/page.tsx
+++ b/web/src/app/scheduled-tasks/new/page.tsx
@@ -20,6 +20,7 @@ import { Spinner } from '@/components/ui/spinner';
 import { toast } from 'sonner';
 import { useCreateScheduledTask } from '@/hooks/use-scheduled-tasks';
 import { useAgentPresets } from '@/hooks/use-agents';
+import { useChannelBindings } from '@/hooks/use-channels';
 import { useTranslation } from '@/i18n/client';
 
 const SCHEDULE_TYPES = [
@@ -40,6 +41,7 @@ export default function NewScheduledTaskPage() {
 
   const createTask = useCreateScheduledTask();
   const { data: agentsData, isLoading: agentsLoading } = useAgentPresets();
+  const { data: channelsData, isLoading: channelsLoading } = useChannelBindings();
 
   const [name, setName] = useState('');
   const [agentId, setAgentId] = useState('');
@@ -48,8 +50,10 @@ export default function NewScheduledTaskPage() {
   const [scheduleValue, setScheduleValue] = useState('');
   const [contextMode, setContextMode] = useState('isolated');
   const [maxRuns, setMaxRuns] = useState('');
+  const [channelBindingId, setChannelBindingId] = useState('');
 
   const agents = agentsData?.presets || [];
+  const channels = channelsData?.bindings?.filter((b) => b.enabled) || [];
 
   const getPlaceholder = () => {
     switch (scheduleType) {
@@ -81,6 +85,7 @@ export default function NewScheduledTaskPage() {
         schedule_value: scheduleValue.trim(),
         context_mode: contextMode,
         max_runs: maxRuns ? parseInt(maxRuns, 10) : null,
+        channel_binding_id: channelBindingId && channelBindingId !== 'none' ? channelBindingId : null,
       });
       toast.success(t('messages.created'));
       router.push('/scheduled-tasks');
@@ -217,6 +222,35 @@ export default function NewScheduledTaskPage() {
                   onChange={(e) => setMaxRuns(e.target.value)}
                   placeholder="100"
                 />
+              </div>
+
+              {/* Channel Binding */}
+              <div className="space-y-2">
+                <Label htmlFor="channel-binding">
+                  {t('fields.channelBinding')}
+                  <span className="text-muted-foreground text-xs ml-1">({tc('status.optional')})</span>
+                </Label>
+                {channelsLoading ? (
+                  <div className="flex items-center gap-2 py-2">
+                    <Spinner size="sm" />
+                    <span className="text-sm text-muted-foreground">{tc('status.loading')}</span>
+                  </div>
+                ) : (
+                  <Select value={channelBindingId} onValueChange={setChannelBindingId}>
+                    <SelectTrigger id="channel-binding">
+                      <SelectValue placeholder={t('fields.noChannel')} />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="none">{t('fields.noChannel')}</SelectItem>
+                      {channels.map((ch) => (
+                        <SelectItem key={ch.id} value={ch.id}>
+                          [{ch.channel_type}] {ch.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
+                <p className="text-xs text-muted-foreground">{t('hints.channelBinding')}</p>
               </div>
 
               {/* Submit */}

--- a/web/src/i18n/locales/en-US/scheduled-tasks.json
+++ b/web/src/i18n/locales/en-US/scheduled-tasks.json
@@ -15,7 +15,12 @@
     "status": "Status",
     "nextRun": "Next Run",
     "lastRun": "Last Run",
-    "runCount": "Run Count"
+    "runCount": "Run Count",
+    "channelBinding": "Deliver To Channel",
+    "noChannel": "None (no delivery)"
+  },
+  "hints": {
+    "channelBinding": "Optionally send task results to a channel binding"
   },
   "scheduleTypes": {
     "cron": "Cron",

--- a/web/src/i18n/locales/es/scheduled-tasks.json
+++ b/web/src/i18n/locales/es/scheduled-tasks.json
@@ -15,7 +15,12 @@
     "status": "Estado",
     "nextRun": "Próxima Ejecución",
     "lastRun": "Última Ejecución",
-    "runCount": "Cantidad de Ejecuciones"
+    "runCount": "Cantidad de Ejecuciones",
+    "channelBinding": "Entregar al Canal",
+    "noChannel": "Ninguno (sin entrega)"
+  },
+  "hints": {
+    "channelBinding": "Opcional: enviar los resultados de la tarea a un canal vinculado"
   },
   "scheduleTypes": {
     "cron": "Cron",

--- a/web/src/i18n/locales/ja/scheduled-tasks.json
+++ b/web/src/i18n/locales/ja/scheduled-tasks.json
@@ -15,7 +15,12 @@
     "status": "ステータス",
     "nextRun": "次回実行",
     "lastRun": "前回実行",
-    "runCount": "実行回数"
+    "runCount": "実行回数",
+    "channelBinding": "チャンネルに配信",
+    "noChannel": "なし（配信しない）"
+  },
+  "hints": {
+    "channelBinding": "オプション：タスク結果を指定のチャンネルバインディングに送信"
   },
   "scheduleTypes": {
     "cron": "Cron",

--- a/web/src/i18n/locales/pt-BR/scheduled-tasks.json
+++ b/web/src/i18n/locales/pt-BR/scheduled-tasks.json
@@ -15,7 +15,12 @@
     "status": "Status",
     "nextRun": "Próxima Execução",
     "lastRun": "Última Execução",
-    "runCount": "Contagem de Execuções"
+    "runCount": "Contagem de Execuções",
+    "channelBinding": "Entregar ao Canal",
+    "noChannel": "Nenhum (sem entrega)"
+  },
+  "hints": {
+    "channelBinding": "Opcional: enviar os resultados da tarefa para um canal vinculado"
   },
   "scheduleTypes": {
     "cron": "Cron",

--- a/web/src/i18n/locales/zh-CN/scheduled-tasks.json
+++ b/web/src/i18n/locales/zh-CN/scheduled-tasks.json
@@ -15,7 +15,12 @@
     "status": "状态",
     "nextRun": "下次运行",
     "lastRun": "上次运行",
-    "runCount": "运行次数"
+    "runCount": "运行次数",
+    "channelBinding": "投递到渠道",
+    "noChannel": "无（不投递）"
+  },
+  "hints": {
+    "channelBinding": "可选：将任务结果发送到指定的渠道绑定"
   },
   "scheduleTypes": {
     "cron": "Cron 表达式",

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2223,6 +2223,7 @@ export interface ScheduledTask {
   context_mode: string;
   session_id: string | null;
   channel_binding_id: string | null;
+  channel_binding_name: string | null;
   status: string;
   next_run: string | null;
   last_run: string | null;
@@ -2240,6 +2241,7 @@ export interface ScheduledTaskCreateRequest {
   schedule_value: string;
   context_mode?: string;
   max_runs?: number | null;
+  channel_binding_id?: string | null;
 }
 
 export interface ScheduledTaskUpdateRequest {
@@ -2249,6 +2251,7 @@ export interface ScheduledTaskUpdateRequest {
   schedule_value?: string;
   context_mode?: string;
   max_runs?: number | null;
+  channel_binding_id?: string | null;
 }
 
 export interface TaskRunLog {


### PR DESCRIPTION
## Summary

- Add optional "Deliver To Channel" dropdown to the scheduled task creation form, allowing users to route task output to a Feishu group, Telegram chat, or other channel binding
- Display linked channel binding on the task detail page as a clickable link
- Backend validates channel binding FK and returns `channel_binding_name` in responses

Closes #217

## Changes

**Backend** (`app/api/v1/scheduler.py`):
- Add `channel_binding_id` to `ScheduledTaskCreate` and `ScheduledTaskUpdate` schemas
- Add `channel_binding_name` to `ScheduledTaskResponse`
- Validate channel binding exists on create
- Batch-load binding names in list endpoint, single load in detail endpoint

**Frontend**:
- `new/page.tsx`: Add channel binding selector (optional, filters to enabled bindings only)
- `[id]/page.tsx`: Show channel binding as clickable link with Send icon
- `api.ts`: Add `channel_binding_id` to create/update request types, `channel_binding_name` to response type

**i18n** (all 5 languages):
- `fields.channelBinding`, `fields.noChannel`, `hints.channelBinding`

## Test plan

- [x] API: create task with `channel_binding_id` → returns `channel_binding_name`
- [x] API: GET task detail → includes `channel_binding_name`
- [x] API: list tasks → batch-loads `channel_binding_name`
- [x] API: create with invalid binding ID → returns 400
- [x] Frontend: "Deliver To Channel" dropdown shows enabled bindings
- [x] Frontend: task detail page shows linked channel as clickable link
- [x] Docker redeploy successful, all containers healthy