### PR TITLE
feat: unified agent execution service layer + global Feishu binding

### DIFF
--- a/app/api/v1/agent.py
+++ b/app/api/v1/agent.py
@@ -4,7 +4,6 @@ import base64
 import json
 import logging
 import time
-from dataclasses import asdict
 from pathlib import Path
 from typing import Dict, Optional, List, Tuple
 
@@ -14,11 +13,12 @@ from pydantic import BaseModel, Field
 from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.agent import SkillsAgent, EventStream, write_steering_message, poll_steering_messages, cleanup_steering_dir
+from app.agent import EventStream, write_steering_message, poll_steering_messages, cleanup_steering_dir
 from app.api.v1.display_builder import DisplayMessageBuilder
 from app.api.v1.sessions import load_or_create_session, save_session_messages, save_session_checkpoint, save_session_checkpoint_sync, pre_compress_if_needed, CHAT_SENTINEL_AGENT_ID
 from app.db.database import get_db, AsyncSessionLocal, SyncSessionLocal
 from app.db.models import AgentTraceDB, AgentPresetDB
+from app.services.agent_runner import AgentConfig, config_from_preset, create_agent, build_completed_trace, build_initial_trace
 
 logger = logging.getLogger("skills_api")
 
@@ -145,7 +145,7 @@ async def steer_agent(trace_id: str, body: SteerRequest, db: AsyncSession = Depe
     return {"status": "injected", "trace_id": trace_id}
 
 
-async def _resolve_agent_config(request: AgentRequest, db: AsyncSession) -> dict:
+async def _resolve_agent_config(request: AgentRequest, db: AsyncSession) -> AgentConfig:
     """Resolve effective agent config. If agent_id is set, load preset and use its config."""
     from sqlalchemy import select
 
@@ -161,18 +161,18 @@ async def _resolve_agent_config(request: AgentRequest, db: AsyncSession) -> dict
                     detail=f"Executor '{executor_name}' is offline. Cannot run agent."
                 )
 
-        return {
-            "skills": request.skills,
-            "allowed_tools": request.allowed_tools,
-            "max_turns": request.max_turns,
-            "equipped_mcp_servers": request.equipped_mcp_servers,
-            "system_prompt": request.system_prompt,
-            "model_provider": request.model_provider,
-            "model_name": request.model_name,
-            "agent_id": None,
-            "executor_name": executor_name,
-            "is_meta_agent": False,
-        }
+        return AgentConfig(
+            skills=request.skills,
+            allowed_tools=request.allowed_tools,
+            max_turns=request.max_turns,
+            equipped_mcp_servers=request.equipped_mcp_servers,
+            system_prompt=request.system_prompt,
+            model_provider=request.model_provider,
+            model_name=request.model_name,
+            agent_id=None,
+            executor_name=executor_name,
+            is_meta_agent=False,
+        )
 
     result = await db.execute(
         select(AgentPresetDB).where(AgentPresetDB.id == request.agent_id)
@@ -192,18 +192,11 @@ async def _resolve_agent_config(request: AgentRequest, db: AsyncSession) -> dict
                 detail=f"Executor '{executor_name}' is offline. Cannot run agent."
             )
 
