### PR TITLE
feat: add global Feishu binding support (all-groups mode)

### DIFF
--- a/app/channels/feishu.py
+++ b/app/channels/feishu.py
@@ -251,6 +251,12 @@ class FeishuAdapter(ChannelAdapter):
             msg = event.message
             sender = event.sender
 
+            chat_type = getattr(msg, "chat_type", "unknown")
+            logger.info(
+                f"Feishu inbound event: chat_type={chat_type} chat_id={msg.chat_id} "
+                f"msg_id={msg.message_id} msg_type={msg.message_type}"
+            )
+
             # Message dedup
             msg_id = msg.message_id
             if msg_id in self._seen_messages:
@@ -309,6 +315,7 @@ class FeishuAdapter(ChannelAdapter):
                 message_type=msg_type,
                 external_message_id=msg.message_id,
                 media=media_paths,
+                metadata={"app_id": self._app_id, "chat_type": chat_type},
             )
 
             # Bridge from the WS thread into the async event loop

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -732,7 +732,8 @@ class ChannelBindingDB(Base):
     )
 
     __table_args__ = (
-        UniqueConstraint("channel_type", "external_id", name="uq_channel_binding"),
+        # UniqueConstraint replaced by partial indexes (uq_channel_binding_specific,
+        # uq_channel_binding_global) created in _run_migrations() for global binding support
         Index("ix_channel_bindings_channel_type", "channel_type"),
     )
 

--- a/tests/test_api/test_channels.py
+++ b/tests/test_api/test_channels.py
@@ -143,3 +143,158 @@ class TestChannelsAPI:
     async def test_adapters_status(self, client):
         resp = await client.get("/api/v1/channels/adapters")
         assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+class TestGlobalBindingsAPI:
