### PR TITLE
fix: only respond to @mentions in Feishu group chats

### DIFF
--- a/app/channels/feishu.py
+++ b/app/channels/feishu.py
@@ -274,6 +274,17 @@ class FeishuAdapter(ChannelAdapter):
             if self._bot_open_id and sender_id == self._bot_open_id:
                 return
 
+            # In group chats, only respond when the bot is @mentioned
+            mentions = getattr(msg, "mentions", None) or []
+            bot_mention_key = None
+            if chat_type == "group" and self._bot_open_id:
+                for m in mentions:
+                    if m.id and m.id.open_id == self._bot_open_id:
+                        bot_mention_key = m.key  # e.g. "@_user_1"
+                        break
+                if not bot_mention_key:
+                    return
+
             msg_type = msg.message_type
             content = ""
             media_paths: list[str] = []
@@ -302,6 +313,10 @@ class FeishuAdapter(ChannelAdapter):
             else:
                 # Unsupported message type — ignore
                 return
+
+            # Strip the bot @mention placeholder from content (e.g. "@_user_1")
+            if bot_mention_key and content:
+                content = content.replace(bot_mention_key, "").strip()
 
             if not content and not media_paths:
                 return


### PR DESCRIPTION
## Summary

- In group chats (`chat_type == "group"`), skip messages where the bot is not @mentioned
- P2P (direct) chats are unaffected — the bot still responds to all messages
- Strip the `@_user_1` mention placeholder from the message content before passing it to the agent

## How it works

The Feishu SDK's `EventMessage.mentions` contains `MentionEvent` objects with `id.open_id` (the mentioned user) and `key` (the placeholder in the text). We check if any mention matches `self._bot_open_id` and skip the message if not.

## Test plan

- [x] Group chat: bot ignores messages without @mention
- [x] Group chat: bot responds when @mentioned, with clean content (placeholder stripped)
- [x] P2P chat: bot responds to all messages (unchanged)
- [x] Docker redeploy verified (API healthy)

Closes #222