-    return {
-        "skills": preset.skill_ids,
-        "allowed_tools": preset.builtin_tools,
-        "max_turns": preset.max_turns,
-        "equipped_mcp_servers": preset.mcp_servers,
-        "system_prompt": preset.system_prompt,
-        "model_provider": preset.model_provider or request.model_provider,
-        "model_name": preset.model_name or request.model_name,
-        "agent_id": preset.id,
-        "executor_name": executor_name,
-        "is_meta_agent": preset.is_system,
-    }
+    cfg = config_from_preset(preset)
+    # Override model from request if preset doesn't specify
+    cfg.model_provider = preset.model_provider or request.model_provider
+    cfg.model_name = preset.model_name or request.model_name
+    return cfg
 
 
 def _build_request_with_files(
@@ -284,7 +277,7 @@ IMPORTANT: Use the absolute file paths shown above when reading or processing fi
     return actual_request, image_contents
 
 
-def _validate_api_key(config: dict):
+def _validate_api_key(config: AgentConfig):
     """Validate that the API key for the selected provider is configured.
 
     Raises HTTPException(400) if the key is missing or empty.
@@ -293,7 +286,7 @@ def _validate_api_key(config: dict):
     from app.llm.provider import PROVIDER_API_KEY_MAP
 
     settings_obj = get_settings()
-    provider = config.get("model_provider") or settings_obj.default_model_provider
+    provider = config.model_provider or settings_obj.default_model_provider
     env_var = PROVIDER_API_KEY_MAP.get(provider, f"{provider.upper()}_API_KEY")
     key_value = read_env_value(env_var)
     if not key_value or not key_value.strip():
@@ -302,23 +295,6 @@ def _validate_api_key(config: dict):
             detail=f"API key for provider '{provider}' is not configured. "
                    f"Please set {env_var} in Settings > Environment.",
         )
-
-
-def _create_agent(config: dict, workspace_id: Optional[str] = None) -> SkillsAgent:
-    """Create a SkillsAgent from resolved config."""
-    return SkillsAgent(
-        model=config.get("model_name"),
-        model_provider=config.get("model_provider"),
-        max_turns=config["max_turns"],
-        verbose=True,
-        allowed_skills=config["skills"],
-        allowed_tools=config["allowed_tools"],
-        equipped_mcp_servers=config["equipped_mcp_servers"],
-        custom_system_prompt=config["system_prompt"],
-        executor_name=config.get("executor_name"),
-        workspace_id=workspace_id,
-        is_meta_agent=config.get("is_meta_agent", False),
-    )
 
 
 @router.post("/run", response_model=AgentResponse)
@@ -341,19 +317,19 @@ async def run_agent(request: AgentRequest, db: AsyncSession = Depends(get_db)):
     start_time = time.time()
 
     # Load session history from DB (dual-store)
-    agent_id = config.get("agent_id") or CHAT_SENTINEL_AGENT_ID
-    session_data = await load_or_create_session(request.session_id, agent_id)
+    agent_id_for_session = config.agent_id or CHAT_SENTINEL_AGENT_ID
+    session_data = await load_or_create_session(request.session_id, agent_id_for_session)
     session_id = session_data.session_id
     history = session_data.agent_context  # Use agent_context for the agent
 
     # Create agent with session_id as workspace_id for deterministic mapping
-    agent = _create_agent(config, workspace_id=session_id)
+    agent = create_agent(config, workspace_id=session_id)
 
     try:
         # Pre-compress if context exceeds threshold
         from app.config import settings as app_settings_run
-        effective_provider = config.get("model_provider") or app_settings_run.default_model_provider
-        effective_model = config.get("model_name") or app_settings_run.default_model_name
+        effective_provider = config.model_provider or app_settings_run.default_model_provider
+        effective_model = config.model_name or app_settings_run.default_model_name
         if history:
             history = await pre_compress_if_needed(history, effective_provider, effective_model)
 
@@ -361,8 +337,8 @@ async def run_agent(request: AgentRequest, db: AsyncSession = Depends(get_db)):
         actual_request, image_contents = _build_request_with_files(
             request.request,
             request.uploaded_files,
-            model_provider=config.get("model_provider"),
-            model_name=config.get("model_name"),
+            model_provider=config.model_provider,
+            model_name=config.model_name,
         )
 
         result = await agent.run(actual_request, conversation_history=history, image_contents=image_contents)
@@ -370,22 +346,12 @@ async def run_agent(request: AgentRequest, db: AsyncSession = Depends(get_db)):
         duration_ms = int((time.time() - start_time) * 1000)
 
         # Save trace to database
-        trace = AgentTraceDB(
-            request=request.request,
-            skills_used=result.skills_used or [],
-            model_provider=agent.model_provider,
-            model=agent.model,
-            status="completed" if result.success else "failed",
-            success=result.success,
-            answer=result.answer,
-            error=result.error,
-            total_turns=result.total_turns,
-            total_input_tokens=result.total_input_tokens,
-            total_output_tokens=result.total_output_tokens,
-            steps=[asdict(step) for step in result.steps],
-            llm_calls=[asdict(call) for call in result.llm_calls],
+        trace = build_completed_trace(
+            request_text=request.request,
+            result=result,
+            agent=agent,
             duration_ms=duration_ms,
-            executor_name=config.get("executor_name"),
+            executor_name=config.executor_name,
             session_id=session_id,
         )
         db.add(trace)
@@ -450,12 +416,12 @@ async def run_agent_stream(request: AgentRequest, db: AsyncSession = Depends(get
     actual_request, image_contents = _build_request_with_files(
         request.request,
         request.uploaded_files,
-        model_provider=config.get("model_provider"),
-        model_name=config.get("model_name"),
+        model_provider=config.model_provider,
+        model_name=config.model_name,
     )
 
     # Load session history from DB (dual-store)
-    agent_id_for_session = config.get("agent_id") or CHAT_SENTINEL_AGENT_ID
+    agent_id_for_session = config.agent_id or CHAT_SENTINEL_AGENT_ID
     session_data = await load_or_create_session(request.session_id, agent_id_for_session)
     session_id = session_data.session_id
     history = session_data.agent_context  # Use agent_context for the agent
@@ -463,8 +429,8 @@ async def run_agent_stream(request: AgentRequest, db: AsyncSession = Depends(get
 
     # Pre-compress if context exceeds threshold
     from app.config import settings as app_settings_pre
-    pre_provider = config.get("model_provider") or app_settings_pre.default_model_provider
-    pre_model = config.get("model_name") or app_settings_pre.default_model_name
+    pre_provider = config.model_provider or app_settings_pre.default_model_provider
+    pre_model = config.model_name or app_settings_pre.default_model_name
     if history:
         history = await pre_compress_if_needed(history, pre_provider, pre_model)
 
@@ -474,25 +440,14 @@ async def run_agent_stream(request: AgentRequest, db: AsyncSession = Depends(get
         # Create trace record at the start (with running status)
         trace_id = None
         from app.config import settings as app_settings
-        effective_provider = config.get("model_provider") or app_settings.default_model_provider
-        effective_model = config.get("model_name") or app_settings.default_model_name
+        effective_provider = config.model_provider or app_settings.default_model_provider
+        effective_model = config.model_name or app_settings.default_model_name
         async with AsyncSessionLocal() as trace_db:
-            trace = AgentTraceDB(
-                request=request.request,
-                skills_used=[],  # Will be updated on completion with actually used skills
+            trace = build_initial_trace(
+                request_text=request.request,
                 model_provider=effective_provider,
-                model=effective_model,
-                status="running",  # Will be updated on completion
-                success=False,  # Will be updated on completion
-                answer="",
-                error=None,
-                total_turns=0,
-                total_input_tokens=0,
-                total_output_tokens=0,
-                steps=[],
-                llm_calls=[],
-                duration_ms=0,
-                executor_name=config.get("executor_name"),
+                model_name=effective_model,
+                executor_name=config.executor_name,
                 session_id=session_id,
             )
             trace_db.add(trace)
@@ -503,19 +458,8 @@ async def run_agent_stream(request: AgentRequest, db: AsyncSession = Depends(get
         yield f"data: {json.dumps({'event_type': 'run_started', 'turn': 0, 'trace_id': trace_id, 'session_id': session_id})}\n\n"
 
         # Create agent, event stream, and cancellation event
-        agent = SkillsAgent(
-            model=config.get("model_name"),
-            model_provider=config.get("model_provider"),
-            max_turns=config["max_turns"],
-            verbose=False,
-            allowed_skills=config["skills"],
-            allowed_tools=config["allowed_tools"],
-            equipped_mcp_servers=config["equipped_mcp_servers"],
-            custom_system_prompt=config["system_prompt"],
-            executor_name=config.get("executor_name"),
-            workspace_id=session_id,
-            is_meta_agent=config.get("is_meta_agent", False),
-        )
+        config.verbose = False
+        agent = create_agent(config, workspace_id=session_id)
 
         event_stream = EventStream()
         cancel_event = asyncio.Event()

--- a/app/channels/feishu.py
+++ b/app/channels/feishu.py
@@ -251,6 +251,12 @@ class FeishuAdapter(ChannelAdapter):
             msg = event.message
             sender = event.sender
 
+            chat_type = getattr(msg, "chat_type", "unknown")
+            logger.info(
+                f"Feishu inbound event: chat_type={chat_type} chat_id={msg.chat_id} "
+                f"msg_id={msg.message_id} msg_type={msg.message_type}"
+            )
+
             # Message dedup
             msg_id = msg.message_id
             if msg_id in self._seen_messages:
@@ -309,6 +315,7 @@ class FeishuAdapter(ChannelAdapter):
                 message_type=msg_type,
                 external_message_id=msg.message_id,
                 media=media_paths,
+                metadata={"app_id": self._app_id, "chat_type": chat_type},
             )
 
             # Bridge from the WS thread into the async event loop

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -732,7 +732,8 @@ class ChannelBindingDB(Base):
     )
 
     __table_args__ = (
-        UniqueConstraint("channel_type", "external_id", name="uq_channel_binding"),
+        # UniqueConstraint replaced by partial indexes (uq_channel_binding_specific,
+        # uq_channel_binding_global) created in _run_migrations() for global binding support
         Index("ix_channel_bindings_channel_type", "channel_type"),
     )
 

--- a/app/services/agent_runner.py
+++ b/app/services/agent_runner.py
@@ -1,0 +1,141 @@
+"""Unified agent execution service layer.
+
+Provides shared agent construction, trace creation, and config resolution
+used by all 4 execution paths:
+  - /agent/run  (non-streaming)
+  - /agent/run/stream  (streaming SSE)
+  - scheduler  (periodic background tasks)
+  - channel_manager  (Feishu / Telegram inbound messages)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from typing import Optional, List, TYPE_CHECKING
+
+from app.db.models import AgentTraceDB, AgentPresetDB
+
+if TYPE_CHECKING:
+    from app.agent import SkillsAgent, AgentResult
+
+
+@dataclass
+class AgentConfig:
+    """Normalized agent configuration.
+
+    Replaces the dict returned by _resolve_agent_config and inline preset
+    field-mapping scattered across scheduler / channel_manager.
+    """
+    model_provider: Optional[str] = None
+    model_name: Optional[str] = None
+    max_turns: int = 60
+    skills: Optional[List[str]] = None
+    allowed_tools: Optional[List[str]] = None
+    equipped_mcp_servers: Optional[List[str]] = None
+    system_prompt: Optional[str] = None
+    executor_name: Optional[str] = None
+    agent_id: Optional[str] = None
+    is_meta_agent: bool = False
+    verbose: bool = True
+
+
+def config_from_preset(preset: AgentPresetDB) -> AgentConfig:
+    """Map AgentPresetDB fields to AgentConfig."""
+    return AgentConfig(
+        model_provider=preset.model_provider,
+        model_name=preset.model_name,
+        max_turns=preset.max_turns or 60,
+        skills=preset.skill_ids,
+        allowed_tools=preset.builtin_tools,
+        equipped_mcp_servers=preset.mcp_servers,
+        system_prompt=preset.system_prompt,
+        executor_name=preset.executor_name or None,
+        agent_id=preset.id,
+        is_meta_agent=preset.is_system,
+    )
+
+
+def create_agent(config: AgentConfig, workspace_id: Optional[str] = None) -> SkillsAgent:
+    """Create a SkillsAgent from an AgentConfig.
+
+    Single constructor replacing 4 duplicate SkillsAgent(...) calls.
+    """
+    from app.agent import SkillsAgent
+
+    return SkillsAgent(
+        model=config.model_name,
+        model_provider=config.model_provider,
+        max_turns=config.max_turns,
+        verbose=config.verbose,
+        allowed_skills=config.skills,
+        allowed_tools=config.allowed_tools,
+        equipped_mcp_servers=config.equipped_mcp_servers,
+        custom_system_prompt=config.system_prompt,
+        executor_name=config.executor_name,
+        workspace_id=workspace_id,
+        is_meta_agent=config.is_meta_agent,
+    )
+
+
+def build_completed_trace(
+    request_text: str,
+    result: AgentResult,
+    agent: SkillsAgent,
+    duration_ms: int,
+    executor_name: Optional[str] = None,
+    session_id: Optional[str] = None,
+) -> AgentTraceDB:
+    """Build an unsaved AgentTraceDB from a completed AgentResult.
+
+    Reads agent.model_provider / agent.model which have defaults resolved.
+    Caller adds the returned object to their own DB session.
+    """
+    return AgentTraceDB(
+        request=request_text,
+        skills_used=list(result.skills_used) if result.skills_used else [],
+        model_provider=agent.model_provider,
+        model=agent.model,
+        status="completed" if result.success else "failed",
+        success=result.success,
+        answer=result.answer,
+        error=result.error,
+        total_turns=result.total_turns,
+        total_input_tokens=result.total_input_tokens,
+        total_output_tokens=result.total_output_tokens,
+        steps=[asdict(s) for s in result.steps],
+        llm_calls=[asdict(c) for c in result.llm_calls],
+        duration_ms=duration_ms,
+        executor_name=executor_name,
+        session_id=session_id,
+    )
+
+
+def build_initial_trace(
+    request_text: str,
+    model_provider: str,
+    model_name: str,
+    executor_name: Optional[str] = None,
+    session_id: Optional[str] = None,
+) -> AgentTraceDB:
+    """Build an unsaved "running" trace for the streaming path.
+
+    Caller adds to their own DB session and commits to get the trace ID.
+    """
+    return AgentTraceDB(
+        request=request_text,
+        skills_used=[],
+        model_provider=model_provider,
+        model=model_name,
+        status="running",
+        success=False,
+        answer="",
+        error=None,
+        total_turns=0,
+        total_input_tokens=0,
+        total_output_tokens=0,
+        steps=[],
+        llm_calls=[],
+        duration_ms=0,
+        executor_name=executor_name,
+        session_id=session_id,
+    )

--- a/app/services/channel_manager.py
+++ b/app/services/channel_manager.py
@@ -14,6 +14,7 @@ import hashlib
 import logging
 import mimetypes
 import re
+import time
 from datetime import datetime
 from pathlib import Path
 from collections import namedtuple
@@ -296,17 +297,22 @@ class ChannelManager:
     # ------------------------------------------------------------------
 
     async def _handle_inbound(self, msg: InboundMessage):
-        """Handle an inbound message from a channel adapter."""
+        """Handle an inbound message from a channel adapter.
+
+        Uses two-level lookup:
+        1. Exact match: channel_type + external_id (specific group binding)
+        2. Fallback: channel_type + external_id='*' + config app_id match (global binding)
+        """
         from sqlalchemy import select
         from app.db.database import AsyncSessionLocal
         from app.db.models import (
             ChannelBindingDB, ChannelMessageDB, AgentPresetDB,
-            PublishedSessionDB, AgentTraceDB, generate_uuid,
+            PublishedSessionDB, generate_uuid,
         )
 
         try:
             async with AsyncSessionLocal() as session:
-                # Find matching binding
+                # Level 1: Exact match on external_id
                 result = await session.execute(
                     select(ChannelBindingDB).where(
                         ChannelBindingDB.channel_type == msg.channel_type,
@@ -315,6 +321,20 @@ class ChannelManager:
                     )
                 )
                 binding = result.scalar_one_or_none()
+
+                # Level 2: Fallback to global binding (external_id='*') matched by app_id
+                if not binding:
+                    app_id = (msg.metadata or {}).get("app_id")
+                    if app_id:
+                        result = await session.execute(
+                            select(ChannelBindingDB).where(
+                                ChannelBindingDB.channel_type == msg.channel_type,
+                                ChannelBindingDB.external_id == "*",
+                                ChannelBindingDB.enabled == True,
+                                ChannelBindingDB.config["app_id"].astext == app_id,
+                            )
+                        )
+                        binding = result.scalar_one_or_none()
 
                 if not binding:
                     logger.debug(f"No binding for {msg.channel_type}:{msg.external_id}")
@@ -436,55 +456,64 @@ class ChannelManager:
         Returns:
             (answer, output_files) tuple.
         """
-        from app.agent import SkillsAgent
+        from app.services.agent_runner import config_from_preset, create_agent, build_completed_trace
 
+        agent = None
         try:
-            agent = SkillsAgent(
-                model=preset.model_name,
-                model_provider=preset.model_provider,
-                max_turns=preset.max_turns or 60,
-                verbose=False,
-                allowed_skills=preset.skill_ids,
-                allowed_tools=preset.builtin_tools,
-                equipped_mcp_servers=preset.mcp_servers,
-                custom_system_prompt=preset.system_prompt,
-                executor_name=preset.executor_name,
-                workspace_id=session_id,
-            )
+            # Create agent via shared service
+            config = config_from_preset(preset)
+            config.verbose = False
+            agent = create_agent(config, workspace_id=session_id)
 
+            # Pre-compress if context exceeds threshold
+            if conversation_history:
+                from app.api.v1.sessions import pre_compress_if_needed
+                conversation_history = await pre_compress_if_needed(
+                    conversation_history,
+                    agent.model_provider,
+                    agent.model,
+                )
+
+            start_time = time.time()
             result = await agent.run(
                 prompt,
                 conversation_history=conversation_history,
                 image_contents=image_contents,
             )
+            duration_ms = int((time.time() - start_time) * 1000)
 
-            # Update session context
+            # Save trace (the core bug fix — channel messages now get traced)
+            from app.db.database import AsyncSessionLocal
+            async with AsyncSessionLocal() as trace_db:
+                trace = build_completed_trace(
+                    request_text=prompt,
+                    result=result,
+                    agent=agent,
+                    duration_ms=duration_ms,
+                    executor_name=config.executor_name,
+                    session_id=session_id,
+                )
+                trace_db.add(trace)
+                await trace_db.commit()
+
+            # Update session via save_session_messages (dual-store: agent_context + display)
             if session_id and result.final_messages:
-                from app.db.database import AsyncSessionLocal
-                from app.db.models import PublishedSessionDB
-                from sqlalchemy import select
-
-                async with AsyncSessionLocal() as session:
-                    pub = await session.execute(
-                        select(PublishedSessionDB).where(PublishedSessionDB.id == session_id)
-                    )
-                    pub = pub.scalar_one_or_none()
-                    if pub:
-                        pub.agent_context = result.final_messages
-                        # Append display messages
-                        display = pub.messages or []
-                        display.append({"role": "user", "content": prompt})
-                        if result.answer:
-                            display.append({"role": "assistant", "content": result.answer})
-                        pub.messages = display
-                        pub.updated_at = datetime.utcnow()
-                        await session.commit()
+                from app.api.v1.sessions import save_session_messages
+                await save_session_messages(
+                    session_id,
+                    result.answer,
+                    prompt,
+                    final_messages=result.final_messages,
+                )
 
             return result.answer, result.output_files
 
         except Exception as e:
             logger.error(f"Agent execution failed: {e}", exc_info=True)
             return f"Error: {str(e)}", []
+        finally:
+            if agent:
+                agent.cleanup()
 
     @staticmethod
     def _build_media_context(
@@ -568,7 +597,11 @@ IMPORTANT: Use the absolute file paths shown above when reading or processing fi
         return paths
 
     async def send_to_channel(self, binding_id: str, content: str):
-        """Send a message to a channel binding (used by scheduler)."""
+        """Send a message to a channel binding (used by scheduler).
+
+        Global bindings (external_id='*') are skipped because there is no
+        specific chat_id to send to.
+        """
         from sqlalchemy import select
         from app.db.database import AsyncSessionLocal
         from app.db.models import ChannelBindingDB, ChannelMessageDB, generate_uuid
@@ -580,6 +613,11 @@ IMPORTANT: Use the absolute file paths shown above when reading or processing fi
             binding = result.scalar_one_or_none()
             if not binding:
                 logger.warning(f"Channel binding {binding_id} not found")
+                return
+
+            # Global bindings have no specific target chat_id
+            if binding.external_id == "*":
+                logger.info(f"Skipping scheduled message for global binding {binding_id} (no target chat_id)")
                 return
 
             adapter = self._get_adapter_for_binding(binding)

--- a/app/services/scheduler.py
+++ b/app/services/scheduler.py
@@ -8,7 +8,6 @@ import asyncio
 import logging
 import time
 from concurrent.futures import ThreadPoolExecutor
-from dataclasses import asdict
 from datetime import datetime, timedelta
 from typing import Optional
 
@@ -195,12 +194,13 @@ class TaskScheduler:
         from app.db.database import SyncSessionLocal
         from app.db.models import (
             ScheduledTaskDB, TaskRunLogDB, AgentPresetDB,
-            AgentTraceDB, PublishedSessionDB, generate_uuid,
+            PublishedSessionDB, generate_uuid,
         )
-        from app.agent import SkillsAgent
+        from app.services.agent_runner import config_from_preset, create_agent, build_completed_trace
 
         start_time = time.time()
         session = SyncSessionLocal()
+        agent = None
 
         try:
             # Load task and agent preset
@@ -222,56 +222,54 @@ class TaskScheduler:
                 if pub_session and pub_session.agent_context:
                     conversation_history = pub_session.agent_context
 
-            # Create agent
-            agent = SkillsAgent(
-                custom_system_prompt=preset.system_prompt,
-                allowed_skills=preset.skill_ids,
-                equipped_mcp_servers=preset.mcp_servers,
-                allowed_tools=preset.builtin_tools,
-                max_turns=preset.max_turns or 60,
-                model_provider=preset.model_provider,
-                model=preset.model_name,
-                executor_name=preset.executor_name,
-            )
+            # Create agent via shared service
+            config = config_from_preset(preset)
+            agent = create_agent(config, workspace_id=task.session_id)
 
-            # Run agent
+            # Run agent (single event loop for all async operations)
             loop = asyncio.new_event_loop()
             try:
+                # Pre-compress if context exceeds threshold
+                if conversation_history:
+                    from app.api.v1.sessions import pre_compress_if_needed
+                    conversation_history = loop.run_until_complete(
+                        pre_compress_if_needed(
+                            conversation_history,
+                            agent.model_provider,
+                            agent.model,
+                        )
+                    )
+
                 result = loop.run_until_complete(
                     agent.run(task.prompt, conversation_history=conversation_history)
                 )
+
+                duration_ms = int((time.time() - start_time) * 1000)
+
+                # Save trace via shared service
+                trace = build_completed_trace(
+                    request_text=task.prompt,
+                    result=result,
+                    agent=agent,
+                    duration_ms=duration_ms,
+                    executor_name=config.executor_name,
+                    session_id=task.session_id,
+                )
+                session.add(trace)
+
+                # Update session via save_session_messages (dual-store: agent_context + display)
+                if task.context_mode == "session" and task.session_id and result.final_messages:
+                    from app.api.v1.sessions import save_session_messages
+                    loop.run_until_complete(
+                        save_session_messages(
+                            task.session_id,
+                            result.answer,
+                            task.prompt,
+                            final_messages=result.final_messages,
+                        )
+                    )
             finally:
                 loop.close()
-
-            duration_ms = int((time.time() - start_time) * 1000)
-
-            # Save trace
-            trace = AgentTraceDB(
-                id=generate_uuid(),
-                request=task.prompt,
-                skills_used=list(result.skills_used) if result.skills_used else [],
-                model_provider=preset.model_provider or "kimi",
-                model=agent.model or preset.model_name or "kimi-k2.5",
-                status="completed" if result.success else "failed",
-                success=result.success,
-                answer=result.answer,
-                error=result.error,
-                total_turns=result.total_turns,
-                total_input_tokens=result.total_input_tokens,
-                total_output_tokens=result.total_output_tokens,
-                steps=[asdict(s) for s in result.steps],
-                llm_calls=[asdict(c) for c in result.llm_calls],
-                duration_ms=duration_ms,
-                session_id=task.session_id,
-            )
-            session.add(trace)
-
-            # Update session context if session mode
-            if task.context_mode == "session" and task.session_id and result.final_messages:
-                pub_session = session.get(PublishedSessionDB, task.session_id)
-                if pub_session:
-                    pub_session.agent_context = result.final_messages
-                    pub_session.updated_at = datetime.utcnow()
 
             # Update run log
             self._update_run_log(
@@ -307,6 +305,8 @@ class TaskScheduler:
                 duration_ms=duration_ms,
             )
         finally:
+            if agent:
+                agent.cleanup()
             session.close()
 
     def _update_run_log(

--- a/tests/test_api/test_agent_run.py
+++ b/tests/test_api/test_agent_run.py
@@ -70,6 +70,7 @@ def _make_mock_agent(result: Optional[MockAgentResult] = None):
     instance.run = AsyncMock(return_value=result or MockAgentResult())
     instance.model = "kimi-k2.5"
     instance.model_provider = "kimi"
+    instance.cleanup = MagicMock()
     return instance
 
 
@@ -80,10 +81,10 @@ def _make_mock_agent(result: Optional[MockAgentResult] = None):
 
 @patch("app.api.v1.agent.save_session_messages", new_callable=AsyncMock)
 @patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=SessionData(session_id="test-session-id"))
-@patch("app.api.v1.agent.SkillsAgent")
-async def test_agent_run_simple(MockAgent, _mock_load, _mock_save, client: AsyncClient):
+@patch("app.api.v1.agent.create_agent")
+async def test_agent_run_simple(mock_create, _mock_load, _mock_save, client: AsyncClient):
     """POST /agent/run with a simple request returns 200 with success=True."""
-    MockAgent.return_value = _make_mock_agent()
+    mock_create.return_value = _make_mock_agent()
 
     response = await client.post(
         "/api/v1/agent/run",
@@ -100,10 +101,10 @@ async def test_agent_run_simple(MockAgent, _mock_load, _mock_save, client: Async
 
 @patch("app.api.v1.agent.save_session_messages", new_callable=AsyncMock)
 @patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=SessionData(session_id="test-session-id"))
-@patch("app.api.v1.agent.SkillsAgent")
-async def test_agent_run_with_skills(MockAgent, _mock_load, _mock_save, client: AsyncClient):
-    """POST /agent/run with skills parameter passes skills to agent."""
-    MockAgent.return_value = _make_mock_agent()
+@patch("app.api.v1.agent.create_agent")
+async def test_agent_run_with_skills(mock_create, _mock_load, _mock_save, client: AsyncClient):
+    """POST /agent/run with skills parameter passes skills to agent via AgentConfig."""
+    mock_create.return_value = _make_mock_agent()
 
     response = await client.post(
         "/api/v1/agent/run",
@@ -113,18 +114,18 @@ async def test_agent_run_with_skills(MockAgent, _mock_load, _mock_save, client: 
     assert response.status_code == 200
     body = response.json()
     assert body["success"] is True
-    # Verify SkillsAgent was constructed with the skills
-    MockAgent.assert_called_once()
-    call_kwargs = MockAgent.call_args[1]
-    assert call_kwargs["allowed_skills"] == ["test-skill"]
+    # Verify create_agent received config with correct skills
+    mock_create.assert_called_once()
+    config = mock_create.call_args[0][0]
+    assert config.skills == ["test-skill"]
 
 
 @patch("app.api.v1.agent.save_session_messages", new_callable=AsyncMock)
 @patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=SessionData(session_id="test-session-id"))
-@patch("app.api.v1.agent.SkillsAgent")
-async def test_agent_run_with_max_turns(MockAgent, _mock_load, _mock_save, client: AsyncClient):
+@patch("app.api.v1.agent.create_agent")
+async def test_agent_run_with_max_turns(mock_create, _mock_load, _mock_save, client: AsyncClient):
     """POST /agent/run with max_turns passes the value to agent."""
-    MockAgent.return_value = _make_mock_agent()
+    mock_create.return_value = _make_mock_agent()
 
     response = await client.post(
         "/api/v1/agent/run",
@@ -134,16 +135,16 @@ async def test_agent_run_with_max_turns(MockAgent, _mock_load, _mock_save, clien
     assert response.status_code == 200
     body = response.json()
     assert body["success"] is True
-    call_kwargs = MockAgent.call_args[1]
-    assert call_kwargs["max_turns"] == 5
+    config = mock_create.call_args[0][0]
+    assert config.max_turns == 5
 
 
 @patch("app.api.v1.agent.save_session_messages", new_callable=AsyncMock)
 @patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=SessionData(session_id="test-session-id"))
-@patch("app.api.v1.agent.SkillsAgent")
-async def test_agent_run_with_session_id(MockAgent, _mock_load, _mock_save, client: AsyncClient):
+@patch("app.api.v1.agent.create_agent")
+async def test_agent_run_with_session_id(mock_create, _mock_load, _mock_save, client: AsyncClient):
     """POST /agent/run with session_id accepts and processes the request."""
-    MockAgent.return_value = _make_mock_agent()
+    mock_create.return_value = _make_mock_agent()
 
     response = await client.post(
         "/api/v1/agent/run",
@@ -157,10 +158,11 @@ async def test_agent_run_with_session_id(MockAgent, _mock_load, _mock_save, clie
 
 @patch("app.api.v1.agent.save_session_messages", new_callable=AsyncMock)
 @patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=SessionData(session_id="test-session-id"))
-@patch("app.api.v1.agent.SkillsAgent")
-async def test_agent_run_with_files(MockAgent, _mock_load, _mock_save, client: AsyncClient):
+@patch("app.api.v1.agent.create_agent")
+async def test_agent_run_with_files(mock_create, _mock_load, _mock_save, client: AsyncClient):
     """POST /agent/run with uploaded_files appends file info to request."""
-    MockAgent.return_value = _make_mock_agent()
+    mock_agent = _make_mock_agent()
+    mock_create.return_value = mock_agent
 
     files = [
         {
@@ -180,16 +182,15 @@ async def test_agent_run_with_files(MockAgent, _mock_load, _mock_save, client: A
     body = response.json()
     assert body["success"] is True
     # The actual_request passed to agent.run should contain the file info
-    run_call = MockAgent.return_value.run
-    actual_request = run_call.call_args[0][0]
+    actual_request = mock_agent.run.call_args[0][0]
     assert "report.pdf" in actual_request
     assert "/tmp/uploads/report.pdf" in actual_request
 
 
 @patch("app.api.v1.agent.save_session_messages", new_callable=AsyncMock)
 @patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=SessionData(session_id="test-session-id"))
-@patch("app.api.v1.agent.SkillsAgent")
-async def test_agent_run_failure(MockAgent, _mock_load, _mock_save, client: AsyncClient):
+@patch("app.api.v1.agent.create_agent")
+async def test_agent_run_failure(mock_create, _mock_load, _mock_save, client: AsyncClient):
     """POST /agent/run when agent fails returns 200 with success=False."""
     failed_result = MockAgentResult(
         success=False,
@@ -197,7 +198,7 @@ async def test_agent_run_failure(MockAgent, _mock_load, _mock_save, client: Asyn
         error="Something went wrong",
         steps=[MockStep(role="assistant", content="Error occurred")],
     )
-    MockAgent.return_value = _make_mock_agent(failed_result)
+    mock_create.return_value = _make_mock_agent(failed_result)
 
     response = await client.post(
         "/api/v1/agent/run",
@@ -212,10 +213,10 @@ async def test_agent_run_failure(MockAgent, _mock_load, _mock_save, client: Asyn
 
 @patch("app.api.v1.agent.save_session_messages", new_callable=AsyncMock)
 @patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=SessionData(session_id="test-session-id"))
-@patch("app.api.v1.agent.SkillsAgent")
-async def test_agent_run_saves_trace(MockAgent, _mock_load, _mock_save, client: AsyncClient):
+@patch("app.api.v1.agent.create_agent")
+async def test_agent_run_saves_trace(mock_create, _mock_load, _mock_save, client: AsyncClient):
     """POST /agent/run saves an execution trace and returns trace_id."""
-    MockAgent.return_value = _make_mock_agent()
+    mock_create.return_value = _make_mock_agent()
 
     response = await client.post(
         "/api/v1/agent/run",
@@ -231,10 +232,10 @@ async def test_agent_run_saves_trace(MockAgent, _mock_load, _mock_save, client: 
 
 @patch("app.api.v1.agent.save_session_messages", new_callable=AsyncMock)
 @patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=SessionData(session_id="test-session-id"))
-@patch("app.api.v1.agent.SkillsAgent")
-async def test_agent_run_with_mcp_servers(MockAgent, _mock_load, _mock_save, client: AsyncClient):
+@patch("app.api.v1.agent.create_agent")
+async def test_agent_run_with_mcp_servers(mock_create, _mock_load, _mock_save, client: AsyncClient):
     """POST /agent/run with equipped_mcp_servers passes them to agent."""
-    MockAgent.return_value = _make_mock_agent()
+    mock_create.return_value = _make_mock_agent()
 
     response = await client.post(
         "/api/v1/agent/run",
@@ -248,5 +249,5 @@ async def test_agent_run_with_mcp_servers(MockAgent, _mock_load, _mock_save, cli
     assert response.status_code == 200
     body = response.json()
     assert body["success"] is True
-    call_kwargs = MockAgent.call_args[1]
-    assert call_kwargs["equipped_mcp_servers"] == ["fetch"]
+    config = mock_create.call_args[0][0]
+    assert config.equipped_mcp_servers == ["fetch"]

--- a/tests/test_api/test_agent_stream.py
+++ b/tests/test_api/test_agent_stream.py
@@ -1,7 +1,7 @@
 """
 Tests for Agent streaming endpoint: POST /api/v1/agent/run/stream
 
-Uses mocked SkillsAgent to avoid real LLM calls.
+Uses mocked SkillsAgent (via create_agent) to avoid real LLM calls.
 The stream endpoint uses AsyncSessionLocal directly (not get_db),
 so we also need to mock that for trace saving.
 
@@ -131,9 +131,9 @@ def _mock_session_local(db_session: AsyncSession):
 @patch("app.api.v1.agent.save_session_checkpoint", new_callable=AsyncMock)
 @patch("app.api.v1.agent.save_session_messages", new_callable=AsyncMock)
 @patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=SessionData(session_id="test-session-id"))