+    """Tests for global Feishu binding support (external_id='*')."""
+
+    async def test_create_global_binding(self, client, db_session):
+        """Creating a Feishu binding without external_id should produce a global binding."""
+        preset = make_preset(name="global-agent-1")
+        db_session.add(preset)
+        await db_session.commit()
+
+        resp = await client.post("/api/v1/channels", json={
+            "channel_type": "feishu",
+            "name": "Global Feishu",
+            "agent_id": preset.id,
+            "config": {"app_id": "cli_global_001", "app_secret": "secret123"},
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["external_id"] == "*"
+        assert data["is_global"] is True
+
+    async def test_create_global_binding_explicit_star(self, client, db_session):
+        """Creating with external_id='*' explicitly should also work."""
+        preset = make_preset(name="global-agent-2")
+        db_session.add(preset)
+        await db_session.commit()
+
+        resp = await client.post("/api/v1/channels", json={
+            "channel_type": "feishu",
+            "external_id": "*",
+            "name": "Global Feishu Explicit",
+            "agent_id": preset.id,
+            "config": {"app_id": "cli_global_002", "app_secret": "secret456"},
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["external_id"] == "*"
+        assert data["is_global"] is True
+
+    async def test_global_binding_feishu_only(self, client, db_session):
+        """Global bindings should be rejected for non-Feishu channel types."""
+        preset = make_preset(name="global-agent-3")
+        db_session.add(preset)
+        await db_session.commit()
+
+        resp = await client.post("/api/v1/channels", json={
+            "channel_type": "webhook",
+            "name": "Global Webhook",
+            "agent_id": preset.id,
+        })
+        assert resp.status_code == 400
+        assert "only supported for Feishu" in resp.json()["detail"]
+
+    async def test_global_binding_requires_app_id(self, client, db_session):
+        """Global Feishu bindings must have app_id in config."""
+        preset = make_preset(name="global-agent-4")
+        db_session.add(preset)
+        await db_session.commit()
+
+        resp = await client.post("/api/v1/channels", json={
+            "channel_type": "feishu",
+            "name": "Global No AppId",
+            "agent_id": preset.id,
+            "config": {"app_secret": "secret789"},
+        })
+        assert resp.status_code == 400
+        assert "app_id" in resp.json()["detail"]
+
+    async def test_duplicate_global_binding_rejected(self, client, db_session):
+        """Two global bindings for the same app_id should be rejected."""
+        preset = make_preset(name="global-agent-5")
+        db_session.add(preset)
+        await db_session.commit()
+
+        resp1 = await client.post("/api/v1/channels", json={
+            "channel_type": "feishu",
+            "name": "Global Feishu First",
+            "agent_id": preset.id,
+            "config": {"app_id": "cli_dup_global", "app_secret": "sec1"},
+        })
+        assert resp1.status_code == 200
+
+        resp2 = await client.post("/api/v1/channels", json={
+            "channel_type": "feishu",
+            "name": "Global Feishu Duplicate",
+            "agent_id": preset.id,
+            "config": {"app_id": "cli_dup_global", "app_secret": "sec2"},
+        })
+        assert resp2.status_code == 409
+
+    async def test_specific_binding_is_not_global(self, client, db_session):
+        """A binding with a specific external_id should have is_global=False."""
+        preset = make_preset(name="global-agent-6")
+        db_session.add(preset)
+        await db_session.commit()
+
+        resp = await client.post("/api/v1/channels", json={
+            "channel_type": "feishu",
+            "external_id": "oc_specific_001",
+            "name": "Specific Feishu",
+            "agent_id": preset.id,
+            "config": {"app_id": "cli_specific_001", "app_secret": "sec3"},
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["is_global"] is False
+        assert data["external_id"] == "oc_specific_001"
+
+    async def test_global_and_specific_coexist(self, client, db_session):
+        """A global binding and specific binding for the same app can coexist."""
+        preset = make_preset(name="global-agent-7")
+        db_session.add(preset)
+        await db_session.commit()
+
+        # Create global
+        resp1 = await client.post("/api/v1/channels", json={
+            "channel_type": "feishu",
+            "name": "Global Coexist",
+            "agent_id": preset.id,
+            "config": {"app_id": "cli_coexist", "app_secret": "sec4"},
+        })
+        assert resp1.status_code == 200
+        assert resp1.json()["is_global"] is True
+
+        # Create specific for same app
+        resp2 = await client.post("/api/v1/channels", json={
+            "channel_type": "feishu",
+            "external_id": "oc_coexist_001",
+            "name": "Specific Coexist",
+            "agent_id": preset.id,
+            "config": {"app_id": "cli_coexist", "app_secret": "sec5"},
+        })
+        assert resp2.status_code == 200
+        assert resp2.json()["is_global"] is False
+
+    async def test_is_global_in_list_response(self, client, db_session):
+        """The is_global field should appear in list responses."""
+        preset = make_preset(name="global-agent-8")
+        db_session.add(preset)
+        await db_session.commit()
+
+        await client.post("/api/v1/channels", json={
+            "channel_type": "feishu",
+            "name": "List Global",
+            "agent_id": preset.id,
+            "config": {"app_id": "cli_list_global", "app_secret": "sec6"},
+        })
+
+        resp = await client.get("/api/v1/channels")
+        assert resp.status_code == 200
+        bindings = resp.json()["bindings"]
+        global_binding = next(b for b in bindings if b["name"] == "List Global")
+        assert global_binding["is_global"] is True

--- a/web/src/app/channels/[id]/page.tsx
+++ b/web/src/app/channels/[id]/page.tsx
@@ -374,7 +374,13 @@ export default function ChannelDetailPage() {
                 </div>
                 <div>
                   <span className="text-sm font-medium text-muted-foreground">{t('fields.externalId')}</span>
-                  <p className="mt-1 font-mono text-sm">{binding.external_id}</p>
+                  <div className="mt-1">
+                    {binding.is_global ? (
+                      <Badge variant="info">{t('scope.allGroups')}</Badge>
+                    ) : (
+                      <p className="font-mono text-sm">{binding.external_id}</p>
+                    )}
+                  </div>
                 </div>
                 <div>
                   <span className="text-sm font-medium text-muted-foreground">{t('fields.agent')}</span>

--- a/web/src/app/channels/page.tsx
+++ b/web/src/app/channels/page.tsx
@@ -269,7 +269,11 @@ function BindingCard({
         <div className="space-y-1.5 text-sm text-muted-foreground flex-1">
           <div>
             <span className="font-medium">{t('fields.externalId')}:</span>{' '}
-            <span className="font-mono text-xs">{binding.external_id}</span>
+            {binding.is_global ? (
+              <Badge variant="info" className="text-xs">{t('scope.allGroups')}</Badge>
+            ) : (
+              <span className="font-mono text-xs">{binding.external_id}</span>
+            )}
           </div>
           {binding.trigger_pattern && (
             <div>

--- a/web/src/app/scheduled-tasks/new/page.tsx
+++ b/web/src/app/scheduled-tasks/new/page.tsx
@@ -53,7 +53,7 @@ export default function NewScheduledTaskPage() {
   const [channelBindingId, setChannelBindingId] = useState('');
 
   const agents = agentsData?.presets || [];
-  const channels = channelsData?.bindings?.filter((b) => b.enabled) || [];
+  const channels = channelsData?.bindings?.filter((b) => b.enabled && !b.is_global) || [];
 
   const getPlaceholder = () => {
     switch (scheduleType) {

--- a/web/src/i18n/locales/en-US/channels.json
+++ b/web/src/i18n/locales/en-US/channels.json
@@ -13,7 +13,14 @@
     "enabled": "Enabled",
     "config": "Configuration",
     "appId": "App ID",
-    "appSecret": "App Secret"
+    "appSecret": "App Secret",
+    "scope": "Scope"
+  },
+  "scope": {
+    "allGroups": "All Groups",
+    "specificGroup": "Specific Group",
+    "allGroupsHint": "Respond in every group the bot is added to",
+    "specificGroupHint": "Only respond in one specific group"
   },
   "channelTypes": {
     "feishu": "Feishu (Lark)",

--- a/web/src/i18n/locales/es/channels.json
+++ b/web/src/i18n/locales/es/channels.json
@@ -13,7 +13,14 @@
     "enabled": "Habilitado",
     "config": "Configuracion",
     "appId": "App ID",
-    "appSecret": "App Secret"
+    "appSecret": "App Secret",
+    "scope": "Alcance"
+  },
+  "scope": {
+    "allGroups": "Todos los grupos",
+    "specificGroup": "Grupo especifico",
+    "allGroupsHint": "Responder en todos los grupos donde se agrego el bot",
+    "specificGroupHint": "Responder solo en un grupo especifico"
   },
   "channelTypes": {
     "feishu": "Feishu (Lark)",

--- a/web/src/i18n/locales/ja/channels.json
+++ b/web/src/i18n/locales/ja/channels.json
@@ -13,7 +13,14 @@
     "enabled": "有効",
     "config": "設定",
     "appId": "App ID",
-    "appSecret": "App Secret"
+    "appSecret": "App Secret",
+    "scope": "スコープ"
+  },
+  "scope": {
+    "allGroups": "全グループ",
+    "specificGroup": "特定グループ",
+    "allGroupsHint": "ボットが追加されたすべてのグループで応答",
+    "specificGroupHint": "特定の1つのグループでのみ応答"
   },
   "channelTypes": {
     "feishu": "Feishu (Lark)",

--- a/web/src/i18n/locales/pt-BR/channels.json
+++ b/web/src/i18n/locales/pt-BR/channels.json
@@ -13,7 +13,14 @@
     "enabled": "Habilitado",
     "config": "Configuracao",
     "appId": "App ID",
-    "appSecret": "App Secret"
+    "appSecret": "App Secret",
+    "scope": "Escopo"
+  },
+  "scope": {
+    "allGroups": "Todos os grupos",
+    "specificGroup": "Grupo especifico",
+    "allGroupsHint": "Responder em todos os grupos onde o bot foi adicionado",
+    "specificGroupHint": "Responder apenas em um grupo especifico"
   },
   "channelTypes": {
     "feishu": "Feishu (Lark)",

--- a/web/src/i18n/locales/zh-CN/channels.json
+++ b/web/src/i18n/locales/zh-CN/channels.json
@@ -13,7 +13,14 @@
     "enabled": "已启用",
     "config": "配置",
     "appId": "App ID",
-    "appSecret": "App Secret"
+    "appSecret": "App Secret",
+    "scope": "作用范围"
+  },
+  "scope": {
+    "allGroups": "所有群组",
+    "specificGroup": "指定群组",
+    "allGroupsHint": "在机器人加入的所有群组中响应",
+    "specificGroupHint": "仅在一个指定群组中响应"
   },
   "channelTypes": {
     "feishu": "飞书",

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2061,6 +2061,7 @@ export interface ChannelBinding {
   agent_name: string | null;
   trigger_pattern: string | null;
   enabled: boolean;
+  is_global: boolean;
   config: Record<string, unknown> | null;
   created_at: string;
   updated_at: string;
@@ -2073,7 +2074,7 @@ export interface ChannelBindingListResponse {
 
 export interface ChannelBindingCreateRequest {
   channel_type: string;
-  external_id: string;
+  external_id?: string;
   name: string;
   agent_id: string;
   trigger_pattern?: string | null;


### PR DESCRIPTION
## Summary

- Allow a single Feishu bot to serve **all groups** it's added to via a sentinel `external_id="*"`, eliminating the need for per-group binding configuration
- Specific per-group bindings still take priority over global ones during message routing (two-level lookup)
- Frontend adds a scope toggle (All Groups / Specific Group) on the create form, and shows an "All Groups" badge on list/detail pages

## Changes

| Area | Files | What |
|------|-------|------|
| DB | `database.py`, `models.py` | Replace unique constraint with partial indexes for specific vs global bindings |
| Adapter | `feishu.py` | Add `app_id` to inbound message metadata for global routing |
| Routing | `channel_manager.py` | Two-level lookup (exact → global fallback) + skip global bindings for scheduled sends |
| API | `channels.py` | Optional `external_id`, `is_global` response field, Feishu-only validation |
| Frontend | `new/page.tsx`, `page.tsx`, `[id]/page.tsx`, `api.ts` | Scope toggle UI, "All Groups" badge, updated TS types |
| i18n | 5 locale files | Scope-related keys in en-US, zh-CN, ja, es, pt-BR |
| Tests | `test_channels.py`, `test_e2e_workflows.py` | 18 unit + 10 E2E tests covering global binding lifecycle |

## Test plan

- [x] 18 unit tests pass (global creation, validation, duplicate rejection, coexistence, is_global field)
- [x] 10 E2E tests pass (full lifecycle: create → list → detail → toggle → routing priority → delete)
- [x] 22 existing E2E tests pass (no regressions)
- [x] Redeployed and all containers healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)