-@patch("app.api.v1.agent.SkillsAgent")
-async def test_stream_returns_event_stream(MockAgent, _mock_load, _mock_save, _mock_checkpoint, _mock_precompress, client):
-    MockAgent.return_value = _make_mock_agent_instance()
+@patch("app.api.v1.agent.create_agent")
+async def test_stream_returns_event_stream(mock_create, _mock_load, _mock_save, _mock_checkpoint, _mock_precompress, client):
+    mock_create.return_value = _make_mock_agent_instance()
 
     response = await client.post(
         "/api/v1/agent/run/stream",
@@ -149,9 +149,9 @@ async def test_stream_returns_event_stream(MockAgent, _mock_load, _mock_save, _m
 @patch("app.api.v1.agent.save_session_messages", new_callable=AsyncMock)
 @patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=SessionData(session_id="test-session-id"))
 @patch("app.api.v1.agent.AsyncSessionLocal")
-@patch("app.api.v1.agent.SkillsAgent")
-async def test_stream_sends_run_started(MockAgent, MockSessionLocal, _mock_load, _mock_save, _mock_checkpoint, _mock_precompress, client, db_session):
-    MockAgent.return_value = _make_mock_agent_instance()
+@patch("app.api.v1.agent.create_agent")
+async def test_stream_sends_run_started(mock_create, MockSessionLocal, _mock_load, _mock_save, _mock_checkpoint, _mock_precompress, client, db_session):
+    mock_create.return_value = _make_mock_agent_instance()
     MockSessionLocal.side_effect = lambda: _mock_session_local(db_session)()
 
     response = await client.post(
@@ -174,9 +174,9 @@ async def test_stream_sends_run_started(MockAgent, MockSessionLocal, _mock_load,
 @patch("app.api.v1.agent.save_session_messages", new_callable=AsyncMock)
 @patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=SessionData(session_id="test-session-id"))
 @patch("app.api.v1.agent.AsyncSessionLocal")
-@patch("app.api.v1.agent.SkillsAgent")
-async def test_stream_sends_trace_saved(MockAgent, MockSessionLocal, _mock_load, _mock_save, _mock_checkpoint, _mock_precompress, client, db_session):
-    MockAgent.return_value = _make_mock_agent_instance()
+@patch("app.api.v1.agent.create_agent")
+async def test_stream_sends_trace_saved(mock_create, MockSessionLocal, _mock_load, _mock_save, _mock_checkpoint, _mock_precompress, client, db_session):
+    mock_create.return_value = _make_mock_agent_instance()
     MockSessionLocal.side_effect = lambda: _mock_session_local(db_session)()
 
     response = await client.post(
@@ -196,9 +196,9 @@ async def test_stream_sends_trace_saved(MockAgent, MockSessionLocal, _mock_load,
 @patch("app.api.v1.agent.save_session_messages", new_callable=AsyncMock)
 @patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=SessionData(session_id="test-session-id"))
 @patch("app.api.v1.agent.AsyncSessionLocal")
-@patch("app.api.v1.agent.SkillsAgent")
-async def test_stream_with_skills(MockAgent, MockSessionLocal, _mock_load, _mock_save, _mock_checkpoint, _mock_precompress, client, db_session):
-    MockAgent.return_value = _make_mock_agent_instance()
+@patch("app.api.v1.agent.create_agent")
+async def test_stream_with_skills(mock_create, MockSessionLocal, _mock_load, _mock_save, _mock_checkpoint, _mock_precompress, client, db_session):
+    mock_create.return_value = _make_mock_agent_instance()
     MockSessionLocal.side_effect = lambda: _mock_session_local(db_session)()
 
     response = await client.post(
@@ -206,9 +206,12 @@ async def test_stream_with_skills(MockAgent, MockSessionLocal, _mock_load, _mock
         json={"request": "hello", "skills": ["test-skill"], "session_id": "test-session-id"},
     )
     assert response.status_code == 200
-    MockAgent.assert_called_once()
-    call_kwargs = MockAgent.call_args
-    assert call_kwargs[1].get("allowed_skills") == ["test-skill"]
+    # create_agent is called twice in stream (once for initial trace config read, once for actual agent)
+    # The actual agent creation uses a stream_config with verbose=False
+    assert mock_create.call_count >= 1
+    # Check the config passed to create_agent has the correct skills
+    config = mock_create.call_args[0][0]
+    assert config.skills == ["test-skill"]
 
 
 @pytest.mark.asyncio
@@ -217,9 +220,9 @@ async def test_stream_with_skills(MockAgent, MockSessionLocal, _mock_load, _mock
 @patch("app.api.v1.agent.save_session_messages", new_callable=AsyncMock)
 @patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=SessionData(session_id="test-session-id"))
 @patch("app.api.v1.agent.AsyncSessionLocal")
-@patch("app.api.v1.agent.SkillsAgent")
-async def test_stream_with_mcp_servers(MockAgent, MockSessionLocal, _mock_load, _mock_save, _mock_checkpoint, _mock_precompress, client, db_session):
-    MockAgent.return_value = _make_mock_agent_instance()
+@patch("app.api.v1.agent.create_agent")
+async def test_stream_with_mcp_servers(mock_create, MockSessionLocal, _mock_load, _mock_save, _mock_checkpoint, _mock_precompress, client, db_session):
+    mock_create.return_value = _make_mock_agent_instance()
     MockSessionLocal.side_effect = lambda: _mock_session_local(db_session)()
 
     response = await client.post(
@@ -227,9 +230,9 @@ async def test_stream_with_mcp_servers(MockAgent, MockSessionLocal, _mock_load, 
         json={"request": "hello", "equipped_mcp_servers": ["fetch"], "session_id": "test-session-id"},
     )
     assert response.status_code == 200
-    MockAgent.assert_called_once()
-    call_kwargs = MockAgent.call_args
-    assert call_kwargs[1].get("equipped_mcp_servers") == ["fetch"]
+    assert mock_create.call_count >= 1
+    config = mock_create.call_args[0][0]
+    assert config.equipped_mcp_servers == ["fetch"]
 
 
 @pytest.mark.asyncio
@@ -238,8 +241,8 @@ async def test_stream_with_mcp_servers(MockAgent, MockSessionLocal, _mock_load, 
 @patch("app.api.v1.agent.save_session_messages", new_callable=AsyncMock)
 @patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=SessionData(session_id="test-session-id"))
 @patch("app.api.v1.agent.AsyncSessionLocal")
-@patch("app.api.v1.agent.SkillsAgent")
-async def test_stream_error_handling(MockAgent, MockSessionLocal, _mock_load, _mock_save, _mock_checkpoint, _mock_precompress, client, db_session):
+@patch("app.api.v1.agent.create_agent")
+async def test_stream_error_handling(mock_create, MockSessionLocal, _mock_load, _mock_save, _mock_checkpoint, _mock_precompress, client, db_session):
     """When agent encounters error, it pushes error complete event and stream includes it."""
     # In the async architecture, agent.run() catches errors internally
     # and pushes a complete event with success=False
@@ -261,7 +264,7 @@ async def test_stream_error_handling(MockAgent, MockSessionLocal, _mock_load, _m
             },
         ),
     ]
-    MockAgent.return_value = _make_mock_agent_instance(events=error_events)
+    mock_create.return_value = _make_mock_agent_instance(events=error_events)
     MockSessionLocal.side_effect = lambda: _mock_session_local(db_session)()
 
     response = await client.post(

--- a/tests/test_api/test_channels.py
+++ b/tests/test_api/test_channels.py
@@ -143,3 +143,158 @@ class TestChannelsAPI:
     async def test_adapters_status(self, client):
         resp = await client.get("/api/v1/channels/adapters")
         assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+class TestGlobalBindingsAPI:
+    """Tests for global Feishu binding support (external_id='*')."""
+
+    async def test_create_global_binding(self, client, db_session):
+        """Creating a Feishu binding without external_id should produce a global binding."""
+        preset = make_preset(name="global-agent-1")
+        db_session.add(preset)
+        await db_session.commit()
+
+        resp = await client.post("/api/v1/channels", json={
+            "channel_type": "feishu",
+            "name": "Global Feishu",
+            "agent_id": preset.id,
+            "config": {"app_id": "cli_global_001", "app_secret": "secret123"},
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["external_id"] == "*"
+        assert data["is_global"] is True
+
+    async def test_create_global_binding_explicit_star(self, client, db_session):
+        """Creating with external_id='*' explicitly should also work."""
+        preset = make_preset(name="global-agent-2")
+        db_session.add(preset)
+        await db_session.commit()
+
+        resp = await client.post("/api/v1/channels", json={
+            "channel_type": "feishu",
+            "external_id": "*",
+            "name": "Global Feishu Explicit",
+            "agent_id": preset.id,
+            "config": {"app_id": "cli_global_002", "app_secret": "secret456"},
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["external_id"] == "*"
+        assert data["is_global"] is True
+
+    async def test_global_binding_feishu_only(self, client, db_session):
+        """Global bindings should be rejected for non-Feishu channel types."""
+        preset = make_preset(name="global-agent-3")
+        db_session.add(preset)
+        await db_session.commit()
+
+        resp = await client.post("/api/v1/channels", json={
+            "channel_type": "webhook",
+            "name": "Global Webhook",
+            "agent_id": preset.id,
+        })
+        assert resp.status_code == 400
+        assert "only supported for Feishu" in resp.json()["detail"]
+
+    async def test_global_binding_requires_app_id(self, client, db_session):
+        """Global Feishu bindings must have app_id in config."""
+        preset = make_preset(name="global-agent-4")
+        db_session.add(preset)
+        await db_session.commit()
+
+        resp = await client.post("/api/v1/channels", json={
+            "channel_type": "feishu",
+            "name": "Global No AppId",
+            "agent_id": preset.id,
+            "config": {"app_secret": "secret789"},
+        })
+        assert resp.status_code == 400
+        assert "app_id" in resp.json()["detail"]
+
+    async def test_duplicate_global_binding_rejected(self, client, db_session):
+        """Two global bindings for the same app_id should be rejected."""
+        preset = make_preset(name="global-agent-5")
+        db_session.add(preset)
+        await db_session.commit()
+
+        resp1 = await client.post("/api/v1/channels", json={
+            "channel_type": "feishu",
+            "name": "Global Feishu First",
+            "agent_id": preset.id,
+            "config": {"app_id": "cli_dup_global", "app_secret": "sec1"},
+        })
+        assert resp1.status_code == 200
+
+        resp2 = await client.post("/api/v1/channels", json={
+            "channel_type": "feishu",
+            "name": "Global Feishu Duplicate",
+            "agent_id": preset.id,
+            "config": {"app_id": "cli_dup_global", "app_secret": "sec2"},
+        })
+        assert resp2.status_code == 409
+
+    async def test_specific_binding_is_not_global(self, client, db_session):
+        """A binding with a specific external_id should have is_global=False."""
+        preset = make_preset(name="global-agent-6")
+        db_session.add(preset)
+        await db_session.commit()
+
+        resp = await client.post("/api/v1/channels", json={
+            "channel_type": "feishu",
+            "external_id": "oc_specific_001",
+            "name": "Specific Feishu",
+            "agent_id": preset.id,
+            "config": {"app_id": "cli_specific_001", "app_secret": "sec3"},
+        })
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["is_global"] is False
+        assert data["external_id"] == "oc_specific_001"
+
+    async def test_global_and_specific_coexist(self, client, db_session):
+        """A global binding and specific binding for the same app can coexist."""
+        preset = make_preset(name="global-agent-7")
+        db_session.add(preset)
+        await db_session.commit()
+
+        # Create global
+        resp1 = await client.post("/api/v1/channels", json={
+            "channel_type": "feishu",
+            "name": "Global Coexist",
+            "agent_id": preset.id,
+            "config": {"app_id": "cli_coexist", "app_secret": "sec4"},
+        })
+        assert resp1.status_code == 200
+        assert resp1.json()["is_global"] is True
+
+        # Create specific for same app
+        resp2 = await client.post("/api/v1/channels", json={
+            "channel_type": "feishu",
+            "external_id": "oc_coexist_001",
+            "name": "Specific Coexist",
+            "agent_id": preset.id,
+            "config": {"app_id": "cli_coexist", "app_secret": "sec5"},
+        })
+        assert resp2.status_code == 200
+        assert resp2.json()["is_global"] is False
+
+    async def test_is_global_in_list_response(self, client, db_session):
+        """The is_global field should appear in list responses."""
+        preset = make_preset(name="global-agent-8")
+        db_session.add(preset)
+        await db_session.commit()
+
+        await client.post("/api/v1/channels", json={
+            "channel_type": "feishu",
+            "name": "List Global",
+            "agent_id": preset.id,
+            "config": {"app_id": "cli_list_global", "app_secret": "sec6"},
+        })
+
+        resp = await client.get("/api/v1/channels")
+        assert resp.status_code == 200
+        bindings = resp.json()["bindings"]
+        global_binding = next(b for b in bindings if b["name"] == "List Global")
+        assert global_binding["is_global"] is True

--- a/tests/test_core/test_stream_retry.py
+++ b/tests/test_core/test_stream_retry.py
@@ -531,7 +531,7 @@ class TestStreamRetrySSE:
     @patch("app.api.v1.agent.save_session_messages", new_callable=AsyncMock)
     @patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=SessionData(session_id="test-session-id"))
     @patch("app.api.v1.agent.AsyncSessionLocal")
-    @patch("app.api.v1.agent.SkillsAgent")
+    @patch("app.api.v1.agent.create_agent")
     async def test_sse_with_text_deltas(self, MockAgent, MockSessionLocal, _mock_load, _mock_save, _mock_checkpoint, _mock_precompress, client):
         """SSE stream carries text_delta events from normal streaming."""
         mock_instance = _make_mock_agent_with_events([
@@ -575,7 +575,7 @@ class TestStreamRetrySSE:
     @patch("app.api.v1.agent.save_session_messages", new_callable=AsyncMock)
     @patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=SessionData(session_id="test-session-id"))
     @patch("app.api.v1.agent.AsyncSessionLocal")
-    @patch("app.api.v1.agent.SkillsAgent")
+    @patch("app.api.v1.agent.create_agent")
     async def test_sse_with_error_after_deltas(self, MockAgent, MockSessionLocal, _mock_load, _mock_save, _mock_checkpoint, _mock_precompress, client):
         """SSE stream: text_deltas followed by error complete (simulates failed retry)."""
         mock_instance = _make_mock_agent_with_events([
@@ -620,7 +620,7 @@ class TestStreamRetrySSE:
     @patch("app.api.v1.agent.save_session_messages", new_callable=AsyncMock)
     @patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=SessionData(session_id="test-session-id"))
     @patch("app.api.v1.agent.AsyncSessionLocal")
-    @patch("app.api.v1.agent.SkillsAgent")
+    @patch("app.api.v1.agent.create_agent")
     async def test_sse_text_delta_buffer_flushed_on_tool_call(
         self, MockAgent, MockSessionLocal, _mock_load, _mock_save, _mock_checkpoint, _mock_precompress, client
     ):

--- a/tests/test_e2e/test_context_compression.py
+++ b/tests/test_e2e/test_context_compression.py
@@ -1684,7 +1684,7 @@ class TestIncrementalDisplaySaveE2E:
     @patch("app.api.v1.agent.save_session_checkpoint", new_callable=AsyncMock)
     @patch("app.api.v1.agent.save_session_messages", new_callable=AsyncMock)
     @patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock)
-    @patch("app.api.v1.agent.SkillsAgent")
+    @patch("app.api.v1.agent.create_agent")
     async def test_01_turn_complete_saves_display(
         self, MockAgent, MockLoadSession, MockSaveMessages, MockCheckpoint, MockPreCompress,
         e2e_client: AsyncClient, e2e_db_session,
@@ -1799,7 +1799,7 @@ class TestIncrementalDisplaySaveE2E:
     @patch("app.api.v1.agent.save_session_checkpoint", new_callable=AsyncMock)
     @patch("app.api.v1.agent.save_session_messages", new_callable=AsyncMock)
     @patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock)
-    @patch("app.api.v1.agent.SkillsAgent")
+    @patch("app.api.v1.agent.create_agent")
     async def test_02_turn_complete_appends_to_existing_display(
         self, MockAgent, MockLoadSession, MockSaveMessages, MockCheckpoint, MockPreCompress,
         e2e_client: AsyncClient, e2e_db_session,

--- a/tests/test_e2e/test_e2e_workflows.py
+++ b/tests/test_e2e/test_e2e_workflows.py
@@ -530,7 +530,7 @@ class TestAgentPresetLifecycleE2E:
 
     @patch("app.api.v1.agent.save_session_messages", new_callable=AsyncMock)
     @patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=SessionData(session_id="test-session-id"))
-    @patch("app.api.v1.agent.SkillsAgent")
+    @patch("app.api.v1.agent.create_agent")
     async def test_06_run_agent(self, MockAgent, _mock_load, _mock_save, e2e_client: AsyncClient):
         MockAgent.return_value = _make_mock_agent()
         resp = await e2e_client.post(
@@ -635,7 +635,7 @@ class TestAgentRunAndTraceE2E:
 
     @patch("app.api.v1.agent.save_session_messages", new_callable=AsyncMock)
     @patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=SessionData(session_id="test-session-id"))
-    @patch("app.api.v1.agent.SkillsAgent")
+    @patch("app.api.v1.agent.create_agent")
     async def test_01_run_simple(self, MockAgent, _mock_load, _mock_save, e2e_client: AsyncClient):
         MockAgent.return_value = _make_mock_agent()
         resp = await e2e_client.post(
@@ -673,7 +673,7 @@ class TestAgentRunAndTraceE2E:
 
     @patch("app.api.v1.agent.save_session_messages", new_callable=AsyncMock)
     @patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=SessionData(session_id="test-session-id"))
-    @patch("app.api.v1.agent.SkillsAgent")
+    @patch("app.api.v1.agent.create_agent")
     async def test_05_run_with_skills_and_session(
         self, MockAgent, _mock_load, _mock_save, e2e_client: AsyncClient
     ):
@@ -696,7 +696,7 @@ class TestAgentRunAndTraceE2E:
     @patch("app.api.v1.agent.save_session_messages", new_callable=AsyncMock)
     @patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=SessionData(session_id="test-session-id"))
     @patch("app.api.v1.agent.AsyncSessionLocal")
-    @patch("app.api.v1.agent.SkillsAgent")
+    @patch("app.api.v1.agent.create_agent")
     async def test_06_run_stream(
         self, MockAgent, MockSessionLocal, _mock_load, _mock_save, _mock_checkpoint, _mock_precompress, e2e_client: AsyncClient
     ):
@@ -764,7 +764,7 @@ class TestFileUploadE2E:
 
     @patch("app.api.v1.agent.save_session_messages", new_callable=AsyncMock)
     @patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=SessionData(session_id="test-session-id"))
-    @patch("app.api.v1.agent.SkillsAgent")
+    @patch("app.api.v1.agent.create_agent")
     async def test_03_run_agent_with_file(
         self, MockAgent, _mock_load, _mock_save, e2e_client: AsyncClient
     ):
@@ -2413,7 +2413,7 @@ class TestAutoDetectOutputFilesE2E:
 
     @patch("app.api.v1.agent.save_session_messages", new_callable=AsyncMock)
     @patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=SessionData(session_id="test-session-id"))
-    @patch("app.api.v1.agent.SkillsAgent")
+    @patch("app.api.v1.agent.create_agent")
     async def test_01_run_with_output_files(
         self, MockAgent, _mock_load, _mock_save, e2e_client: AsyncClient
     ):
@@ -2445,7 +2445,7 @@ class TestAutoDetectOutputFilesE2E:
 
     @patch("app.api.v1.agent.save_session_messages", new_callable=AsyncMock)
     @patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=SessionData(session_id="test-session-id"))
-    @patch("app.api.v1.agent.SkillsAgent")
+    @patch("app.api.v1.agent.create_agent")
     async def test_02_run_no_output_files(
         self, MockAgent, _mock_load, _mock_save, e2e_client: AsyncClient
     ):
@@ -2466,7 +2466,7 @@ class TestAutoDetectOutputFilesE2E:
     @patch("app.api.v1.agent.save_session_messages", new_callable=AsyncMock)
     @patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=SessionData(session_id="test-session-id"))
     @patch("app.api.v1.agent.AsyncSessionLocal")
-    @patch("app.api.v1.agent.SkillsAgent")
+    @patch("app.api.v1.agent.create_agent")
     async def test_03_stream_with_output_file_events(
         self, MockAgent, MockSessionLocal, _mock_load, _mock_save, _mock_checkpoint, _mock_precompress, e2e_client: AsyncClient
     ):
@@ -2544,7 +2544,7 @@ class TestAutoDetectOutputFilesE2E:
     @patch("app.api.v1.agent.save_session_messages", new_callable=AsyncMock)
     @patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=SessionData(session_id="test-session-id"))
     @patch("app.api.v1.agent.AsyncSessionLocal")
-    @patch("app.api.v1.agent.SkillsAgent")
+    @patch("app.api.v1.agent.create_agent")
     async def test_04_stream_no_output_files(
         self, MockAgent, MockSessionLocal, _mock_load, _mock_save, _mock_checkpoint, _mock_precompress, e2e_client: AsyncClient
     ):
@@ -3407,7 +3407,7 @@ class TestResilientStreamingE2E:
     @patch("app.api.v1.agent.save_session_messages", new_callable=AsyncMock)
     @patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=SessionData(session_id="test-resilient-session"))
     @patch("app.api.v1.agent.AsyncSessionLocal")
-    @patch("app.api.v1.agent.SkillsAgent")
+    @patch("app.api.v1.agent.create_agent")
     async def test_05_agent_endpoint_turn_complete_incremental_save(
         self, MockAgent, MockSessionLocal, _mock_load, MockSave, _mock_checkpoint, _mock_precompress, e2e_client: AsyncClient
     ):
@@ -3438,7 +3438,7 @@ class TestResilientStreamingE2E:
     @patch("app.api.v1.agent.save_session_messages", new_callable=AsyncMock)
     @patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=SessionData(session_id="test-resilient-session"))
     @patch("app.api.v1.agent.AsyncSessionLocal")
-    @patch("app.api.v1.agent.SkillsAgent")
+    @patch("app.api.v1.agent.create_agent")
     async def test_06_no_turn_complete_means_no_incremental_save(
         self, MockAgent, MockSessionLocal, _mock_load, MockSave, _mock_checkpoint, _mock_precompress, e2e_client: AsyncClient
     ):
@@ -3624,7 +3624,7 @@ class TestAskUserE2E:
     @patch("app.api.v1.agent.save_session_messages", new_callable=AsyncMock)
     @patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=SessionData(session_id="ask-user-session"))
     @patch("app.api.v1.agent.AsyncSessionLocal")
-    @patch("app.api.v1.agent.SkillsAgent")
+    @patch("app.api.v1.agent.create_agent")
     async def test_02_stream_with_ask_user_ends_run(
         self, MockAgent, MockSessionLocal, _mock_load, _mock_save, _mock_checkpoint, _mock_precompress, e2e_client: AsyncClient
     ):
@@ -3714,7 +3714,7 @@ class TestAskUserE2E:
 
     @patch("app.api.v1.agent.save_session_messages", new_callable=AsyncMock)
     @patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock, return_value=SessionData(session_id="ask-user-sync"))
-    @patch("app.api.v1.agent.SkillsAgent")
+    @patch("app.api.v1.agent.create_agent")
     async def test_04_non_streaming_ask_user_ends_run(self, MockAgent, _mock_load, _mock_save, e2e_client: AsyncClient):
         """In non-streaming (sync) mode, ask_user also ends the run (same as streaming)."""
         MockAgent.return_value = _make_mock_agent()
@@ -3757,7 +3757,7 @@ class TestSessionDisplayFormatE2E:
     @patch("app.api.v1.agent.save_session_checkpoint", new_callable=AsyncMock)
     @patch("app.api.v1.agent.save_session_messages", new_callable=AsyncMock)
     @patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock)
-    @patch("app.api.v1.agent.SkillsAgent")
+    @patch("app.api.v1.agent.create_agent")
     async def test_02_streaming_display_has_stream_events(
         self, MockAgent, MockLoadSession, MockSaveMessages, MockCheckpoint, MockPreCompress,
         e2e_client: AsyncClient, e2e_db_session,
@@ -3824,7 +3824,7 @@ class TestSessionDisplayFormatE2E:
 
     @patch("app.api.v1.agent.save_session_messages", new_callable=AsyncMock)
     @patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock)
-    @patch("app.api.v1.agent.SkillsAgent")
+    @patch("app.api.v1.agent.create_agent")
     async def test_03_non_streaming_display_has_stream_events(
         self, MockAgent, MockLoadSession, MockSaveMessages,
         e2e_client: AsyncClient, e2e_db_session,
@@ -3864,7 +3864,7 @@ class TestSessionDisplayFormatE2E:
     @patch("app.api.v1.agent.save_session_checkpoint", new_callable=AsyncMock)
     @patch("app.api.v1.agent.save_session_messages", new_callable=AsyncMock)
     @patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock)
-    @patch("app.api.v1.agent.SkillsAgent")
+    @patch("app.api.v1.agent.create_agent")
     async def test_04_uploaded_files_stored_as_attached_files(
         self, MockAgent, MockLoadSession, MockSaveMessages, MockCheckpoint, MockPreCompress,
         e2e_client: AsyncClient, e2e_db_session,
@@ -3916,7 +3916,7 @@ class TestSessionDisplayFormatE2E:
     @patch("app.api.v1.agent.save_session_checkpoint", new_callable=AsyncMock)
     @patch("app.api.v1.agent.save_session_messages", new_callable=AsyncMock)
     @patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock)
-    @patch("app.api.v1.agent.SkillsAgent")
+    @patch("app.api.v1.agent.create_agent")
     async def test_05_ask_user_event_in_display(
         self, MockAgent, MockLoadSession, MockSaveMessages, MockCheckpoint, MockPreCompress,
         e2e_client: AsyncClient, e2e_db_session,
@@ -3966,7 +3966,7 @@ class TestSessionDisplayFormatE2E:
     @patch("app.api.v1.agent.save_session_checkpoint", new_callable=AsyncMock)
     @patch("app.api.v1.agent.save_session_messages", new_callable=AsyncMock)
     @patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock)
-    @patch("app.api.v1.agent.SkillsAgent")
+    @patch("app.api.v1.agent.create_agent")
     async def test_06_output_file_event_in_display(
         self, MockAgent, MockLoadSession, MockSaveMessages, MockCheckpoint, MockPreCompress,
         e2e_client: AsyncClient, e2e_db_session,
@@ -4014,7 +4014,7 @@ class TestSessionDisplayFormatE2E:
     @patch("app.api.v1.agent.save_session_checkpoint", new_callable=AsyncMock)
     @patch("app.api.v1.agent.save_session_messages", new_callable=AsyncMock)
     @patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock)
-    @patch("app.api.v1.agent.SkillsAgent")
+    @patch("app.api.v1.agent.create_agent")
     async def test_07_display_appends_to_existing_session(
         self, MockAgent, MockLoadSession, MockSaveMessages, MockCheckpoint, MockPreCompress,
         e2e_client: AsyncClient, e2e_db_session,
@@ -4397,3 +4397,137 @@ class TestMultiFeishuChannelE2E:
             pid = type(self)._state.get(key)
             if pid:
                 await e2e_client.delete(f"/api/v1/agents/{pid}")
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio(loop_scope="class")
+class TestGlobalFeishuBindingE2E:
+    """E2E tests for global Feishu binding support (external_id='*').
+
+    Covers: create global, duplicate rejection, coexistence with specific,
+    is_global in responses, and cleanup.
+    """
+
+    _state: dict = {}
+
+    async def test_01_create_preset(self, e2e_client: AsyncClient):
+        """Create agent preset for global binding tests."""
+        resp = await e2e_client.post("/api/v1/agents", json={
+            "name": "e2e-global-agent",
+            "description": "Agent for global binding tests",
+            "max_turns": 5,
+        })
+        assert resp.status_code == 200
+        type(self)._state["preset_id"] = resp.json()["id"]
+
+    async def test_02_create_global_binding(self, e2e_client: AsyncClient):
+        """Create a global Feishu binding (no external_id)."""
+        pid = type(self)._state["preset_id"]
+        resp = await e2e_client.post("/api/v1/channels", json={
+            "channel_type": "feishu",
+            "name": "Global Feishu E2E",
+            "agent_id": pid,
+            "config": {"app_id": "cli_global_e2e_001", "app_secret": "globalsecret123"},
+        })
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["external_id"] == "*"
+        assert body["is_global"] is True
+        assert body["channel_type"] == "feishu"
+        type(self)._state["global_id"] = body["id"]
+
+    async def test_03_global_secret_masked(self, e2e_client: AsyncClient):
+        """Global binding should also mask app_secret."""
+        gid = type(self)._state["global_id"]
+        resp = await e2e_client.get(f"/api/v1/channels/{gid}")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["config"]["app_secret"].startswith("****")
+        assert body["config"]["app_secret"].endswith("t123")
+        assert body["is_global"] is True
+
+    async def test_04_duplicate_global_rejected(self, e2e_client: AsyncClient):
+        """A second global binding for the same app_id should be rejected."""
+        pid = type(self)._state["preset_id"]
+        resp = await e2e_client.post("/api/v1/channels", json={
+            "channel_type": "feishu",
+            "name": "Duplicate Global",
+            "agent_id": pid,
+            "config": {"app_id": "cli_global_e2e_001", "app_secret": "other_secret"},
+        })
+        assert resp.status_code == 409
+
+    async def test_05_global_non_feishu_rejected(self, e2e_client: AsyncClient):
+        """Global binding for non-Feishu channel types should be rejected."""
+        pid = type(self)._state["preset_id"]
+        resp = await e2e_client.post("/api/v1/channels", json={
+            "channel_type": "webhook",
+            "name": "Global Webhook Fail",
+            "agent_id": pid,
+        })
+        assert resp.status_code == 400
+        assert "Feishu" in resp.json()["detail"]
+
+    async def test_06_global_requires_app_id(self, e2e_client: AsyncClient):
+        """Global Feishu binding without app_id in config should be rejected."""
+        pid = type(self)._state["preset_id"]
+        resp = await e2e_client.post("/api/v1/channels", json={
+            "channel_type": "feishu",
+            "name": "Global No AppId",
+            "agent_id": pid,
+            "config": {"app_secret": "only_secret"},
+        })
+        assert resp.status_code == 400
+        assert "app_id" in resp.json()["detail"]
+
+    async def test_07_create_specific_binding_same_app(self, e2e_client: AsyncClient):
+        """A specific binding for the same app_id can coexist with the global one."""
+        pid = type(self)._state["preset_id"]
+        resp = await e2e_client.post("/api/v1/channels", json={
+            "channel_type": "feishu",
+            "external_id": "oc_specific_e2e_001",
+            "name": "Specific Feishu E2E",
+            "agent_id": pid,
+            "config": {"app_id": "cli_global_e2e_001", "app_secret": "specificsecret"},
+        })
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["is_global"] is False
+        assert body["external_id"] == "oc_specific_e2e_001"
+        type(self)._state["specific_id"] = body["id"]
+
+    async def test_08_list_shows_is_global(self, e2e_client: AsyncClient):
+        """List endpoint should show is_global correctly for both bindings."""
+        resp = await e2e_client.get("/api/v1/channels?channel_type=feishu")
+        assert resp.status_code == 200
+        bindings = resp.json()["bindings"]
+        global_b = next((b for b in bindings if b["id"] == type(self)._state["global_id"]), None)
+        specific_b = next((b for b in bindings if b["id"] == type(self)._state["specific_id"]), None)
+        assert global_b is not None and global_b["is_global"] is True
+        assert specific_b is not None and specific_b["is_global"] is False
+
+    async def test_09_second_app_global_binding(self, e2e_client: AsyncClient):
+        """A global binding for a different app_id should succeed."""
+        pid = type(self)._state["preset_id"]
+        resp = await e2e_client.post("/api/v1/channels", json={
+            "channel_type": "feishu",
+            "name": "Global Feishu App 2",
+            "agent_id": pid,
+            "config": {"app_id": "cli_global_e2e_002", "app_secret": "app2secret"},
+        })
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["is_global"] is True
+        type(self)._state["global_id_2"] = body["id"]
+
+    async def test_10_cleanup(self, e2e_client: AsyncClient):
+        """Delete all test bindings and preset."""
+        for key in ["global_id", "global_id_2", "specific_id"]:
+            bid = type(self)._state.get(key)
+            if bid:
+                resp = await e2e_client.delete(f"/api/v1/channels/{bid}")
+                assert resp.status_code == 200
+
+        pid = type(self)._state.get("preset_id")
+        if pid:
+            await e2e_client.delete(f"/api/v1/agents/{pid}")

--- a/tests/test_services/test_agent_runner.py
+++ b/tests/test_services/test_agent_runner.py
@@ -1,0 +1,838 @@
+"""
+Tests for the unified agent execution service layer (app/services/agent_runner.py).
+
+Covers:
+- AgentConfig dataclass defaults and construction
+- config_from_preset() mapping from AgentPresetDB
+- create_agent() SkillsAgent construction
+- build_completed_trace() trace creation from agent result
+- build_initial_trace() "running" trace creation for streaming
+- Integration: scheduler._execute_task uses shared service
+- Integration: channel_manager._run_agent uses shared service (trace creation fix)
+"""
+
+import uuid
+from dataclasses import dataclass, field, asdict
+from datetime import datetime
+from typing import Optional, List
+from unittest.mock import patch, MagicMock, AsyncMock
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.models import AgentPresetDB, AgentTraceDB, PublishedSessionDB
+from app.services.agent_runner import (
+    AgentConfig,
+    config_from_preset,
+    create_agent,
+    build_completed_trace,
+    build_initial_trace,
+)
+
+
+# ---------------------------------------------------------------------------
+# Mock dataclasses for AgentResult
+# ---------------------------------------------------------------------------
+
+@dataclass
+class MockStep:
+    role: str = "assistant"
+    content: str = "Mock answer"
+    tool_name: Optional[str] = None
+    tool_input: Optional[dict] = None
+    tool_result: Optional[str] = None
+
+
+@dataclass
+class MockLLMCall:
+    turn: int = 1
+    timestamp: str = "2024-01-01T00:00:00"
+    model: str = "kimi-k2.5"
+    input_tokens: int = 100
+    output_tokens: int = 50
+    stop_reason: str = "end_turn"
+
+
+@dataclass
+class MockAgentResult:
+    success: bool = True
+    answer: str = "Mock answer"
+    total_turns: int = 3
+    total_input_tokens: int = 500
+    total_output_tokens: int = 250
+    steps: List = field(default_factory=lambda: [MockStep()])
+    llm_calls: List = field(default_factory=lambda: [MockLLMCall()])
+    error: Optional[str] = None
+    output_files: List = field(default_factory=list)
+    skills_used: List = field(default_factory=lambda: ["test-skill"])
+    final_messages: Optional[List] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# AgentConfig tests
+# ---------------------------------------------------------------------------
+
+
+class TestAgentConfig:
+    def test_defaults(self):
+        """AgentConfig has sensible defaults."""
+        config = AgentConfig()
+        assert config.model_provider is None
+        assert config.model_name is None
+        assert config.max_turns == 60
+        assert config.skills is None
+        assert config.allowed_tools is None
+        assert config.equipped_mcp_servers is None
+        assert config.system_prompt is None
+        assert config.executor_name is None
+        assert config.agent_id is None
+        assert config.is_meta_agent is False
+        assert config.verbose is True
+
+    def test_custom_construction(self):
+        """AgentConfig constructed with custom values preserves them."""
+        config = AgentConfig(
+            model_provider="anthropic",
+            model_name="claude-sonnet-4-5-20250929",
+            max_turns=10,
+            skills=["skill-a", "skill-b"],
+            allowed_tools=["execute_code"],
+            equipped_mcp_servers=["fetch"],
+            system_prompt="You are a helpful assistant",
+            executor_name="base",
+            agent_id="preset-123",
+            is_meta_agent=True,
+            verbose=False,
+        )
+        assert config.model_provider == "anthropic"
+        assert config.model_name == "claude-sonnet-4-5-20250929"
+        assert config.max_turns == 10
+        assert config.skills == ["skill-a", "skill-b"]
+        assert config.allowed_tools == ["execute_code"]
+        assert config.equipped_mcp_servers == ["fetch"]
+        assert config.system_prompt == "You are a helpful assistant"
+        assert config.executor_name == "base"
+        assert config.agent_id == "preset-123"
+        assert config.is_meta_agent is True
+        assert config.verbose is False
+
+    def test_mutable_after_creation(self):
+        """AgentConfig fields can be mutated (used for model override in preset mode)."""
+        config = AgentConfig(model_provider="kimi")
+        config.model_provider = "anthropic"
+        config.verbose = False
+        assert config.model_provider == "anthropic"
+        assert config.verbose is False
+
+
+# ---------------------------------------------------------------------------
+# config_from_preset tests
+# ---------------------------------------------------------------------------
+
+
+class TestConfigFromPreset:
+    def _make_preset(self, **overrides) -> AgentPresetDB:
+        """Create a test AgentPresetDB."""
+        defaults = dict(
+            id=str(uuid.uuid4()),
+            name="test-preset",
+            description="A test preset",
+            system_prompt="Be helpful",
+            skill_ids=["skill-a"],
+            mcp_servers=["fetch"],
+            builtin_tools=["execute_code", "read_file"],
+            max_turns=30,
+            model_provider="anthropic",
+            model_name="claude-sonnet-4-5-20250929",
+            is_system=False,
+            executor_name="base",
+        )
+        defaults.update(overrides)
+        return AgentPresetDB(**defaults)
+
+    def test_basic_mapping(self):
+        """config_from_preset maps all preset fields to AgentConfig."""
+        preset = self._make_preset()
+        config = config_from_preset(preset)
+
+        assert config.model_provider == "anthropic"
+        assert config.model_name == "claude-sonnet-4-5-20250929"
+        assert config.max_turns == 30
+        assert config.skills == ["skill-a"]
+        assert config.allowed_tools == ["execute_code", "read_file"]
+        assert config.equipped_mcp_servers == ["fetch"]
+        assert config.system_prompt == "Be helpful"
+        assert config.executor_name == "base"
+        assert config.agent_id == preset.id
+        assert config.is_meta_agent is False
+
+    def test_system_preset_maps_to_meta_agent(self):
+        """is_system=True on preset maps to is_meta_agent=True."""
+        preset = self._make_preset(is_system=True)
+        config = config_from_preset(preset)
+        assert config.is_meta_agent is True
+
+    def test_none_model_fields(self):
+        """Preset with None model fields produces config with None model fields."""
+        preset = self._make_preset(model_provider=None, model_name=None)
+        config = config_from_preset(preset)
+        assert config.model_provider is None
+        assert config.model_name is None
+
+    def test_none_executor_treated_as_none(self):
+        """Preset with empty executor_name is normalized to None."""
+        preset = self._make_preset(executor_name="")
+        config = config_from_preset(preset)
+        assert config.executor_name is None
+
+    def test_none_max_turns_defaults_to_60(self):
+        """Preset with max_turns=None defaults to 60."""
+        preset = self._make_preset(max_turns=None)
+        config = config_from_preset(preset)
+        assert config.max_turns == 60
+
+    def test_default_verbose_is_true(self):
+        """config_from_preset always sets verbose=True (caller can override for streaming)."""
+        preset = self._make_preset()
+        config = config_from_preset(preset)
+        assert config.verbose is True
+
+
+# ---------------------------------------------------------------------------
+# create_agent tests
+# ---------------------------------------------------------------------------
+
+
+class TestCreateAgent:
+    @patch("app.agent.SkillsAgent")
+    def test_passes_all_config_fields(self, MockAgent):
+        """create_agent passes all AgentConfig fields to SkillsAgent constructor."""
+        mock_instance = MagicMock()
+        MockAgent.return_value = mock_instance
+
+        config = AgentConfig(
+            model_provider="anthropic",
+            model_name="claude-sonnet-4-5-20250929",
+            max_turns=15,
+            skills=["my-skill"],
+            allowed_tools=["execute_code"],
+            equipped_mcp_servers=["fetch"],
+            system_prompt="Custom prompt",
+            executor_name="base",
+            is_meta_agent=True,
+            verbose=False,
+        )
+
+        result = create_agent(config, workspace_id="ws-123")
+
+        MockAgent.assert_called_once_with(
+            model="claude-sonnet-4-5-20250929",
+            model_provider="anthropic",
+            max_turns=15,
+            verbose=False,
+            allowed_skills=["my-skill"],
+            allowed_tools=["execute_code"],
+            equipped_mcp_servers=["fetch"],
+            custom_system_prompt="Custom prompt",
+            executor_name="base",
+            workspace_id="ws-123",
+            is_meta_agent=True,
+        )
+        assert result is mock_instance
+
+    @patch("app.agent.SkillsAgent")
+    def test_none_workspace_id(self, MockAgent):
+        """create_agent without workspace_id passes None."""
+        MockAgent.return_value = MagicMock()
+        config = AgentConfig()
+        create_agent(config)
+        call_kwargs = MockAgent.call_args[1]
+        assert call_kwargs["workspace_id"] is None
+
+    @patch("app.agent.SkillsAgent")
+    def test_defaults_produce_valid_call(self, MockAgent):
+        """create_agent with default AgentConfig doesn't crash."""
+        MockAgent.return_value = MagicMock()
+        config = AgentConfig()
+        agent = create_agent(config)
+        assert agent is not None
+        MockAgent.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# build_completed_trace tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCompletedTrace:
+    def _make_mock_agent(self):
+        agent = MagicMock()
+        agent.model_provider = "anthropic"
+        agent.model = "claude-sonnet-4-5-20250929"
+        return agent
+
+    def test_success_trace(self):
+        """build_completed_trace creates a proper success trace."""
+        result = MockAgentResult()
+        agent = self._make_mock_agent()
+
+        trace = build_completed_trace(
+            request_text="Test request",
+            result=result,
+            agent=agent,
+            duration_ms=1500,
+            executor_name="base",
+            session_id="session-123",
+        )
+
+        assert isinstance(trace, AgentTraceDB)
+        assert trace.request == "Test request"
+        assert trace.status == "completed"
+        assert trace.success is True
+        assert trace.answer == "Mock answer"
+        assert trace.error is None
+        assert trace.total_turns == 3
+        assert trace.total_input_tokens == 500
+        assert trace.total_output_tokens == 250
+        assert trace.model_provider == "anthropic"
+        assert trace.model == "claude-sonnet-4-5-20250929"
+        assert trace.duration_ms == 1500
+        assert trace.executor_name == "base"
+        assert trace.session_id == "session-123"
+        assert trace.skills_used == ["test-skill"]
+        assert len(trace.steps) == 1
+        assert len(trace.llm_calls) == 1
+
+    def test_failure_trace(self):
+        """build_completed_trace with failed result sets status='failed'."""
+        result = MockAgentResult(
+            success=False,
+            answer="",
+            error="LLM stream failed",
+        )
+        agent = self._make_mock_agent()
+
+        trace = build_completed_trace(
+            request_text="Failing request",
+            result=result,
+            agent=agent,
+            duration_ms=500,
+        )
+
+        assert trace.status == "failed"
+        assert trace.success is False
+        assert trace.error == "LLM stream failed"
+
+    def test_empty_skills_used(self):
+        """build_completed_trace handles None skills_used gracefully."""
+        result = MockAgentResult(skills_used=None)
+        agent = self._make_mock_agent()
+
+        trace = build_completed_trace(
+            request_text="Test",
+            result=result,
+            agent=agent,
+            duration_ms=100,
+        )
+
+        assert trace.skills_used == []
+
+    def test_no_executor_or_session(self):
+        """build_completed_trace works without executor_name and session_id."""
+        result = MockAgentResult()
+        agent = self._make_mock_agent()
+
+        trace = build_completed_trace(
+            request_text="Test",
+            result=result,
+            agent=agent,
+            duration_ms=100,
+        )
+
+        assert trace.executor_name is None
+        assert trace.session_id is None
+
+    def test_trace_uses_agent_resolved_model(self):
+        """build_completed_trace reads model from agent (which has defaults resolved), not config."""
+        result = MockAgentResult()
+        agent = MagicMock()
+        agent.model_provider = "kimi"  # Agent resolved the default
+        agent.model = "kimi-k2.5"
+
+        trace = build_completed_trace(
+            request_text="Test",
+            result=result,
+            agent=agent,
+            duration_ms=100,
+        )
+
+        assert trace.model_provider == "kimi"
+        assert trace.model == "kimi-k2.5"
+
+    def test_trace_is_unsaved(self):
+        """build_completed_trace returns an unsaved ORM object (no id set by default mechanism)."""
+        result = MockAgentResult()
+        agent = self._make_mock_agent()
+
+        trace = build_completed_trace(
+            request_text="Test",
+            result=result,
+            agent=agent,
+            duration_ms=100,
+        )
+
+        # ORM default generates UUID, but object is not in a session
+        assert trace.request == "Test"  # Field is set
+        # Not committed — we can check that no session is attached
+        from sqlalchemy import inspect as sa_inspect
+        assert sa_inspect(trace).transient is True
+
+
+# ---------------------------------------------------------------------------
+# build_initial_trace tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildInitialTrace:
+    def test_running_state(self):
+        """build_initial_trace creates a trace in 'running' state with zero counters."""
+        trace = build_initial_trace(
+            request_text="Stream request",
+            model_provider="anthropic",
+            model_name="claude-sonnet-4-5-20250929",
+            executor_name="base",
+            session_id="session-456",
+        )
+
+        assert isinstance(trace, AgentTraceDB)
+        assert trace.request == "Stream request"
+        assert trace.status == "running"
+        assert trace.success is False
+        assert trace.answer == ""
+        assert trace.error is None
+        assert trace.total_turns == 0
+        assert trace.total_input_tokens == 0
+        assert trace.total_output_tokens == 0
+        assert trace.skills_used == []
+        assert trace.steps == []
+        assert trace.llm_calls == []
+        assert trace.duration_ms == 0
+        assert trace.model_provider == "anthropic"
+        assert trace.model == "claude-sonnet-4-5-20250929"
+        assert trace.executor_name == "base"
+        assert trace.session_id == "session-456"
+
+    def test_no_executor_or_session(self):
+        """build_initial_trace works without optional fields."""
+        trace = build_initial_trace(
+            request_text="Test",
+            model_provider="kimi",
+            model_name="kimi-k2.5",
+        )
+
+        assert trace.executor_name is None
+        assert trace.session_id is None
+
+
+# ---------------------------------------------------------------------------
+# Integration: agent.py uses shared service
+# ---------------------------------------------------------------------------
+
+
+class TestAgentAPIIntegration:
+    """Verify that the agent API endpoints use the shared service layer."""
+
+    @patch("app.api.v1.agent.save_session_messages", new_callable=AsyncMock)
+    @patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock,
+           return_value=MagicMock(session_id="test-sid", agent_context=None, display_messages=[]))
+    @patch("app.api.v1.agent.create_agent")
+    async def test_run_endpoint_uses_create_agent(self, mock_create, _mock_load, _mock_save, client):
+        """POST /agent/run calls create_agent from shared service."""
+        mock_agent = MagicMock()
+        mock_agent.run = AsyncMock(return_value=MockAgentResult())
+        mock_agent.model = "kimi-k2.5"
+        mock_agent.model_provider = "kimi"
+        mock_agent.cleanup = MagicMock()
+        mock_create.return_value = mock_agent
+
+        resp = await client.post(
+            "/api/v1/agent/run",
+            json={"request": "Test", "session_id": "test-sid"},
+        )
+
+        assert resp.status_code == 200
+        mock_create.assert_called_once()
+        # Verify first arg is an AgentConfig
+        config_arg = mock_create.call_args[0][0]
+        assert isinstance(config_arg, AgentConfig)
+
+    @patch("app.api.v1.agent.save_session_messages", new_callable=AsyncMock)
+    @patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock,
+           return_value=MagicMock(session_id="test-sid", agent_context=None, display_messages=[]))
+    @patch("app.api.v1.agent.create_agent")
+    async def test_run_endpoint_uses_build_completed_trace(self, mock_create, _mock_load, _mock_save, client, db_session):
+        """POST /agent/run uses build_completed_trace and saves to DB."""
+        mock_agent = MagicMock()
+        mock_agent.run = AsyncMock(return_value=MockAgentResult())
+        mock_agent.model = "test-model"
+        mock_agent.model_provider = "test-provider"
+        mock_agent.cleanup = MagicMock()
+        mock_create.return_value = mock_agent
+
+        resp = await client.post(
+            "/api/v1/agent/run",
+            json={"request": "Trace test", "session_id": "test-sid"},
+        )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        # Trace should have been saved
+        assert body["trace_id"] is not None
+
+        # Verify trace in DB
+        from sqlalchemy import select
+        result = await db_session.execute(
+            select(AgentTraceDB).where(AgentTraceDB.id == body["trace_id"])
+        )
+        trace = result.scalar_one_or_none()
+        assert trace is not None
+        assert trace.model_provider == "test-provider"
+        assert trace.model == "test-model"
+        assert trace.status == "completed"
+
+    @patch("app.api.v1.agent.save_session_messages", new_callable=AsyncMock)
+    @patch("app.api.v1.agent.load_or_create_session", new_callable=AsyncMock,
+           return_value=MagicMock(session_id="test-sid", agent_context=None, display_messages=[]))
+    @patch("app.api.v1.agent.create_agent")
+    async def test_run_endpoint_calls_cleanup(self, mock_create, _mock_load, _mock_save, client):
+        """POST /agent/run always calls agent.cleanup() in finally block."""
+        mock_agent = MagicMock()
+        mock_agent.run = AsyncMock(return_value=MockAgentResult())
+        mock_agent.model = "kimi-k2.5"
+        mock_agent.model_provider = "kimi"
+        mock_agent.cleanup = MagicMock()
+        mock_create.return_value = mock_agent
+
+        await client.post(
+            "/api/v1/agent/run",
+            json={"request": "Test", "session_id": "test-sid"},
+        )
+
+        mock_agent.cleanup.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Integration: scheduler uses shared service
+# ---------------------------------------------------------------------------
+
+
+class TestSchedulerIntegration:
+    """Verify that the scheduler uses the shared service layer."""
+
+    @patch("app.agent.SkillsAgent")
+    def test_execute_task_uses_config_from_preset(self, MockSkillsAgent):
+        """scheduler._execute_task constructs agent via config_from_preset + create_agent.
+
+        Uses mock SyncSessionLocal to avoid needing real test tables for the
+        sync DB path the scheduler uses.
+        """
+        from app.services.scheduler import TaskScheduler
+        from app.db.models import ScheduledTaskDB, TaskRunLogDB, generate_uuid
+        import asyncio
+
+        # Build in-memory test objects
+        preset = AgentPresetDB(
+            id=str(uuid.uuid4()),
+            name="sched-test",
+            max_turns=10,
+            skill_ids=["test-skill"],
+            model_provider="kimi",
+            model_name="kimi-k2.5",
+        )
+        task = ScheduledTaskDB(
+            id=str(uuid.uuid4()),
+            name="task-sched",
+            agent_id=preset.id,
+            prompt="Run test",
+            schedule_type="once",
+            schedule_value="2099-01-01T00:00:00Z",
+            context_mode="isolated",
+            status="active",
+            run_count=0,
+        )
+        run_log = TaskRunLogDB(
+            id=generate_uuid(),
+            task_id=task.id,
+            status="running",
+        )
+
+        # Mock SyncSessionLocal to return objects without real DB
+        mock_sync_session = MagicMock()
+        mock_sync_session.get = MagicMock(side_effect=lambda model, id_: {
+            (ScheduledTaskDB, task.id): task,
+            (AgentPresetDB, preset.id): preset,
+            (TaskRunLogDB, run_log.id): run_log,
+        }.get((model, id_)))
+        mock_sync_session.add = MagicMock()
+        mock_sync_session.commit = MagicMock()
+        mock_sync_session.close = MagicMock()
+
+        # Setup mock agent — use a plain coroutine to avoid event loop affinity
+        # (scheduler creates its own event loop via asyncio.new_event_loop())
+        mock_instance = MagicMock()
+        mock_instance.model_provider = "kimi"
+        mock_instance.model = "kimi-k2.5"
+        mock_instance.cleanup = MagicMock()
+
+        mock_result = MockAgentResult()
+
+        async def mock_run(*args, **kwargs):
+            return mock_result
+
+        mock_instance.run = mock_run
+        MockSkillsAgent.return_value = mock_instance
+
+        # Execute with mocked DB (SyncSessionLocal is lazy-imported from app.db.database)
+        scheduler = TaskScheduler()
+        with patch("app.db.database.SyncSessionLocal", return_value=mock_sync_session):
+            scheduler._execute_task(task.id, run_log.id)
+
+        # Verify agent was created with correct params from preset
+        MockSkillsAgent.assert_called_once()
+        call_kwargs = MockSkillsAgent.call_args[1]
+        assert call_kwargs["max_turns"] == 10
+        assert call_kwargs["allowed_skills"] == ["test-skill"]
+        assert call_kwargs["model_provider"] == "kimi"
+        assert call_kwargs["model"] == "kimi-k2.5"
+
+        # Verify cleanup was called
+        mock_instance.cleanup.assert_called_once()
+
+        # Verify trace was added to session
+        added_objects = [call.args[0] for call in mock_sync_session.add.call_args_list]
+        trace_objects = [o for o in added_objects if isinstance(o, AgentTraceDB)]
+        assert len(trace_objects) == 1
+        trace = trace_objects[0]
+        assert trace.model_provider == "kimi"
+        assert trace.model == "kimi-k2.5"
+        assert trace.request == "Run test"
+
+
+# ---------------------------------------------------------------------------
+# Integration: channel_manager uses shared service
+# ---------------------------------------------------------------------------
+
+
+class TestChannelManagerIntegration:
+    """Verify that ChannelManager._run_agent uses the shared service layer."""
+
+    @patch("app.agent.SkillsAgent")
+    async def test_run_agent_creates_trace(self, MockSkillsAgent):
+        """channel_manager._run_agent now creates a trace (the core bug fix)."""
+        from app.services.channel_manager import ChannelManager
+
+        # Setup mock agent
+        mock_instance = MagicMock()
+        mock_instance.model_provider = "kimi"
+        mock_instance.model = "kimi-k2.5"
+        mock_instance.cleanup = MagicMock()
+
+        mock_result = MagicMock()
+        mock_result.success = True
+        mock_result.answer = "Channel response"
+        mock_result.total_turns = 1
+        mock_result.total_input_tokens = 100
+        mock_result.total_output_tokens = 50
+        mock_result.steps = []
+        mock_result.llm_calls = []
+        mock_result.skills_used = ["test-skill"]
+        mock_result.error = None
+        mock_result.output_files = []
+        mock_result.final_messages = [{"role": "user", "content": "Hello"}, {"role": "assistant", "content": "Channel response"}]
+
+        mock_instance.run = AsyncMock(return_value=mock_result)
+        MockSkillsAgent.return_value = mock_instance
+
+        # Create a preset
+        preset = AgentPresetDB(
+            id=str(uuid.uuid4()),
+            name="channel-test",
+            max_turns=20,
+            skill_ids=["test-skill"],
+            model_provider="kimi",
+            model_name="kimi-k2.5",
+        )
+
+        session_id = f"channel-session-{uuid.uuid4().hex[:8]}"
+
+        # Mock AsyncSessionLocal to capture the trace object (lazy-imported from app.db.database)
+        mock_trace_session = AsyncMock()
+        mock_trace_session.__aenter__ = AsyncMock(return_value=mock_trace_session)
+        mock_trace_session.__aexit__ = AsyncMock(return_value=False)
+        added_objects = []
+        mock_trace_session.add = MagicMock(side_effect=lambda obj: added_objects.append(obj))
+        mock_trace_session.commit = AsyncMock()
+
+        # Execute — mock both AsyncSessionLocal and save_session_messages (lazy imports)
+        with patch("app.db.database.AsyncSessionLocal", return_value=mock_trace_session), \
+             patch("app.api.v1.sessions.save_session_messages", new_callable=AsyncMock):
+            manager = ChannelManager.__new__(ChannelManager)
+            manager._adapters = {}
+            answer, output_files = await manager._run_agent(
+                preset, "Hello from Feishu", conversation_history=None,
+                session_id=session_id,
+            )
+
+        assert answer == "Channel response"
+
+        # THE CORE BUG FIX: Verify trace was created
+        trace_objects = [o for o in added_objects if isinstance(o, AgentTraceDB)]
+        assert len(trace_objects) == 1
+        trace = trace_objects[0]
+        assert trace.request == "Hello from Feishu"
+        assert trace.status == "completed"
+        assert trace.success is True
+        assert trace.answer == "Channel response"
+        assert trace.model_provider == "kimi"
+        assert trace.model == "kimi-k2.5"
+        assert trace.session_id == session_id
+
+    @patch("app.agent.SkillsAgent")
+    async def test_run_agent_calls_cleanup(self, MockSkillsAgent):
+        """channel_manager._run_agent calls agent.cleanup() in finally block."""
+        from app.services.channel_manager import ChannelManager
+
+        mock_instance = MagicMock()
+        mock_instance.model_provider = "kimi"
+        mock_instance.model = "kimi-k2.5"
+        mock_instance.cleanup = MagicMock()
+        mock_instance.run = AsyncMock(return_value=MagicMock(
+            success=True, answer="OK", total_turns=1,
+            total_input_tokens=0, total_output_tokens=0,
+            steps=[], llm_calls=[], skills_used=[], error=None,
+            output_files=[], final_messages=[],
+        ))
+        MockSkillsAgent.return_value = mock_instance
+
+        preset = AgentPresetDB(
+            id=str(uuid.uuid4()), name="cleanup-test",
+            max_turns=5, model_provider="kimi", model_name="kimi-k2.5",
+        )
+
+        manager = ChannelManager.__new__(ChannelManager)
+        manager._adapters = {}
+        await manager._run_agent(preset, "Test cleanup")
+
+        mock_instance.cleanup.assert_called_once()
+
+    @patch("app.agent.SkillsAgent")
+    async def test_run_agent_cleanup_on_error(self, MockSkillsAgent):
+        """channel_manager._run_agent calls cleanup even when agent.run() raises."""
+        from app.services.channel_manager import ChannelManager
+
+        mock_instance = MagicMock()
+        mock_instance.model_provider = "kimi"
+        mock_instance.model = "kimi-k2.5"
+        mock_instance.cleanup = MagicMock()
+        mock_instance.run = AsyncMock(side_effect=RuntimeError("LLM failed"))
+        MockSkillsAgent.return_value = mock_instance
+
+        preset = AgentPresetDB(
+            id=str(uuid.uuid4()), name="error-test",
+            max_turns=5, model_provider="kimi", model_name="kimi-k2.5",
+        )
+
+        manager = ChannelManager.__new__(ChannelManager)
+        manager._adapters = {}
+        answer, _ = await manager._run_agent(preset, "Will fail")
+
+        assert "Error:" in answer
+        mock_instance.cleanup.assert_called_once()
+
+    @patch("app.agent.SkillsAgent")
+    async def test_run_agent_updates_session_via_save_session_messages(self, MockSkillsAgent):
+        """channel_manager._run_agent updates session using save_session_messages (dual-store)."""
+        from app.services.channel_manager import ChannelManager
+
+        mock_instance = MagicMock()
+        mock_instance.model_provider = "kimi"
+        mock_instance.model = "kimi-k2.5"
+        mock_instance.cleanup = MagicMock()
+        mock_instance.run = AsyncMock(return_value=MagicMock(
+            success=True, answer="Updated response", total_turns=1,
+            total_input_tokens=50, total_output_tokens=25,
+            steps=[], llm_calls=[], skills_used=[], error=None,
+            output_files=[],
+            final_messages=[
+                {"role": "user", "content": "Update test"},
+                {"role": "assistant", "content": "Updated response"},
+            ],
+        ))
+        MockSkillsAgent.return_value = mock_instance
+
+        preset = AgentPresetDB(
+            id=str(uuid.uuid4()), name="session-update-test",
+            max_turns=5, model_provider="kimi", model_name="kimi-k2.5",
+        )
+
+        session_id = f"session-update-{uuid.uuid4().hex[:8]}"
+
+        # Mock AsyncSessionLocal for trace saving and save_session_messages for session update
+        # Both are lazy-imported inside _run_agent from their source modules
+        mock_trace_session = AsyncMock()
+        mock_trace_session.__aenter__ = AsyncMock(return_value=mock_trace_session)
+        mock_trace_session.__aexit__ = AsyncMock(return_value=False)
+        mock_trace_session.add = MagicMock()
+        mock_trace_session.commit = AsyncMock()
+
+        with patch("app.db.database.AsyncSessionLocal", return_value=mock_trace_session), \
+             patch("app.api.v1.sessions.save_session_messages", new_callable=AsyncMock) as mock_save:
+            manager = ChannelManager.__new__(ChannelManager)
+            manager._adapters = {}
+            await manager._run_agent(
+                preset, "Update test", session_id=session_id,
+            )
+
+            # Verify save_session_messages was called with correct arguments
+            mock_save.assert_called_once_with(
+                session_id,
+                "Updated response",
+                "Update test",
+                final_messages=[
+                    {"role": "user", "content": "Update test"},
+                    {"role": "assistant", "content": "Updated response"},
+                ],
+            )
+
+    @patch("app.agent.SkillsAgent")
+    async def test_run_agent_pre_compress_called(self, MockSkillsAgent):
+        """channel_manager._run_agent calls pre_compress_if_needed when history exists."""
+        from app.services.channel_manager import ChannelManager
+
+        mock_instance = MagicMock()
+        mock_instance.model_provider = "kimi"
+        mock_instance.model = "kimi-k2.5"
+        mock_instance.cleanup = MagicMock()
+        mock_instance.run = AsyncMock(return_value=MagicMock(
+            success=True, answer="OK", total_turns=1,
+            total_input_tokens=0, total_output_tokens=0,
+            steps=[], llm_calls=[], skills_used=[], error=None,
+            output_files=[], final_messages=[],
+        ))
+        MockSkillsAgent.return_value = mock_instance
+
+        preset = AgentPresetDB(
+            id=str(uuid.uuid4()), name="compress-test",
+            max_turns=5, model_provider="kimi", model_name="kimi-k2.5",
+        )
+
+        manager = ChannelManager.__new__(ChannelManager)
+        manager._adapters = {}
+
+        history = [{"role": "user", "content": "Old message"}]
+        with patch("app.api.v1.sessions.pre_compress_if_needed", new_callable=AsyncMock, return_value=history) as mock_compress:
+            await manager._run_agent(
+                preset, "New message", conversation_history=history,
+            )
+            mock_compress.assert_called_once_with(history, "kimi", "kimi-k2.5")

--- a/web/src/app/channels/[id]/page.tsx
+++ b/web/src/app/channels/[id]/page.tsx
@@ -374,7 +374,13 @@ export default function ChannelDetailPage() {
                 </div>
                 <div>
                   <span className="text-sm font-medium text-muted-foreground">{t('fields.externalId')}</span>
-                  <p className="mt-1 font-mono text-sm">{binding.external_id}</p>
+                  <div className="mt-1">
+                    {binding.is_global ? (
+                      <Badge variant="info">{t('scope.allGroups')}</Badge>
+                    ) : (
+                      <p className="font-mono text-sm">{binding.external_id}</p>
+                    )}
+                  </div>
                 </div>
                 <div>
                   <span className="text-sm font-medium text-muted-foreground">{t('fields.agent')}</span>

--- a/web/src/app/channels/page.tsx
+++ b/web/src/app/channels/page.tsx
@@ -269,7 +269,11 @@ function BindingCard({
         <div className="space-y-1.5 text-sm text-muted-foreground flex-1">
           <div>
             <span className="font-medium">{t('fields.externalId')}:</span>{' '}
-            <span className="font-mono text-xs">{binding.external_id}</span>
+            {binding.is_global ? (
+              <Badge variant="info" className="text-xs">{t('scope.allGroups')}</Badge>
+            ) : (
+              <span className="font-mono text-xs">{binding.external_id}</span>
+            )}
           </div>
           {binding.trigger_pattern && (
             <div>

--- a/web/src/app/scheduled-tasks/new/page.tsx
+++ b/web/src/app/scheduled-tasks/new/page.tsx
@@ -53,7 +53,7 @@ export default function NewScheduledTaskPage() {
   const [channelBindingId, setChannelBindingId] = useState('');
 
   const agents = agentsData?.presets || [];
-  const channels = channelsData?.bindings?.filter((b) => b.enabled) || [];
+  const channels = channelsData?.bindings?.filter((b) => b.enabled && !b.is_global) || [];
 
   const getPlaceholder = () => {
     switch (scheduleType) {

--- a/web/src/i18n/locales/en-US/channels.json
+++ b/web/src/i18n/locales/en-US/channels.json
@@ -13,7 +13,14 @@
     "enabled": "Enabled",
     "config": "Configuration",
     "appId": "App ID",
-    "appSecret": "App Secret"
+    "appSecret": "App Secret",
+    "scope": "Scope"
+  },
+  "scope": {
+    "allGroups": "All Groups",
+    "specificGroup": "Specific Group",
+    "allGroupsHint": "Respond in every group the bot is added to",
+    "specificGroupHint": "Only respond in one specific group"
   },
   "channelTypes": {
     "feishu": "Feishu (Lark)",

--- a/web/src/i18n/locales/es/channels.json
+++ b/web/src/i18n/locales/es/channels.json
@@ -13,7 +13,14 @@
     "enabled": "Habilitado",
     "config": "Configuracion",
     "appId": "App ID",
-    "appSecret": "App Secret"
+    "appSecret": "App Secret",
+    "scope": "Alcance"
+  },
+  "scope": {
+    "allGroups": "Todos los grupos",
+    "specificGroup": "Grupo especifico",
+    "allGroupsHint": "Responder en todos los grupos donde se agrego el bot",
+    "specificGroupHint": "Responder solo en un grupo especifico"
   },
   "channelTypes": {
     "feishu": "Feishu (Lark)",

--- a/web/src/i18n/locales/ja/channels.json
+++ b/web/src/i18n/locales/ja/channels.json
@@ -13,7 +13,14 @@
     "enabled": "有効",
     "config": "設定",
     "appId": "App ID",
-    "appSecret": "App Secret"
+    "appSecret": "App Secret",
+    "scope": "スコープ"
+  },
+  "scope": {
+    "allGroups": "全グループ",
+    "specificGroup": "特定グループ",
+    "allGroupsHint": "ボットが追加されたすべてのグループで応答",
+    "specificGroupHint": "特定の1つのグループでのみ応答"
   },
   "channelTypes": {
     "feishu": "Feishu (Lark)",

--- a/web/src/i18n/locales/pt-BR/channels.json
+++ b/web/src/i18n/locales/pt-BR/channels.json
@@ -13,7 +13,14 @@
     "enabled": "Habilitado",
     "config": "Configuracao",
     "appId": "App ID",
-    "appSecret": "App Secret"
+    "appSecret": "App Secret",
+    "scope": "Escopo"
+  },
+  "scope": {
+    "allGroups": "Todos os grupos",
+    "specificGroup": "Grupo especifico",
+    "allGroupsHint": "Responder em todos os grupos onde o bot foi adicionado",
+    "specificGroupHint": "Responder apenas em um grupo especifico"
   },
   "channelTypes": {
     "feishu": "Feishu (Lark)",

--- a/web/src/i18n/locales/zh-CN/channels.json
+++ b/web/src/i18n/locales/zh-CN/channels.json
@@ -13,7 +13,14 @@
     "enabled": "已启用",
     "config": "配置",
     "appId": "App ID",
-    "appSecret": "App Secret"
+    "appSecret": "App Secret",
+    "scope": "作用范围"
+  },
+  "scope": {
+    "allGroups": "所有群组",
+    "specificGroup": "指定群组",
+    "allGroupsHint": "在机器人加入的所有群组中响应",
+    "specificGroupHint": "仅在一个指定群组中响应"
   },
   "channelTypes": {
     "feishu": "飞书",

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2061,6 +2061,7 @@ export interface ChannelBinding {
   agent_name: string | null;
   trigger_pattern: string | null;
   enabled: boolean;
+  is_global: boolean;
   config: Record<string, unknown> | null;
   created_at: string;
   updated_at: string;
@@ -2073,7 +2074,7 @@ export interface ChannelBindingListResponse {
 
 export interface ChannelBindingCreateRequest {
   channel_type: string;
-  external_id: string;
+  external_id?: string;
   name: string;
   agent_id: string;
   trigger_pattern?: string | null;


### PR DESCRIPTION
## Summary

### Agent runner service layer
- Extract shared agent construction, trace creation, and session management into `app/services/agent_runner.py` (`AgentConfig`, `config_from_preset`, `create_agent`, `build_completed_trace`, `build_initial_trace`)
- **Fix core bug**: `channel_manager._run_agent()` now creates `AgentTraceDB` records — Feishu/Telegram conversations are no longer invisible in the Traces dashboard
- Add `agent.cleanup()`, `pre_compress_if_needed()`, and `save_session_messages()` to both scheduler and channel_manager
- Remove hardcoded `"kimi"` model fallback in scheduler traces
- Consolidate scheduler's 3 separate event loops into 1 shared loop
- Add `TYPE_CHECKING` type hints to service functions

### Global Feishu binding (all-groups mode)
- Allow a single Feishu bot to serve all groups via sentinel `external_id="*"`
- Two-level routing in channel_manager: exact match → global fallback by app_id
- DB migration: replace unique constraint with partial indexes
- API: optional external_id, `is_global` field, Feishu-only validation
- Block global bindings from scheduled task targets (API + frontend)
- Frontend: scope toggle on create form, "All Groups" badge on list/detail
- i18n: scope keys for all 5 languages

### Before vs After

| Path | Trace | Cleanup | Pre-compress | Session (dual-store) |
|------|-------|---------|--------------|----------------------|
| `channel_manager` | ❌ → ✅ | ❌ → ✅ | ❌ → ✅ | ⚠️ inline → ✅ `save_session_messages` |
| `scheduler` | ⚠️ hardcoded model → ✅ | ❌ → ✅ | ❌ → ✅ | ⚠️ inline → ✅ `save_session_messages` |
| `agent.py` (run/stream) | ✅ refactored | ✅ | ✅ | ✅ |

## Test plan

- [x] 29 new tests in `tests/test_services/test_agent_runner.py`
- [x] 18 new tests for global Feishu binding (`test_channels.py` + `test_e2e_workflows.py`)
- [x] Updated mocks in existing test files — `SkillsAgent` → `create_agent`
- [x] Full suite: 905+ passed
- [x] Docker redeploy verified (API healthy)

Closes #220