### PR TITLE
feat: decouple scheduled task delivery target from channel binding

### DIFF
--- a/app/api/v1/scheduler.py
+++ b/app/api/v1/scheduler.py
@@ -32,6 +32,7 @@ class ScheduledTaskCreate(BaseModel):
     context_mode: str = Field(default="isolated", pattern="^(isolated|session)$")
     max_runs: Optional[int] = Field(default=None, ge=1)
     channel_binding_id: Optional[str] = None
+    delivery_to: Optional[str] = Field(default=None, max_length=256)
 
 
 class ScheduledTaskUpdate(BaseModel):
@@ -42,6 +43,7 @@ class ScheduledTaskUpdate(BaseModel):
     context_mode: Optional[str] = Field(default=None, pattern="^(isolated|session)$")
     max_runs: Optional[int] = Field(default=None, ge=1)
     channel_binding_id: Optional[str] = None
+    delivery_to: Optional[str] = Field(default=None, max_length=256)
 
 
 class ScheduledTaskResponse(BaseModel):
@@ -56,6 +58,7 @@ class ScheduledTaskResponse(BaseModel):
     session_id: Optional[str] = None
     channel_binding_id: Optional[str] = None
     channel_binding_name: Optional[str] = None
+    delivery_to: Optional[str] = None
     status: str
     next_run: Optional[str] = None
     last_run: Optional[str] = None
@@ -91,6 +94,7 @@ def _task_to_response(task: ScheduledTaskDB, agent_name: str = None, channel_bin
         "session_id": task.session_id,
         "channel_binding_id": task.channel_binding_id,
         "channel_binding_name": channel_binding_name,
+        "delivery_to": task.delivery_to,
         "status": task.status,
         "next_run": task.next_run.isoformat() if task.next_run else None,
         "last_run": task.last_run.isoformat() if task.last_run else None,
@@ -221,12 +225,17 @@ async def create_scheduled_task(
         cb = cb_result.scalar_one_or_none()
         if not cb:
             raise HTTPException(status_code=400, detail="Channel binding not found")
-        if cb.external_id == "*":
+        if cb.external_id == "*" and not data.delivery_to:
             raise HTTPException(
                 status_code=400,
-                detail="Global bindings (all groups) cannot be used as scheduled task targets",
+                detail="Global bindings require a delivery_to target chat ID",
             )
         channel_binding_name = cb.name
+    elif data.delivery_to:
+        raise HTTPException(
+            status_code=400,
+            detail="delivery_to requires a channel_binding_id",
+        )
 
     # Validate schedule
     error = validate_schedule(data.schedule_type, data.schedule_value)
@@ -253,6 +262,7 @@ async def create_scheduled_task(
         schedule_value=data.schedule_value,
         context_mode=data.context_mode,
         channel_binding_id=data.channel_binding_id,
+        delivery_to=data.delivery_to,
         max_runs=data.max_runs,
         next_run=next_run,
         status="active",
@@ -304,7 +314,10 @@ async def update_scheduled_task(
         if existing.scalar_one_or_none():
             raise HTTPException(status_code=409, detail=f"Task name '{update_fields['name']}' already exists")
 
-    # Validate channel binding exists (if changing)
+    # Validate channel binding + delivery_to combination
+    effective_binding_id = update_fields.get("channel_binding_id", task.channel_binding_id)
+    effective_delivery_to = update_fields.get("delivery_to", task.delivery_to)
+
     if "channel_binding_id" in update_fields and update_fields["channel_binding_id"]:
         cb_result = await db.execute(
             select(ChannelBindingDB).where(ChannelBindingDB.id == update_fields["channel_binding_id"])
@@ -312,11 +325,28 @@ async def update_scheduled_task(
         cb = cb_result.scalar_one_or_none()
         if not cb:
             raise HTTPException(status_code=400, detail="Channel binding not found")
-        if cb.external_id == "*":
+        if cb.external_id == "*" and not effective_delivery_to:
             raise HTTPException(
                 status_code=400,
-                detail="Global bindings (all groups) cannot be used as scheduled task targets",
+                detail="Global bindings require a delivery_to target chat ID",
             )
+    elif not effective_binding_id and effective_delivery_to:
+        raise HTTPException(
+            status_code=400,
+            detail="delivery_to requires a channel_binding_id",
+        )
+    elif effective_binding_id:
+        # Binding unchanged — but delivery_to may be cleared; validate
+        if "delivery_to" in update_fields:
+            cb_result = await db.execute(
+                select(ChannelBindingDB).where(ChannelBindingDB.id == effective_binding_id)
+            )
+            cb = cb_result.scalar_one_or_none()
+            if cb and cb.external_id == "*" and not effective_delivery_to:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Global bindings require a delivery_to target chat ID",
+                )
 
     for key, value in update_fields.items():
         setattr(task, key, value)

--- a/app/db/database.py
+++ b/app/db/database.py
@@ -341,6 +341,15 @@ async def _run_migrations():
         await conn.execute(text("CREATE INDEX IF NOT EXISTS ix_task_run_logs_task_id ON task_run_logs (task_id)"))
         await conn.execute(text("CREATE INDEX IF NOT EXISTS ix_task_run_logs_started_at ON task_run_logs (started_at)"))
 
+    # Add delivery_to column to scheduled_tasks table
+    async with engine.begin() as conn:
+        await conn.execute(text("""
+            DO $$ BEGIN
+                ALTER TABLE scheduled_tasks ADD COLUMN delivery_to VARCHAR(256) DEFAULT NULL;
+            EXCEPTION WHEN duplicate_column THEN NULL;
+            END $$
+        """))
+
     # Create channel_bindings and channel_messages tables
     async with engine.begin() as conn:
         await conn.execute(text("""

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -602,6 +602,9 @@ class ScheduledTaskDB(Base):
     channel_binding_id: Mapped[Optional[str]] = mapped_column(
         String(36), nullable=True
     )  # Optional: send results to a channel
+    delivery_to: Mapped[Optional[str]] = mapped_column(
+        String(256), nullable=True
+    )  # Explicit target chat_id (overrides binding's external_id)
     status: Mapped[str] = mapped_column(
         String(32), default="active", nullable=False
     )  # active / paused / completed

--- a/app/services/channel_manager.py
+++ b/app/services/channel_manager.py
@@ -596,11 +596,12 @@ IMPORTANT: Use the absolute file paths shown above when reading or processing fi
                 logger.warning(f"Failed to extract file path from {download_url}: {e}")
         return paths
 
-    async def send_to_channel(self, binding_id: str, content: str):
+    async def send_to_channel(self, binding_id: str, content: str, target_override: Optional[str] = None):
         """Send a message to a channel binding (used by scheduler).
 
-        Global bindings (external_id='*') are skipped because there is no
-        specific chat_id to send to.
+        If target_override is provided, it is used as the delivery target
+        instead of the binding's external_id. This allows global bindings
+        (external_id='*') to deliver to a specific chat.
         """
         from sqlalchemy import select
         from app.db.database import AsyncSessionLocal
@@ -615,9 +616,9 @@ IMPORTANT: Use the absolute file paths shown above when reading or processing fi
                 logger.warning(f"Channel binding {binding_id} not found")
                 return
 
-            # Global bindings have no specific target chat_id
-            if binding.external_id == "*":
-                logger.info(f"Skipping scheduled message for global binding {binding_id} (no target chat_id)")
+            target_id = target_override or binding.external_id
+            if target_id == "*":
+                logger.info(f"Skipping scheduled message for binding {binding_id} (no specific target)")
                 return
 
             adapter = self._get_adapter_for_binding(binding)
@@ -627,17 +628,19 @@ IMPORTANT: Use the absolute file paths shown above when reading or processing fi
 
             # Send message
             await adapter.send_message(OutboundMessage(
-                external_id=binding.external_id,
+                external_id=target_id,
                 content=content,
             ))
 
-            # Record outbound
+            # Record outbound (include actual target in metadata when overridden)
+            msg_metadata = {"target_id": target_id} if target_override else None
             msg_record = ChannelMessageDB(
                 id=generate_uuid(),
                 channel_binding_id=binding.id,
                 direction="outbound",
                 content=content,
                 message_type="text",
+                metadata=msg_metadata,
             )
             session.add(msg_record)
             await session.commit()

--- a/app/services/scheduler.py
+++ b/app/services/scheduler.py
@@ -287,7 +287,10 @@ class TaskScheduler:
                     send_loop = asyncio.new_event_loop()
                     try:
                         send_loop.run_until_complete(
-                            manager.send_to_channel(task.channel_binding_id, result.answer)
+                            manager.send_to_channel(
+                                task.channel_binding_id, result.answer,
+                                target_override=task.delivery_to,
+                            )
                         )
                     finally:
                         send_loop.close()

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -219,6 +219,7 @@ def make_scheduled_task(
         schedule_value=schedule_value,
         context_mode=context_mode,
         status=status,
+        delivery_to=kwargs.get("delivery_to"),
         next_run=kwargs.get("next_run"),
         last_run=kwargs.get("last_run"),
         max_runs=kwargs.get("max_runs"),

--- a/tests/test_api/test_scheduler.py
+++ b/tests/test_api/test_scheduler.py
@@ -2,7 +2,7 @@
 import pytest
 import pytest_asyncio
 
-from tests.factories import make_preset, make_scheduled_task, make_task_run_log
+from tests.factories import make_preset, make_scheduled_task, make_task_run_log, make_channel_binding
 
 
 @pytest.mark.asyncio
@@ -194,3 +194,130 @@ class TestSchedulerAPI:
         assert resp.status_code == 201
         assert resp.json()["schedule_type"] == "cron"
         assert resp.json()["next_run"] is not None
+
+    async def test_create_task_with_global_binding_and_delivery_to(self, client, db_session):
+        """Global binding + delivery_to should succeed."""
+        preset = make_preset(name="sched-agent-global-ok")
+        binding = make_channel_binding(
+            name="global-feishu",
+            channel_type="feishu",
+            external_id="*",
+            agent_id=preset.id,
+        )
+        db_session.add(preset)
+        db_session.add(binding)
+        await db_session.commit()
+
+        resp = await client.post("/api/v1/scheduled-tasks", json={
+            "name": "global-task-ok",
+            "agent_id": preset.id,
+            "prompt": "Report",
+            "schedule_type": "interval",
+            "schedule_value": "3600",
+            "channel_binding_id": binding.id,
+            "delivery_to": "oc_target_chat_123",
+        })
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["delivery_to"] == "oc_target_chat_123"
+        assert data["channel_binding_id"] == binding.id
+
+    async def test_create_task_with_global_binding_no_delivery_to_fails(self, client, db_session):
+        """Global binding without delivery_to should fail with 400."""
+        preset = make_preset(name="sched-agent-global-fail")
+        binding = make_channel_binding(
+            name="global-feishu-2",
+            channel_type="feishu",
+            external_id="*",
+            agent_id=preset.id,
+        )
+        db_session.add(preset)
+        db_session.add(binding)
+        await db_session.commit()
+
+        resp = await client.post("/api/v1/scheduled-tasks", json={
+            "name": "global-task-fail",
+            "agent_id": preset.id,
+            "prompt": "Report",
+            "schedule_type": "interval",
+            "schedule_value": "3600",
+            "channel_binding_id": binding.id,
+        })
+        assert resp.status_code == 400
+        assert "delivery_to" in resp.json()["detail"].lower()
+
+    async def test_create_task_with_delivery_to_override(self, client, db_session):
+        """Specific binding + delivery_to override should succeed."""
+        preset = make_preset(name="sched-agent-override")
+        binding = make_channel_binding(
+            name="specific-feishu",
+            channel_type="feishu",
+            external_id="oc_original_chat",
+            agent_id=preset.id,
+        )
+        db_session.add(preset)
+        db_session.add(binding)
+        await db_session.commit()
+
+        resp = await client.post("/api/v1/scheduled-tasks", json={
+            "name": "override-task",
+            "agent_id": preset.id,
+            "prompt": "Report",
+            "schedule_type": "interval",
+            "schedule_value": "3600",
+            "channel_binding_id": binding.id,
+            "delivery_to": "oc_different_chat",
+        })
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["delivery_to"] == "oc_different_chat"
+
+    async def test_update_clear_delivery_to_with_global_binding_fails(self, client, db_session):
+        """Clearing delivery_to on a task with global binding should fail."""
+        preset = make_preset(name="sched-agent-clear-fail")
+        binding = make_channel_binding(
+            name="global-feishu-3",
+            channel_type="feishu",
+            external_id="*",
+            agent_id=preset.id,
+        )
+        db_session.add(preset)
+        db_session.add(binding)
+        await db_session.commit()
+
+        # Create task with global binding + delivery_to
+        create_resp = await client.post("/api/v1/scheduled-tasks", json={
+            "name": "clear-fail-task",
+            "agent_id": preset.id,
+            "prompt": "Report",
+            "schedule_type": "interval",
+            "schedule_value": "3600",
+            "channel_binding_id": binding.id,
+            "delivery_to": "oc_target_123",
+        })
+        assert create_resp.status_code == 201
+        task_id = create_resp.json()["id"]
+
+        # Try to clear delivery_to — should fail
+        resp = await client.put(f"/api/v1/scheduled-tasks/{task_id}", json={
+            "delivery_to": None,
+        })
+        assert resp.status_code == 400
+        assert "delivery_to" in resp.json()["detail"].lower()
+
+    async def test_create_task_delivery_to_without_channel_fails(self, client, db_session):
+        """delivery_to without channel_binding_id should fail with 400."""
+        preset = make_preset(name="sched-agent-no-channel")
+        db_session.add(preset)
+        await db_session.commit()
+
+        resp = await client.post("/api/v1/scheduled-tasks", json={
+            "name": "orphan-delivery",
+            "agent_id": preset.id,
+            "prompt": "Report",
+            "schedule_type": "interval",
+            "schedule_value": "3600",
+            "delivery_to": "oc_some_chat",
+        })
+        assert resp.status_code == 400
+        assert "delivery_to" in resp.json()["detail"].lower()

--- a/web/src/app/scheduled-tasks/[id]/page.tsx
+++ b/web/src/app/scheduled-tasks/[id]/page.tsx
@@ -298,6 +298,16 @@ export default function ScheduledTaskDetailPage() {
                 </div>
               </div>
               <div>
+                <span className="text-sm font-medium text-muted-foreground">{t('fields.deliveryTo')}</span>
+                <p className="mt-1 text-sm">
+                  {task.delivery_to ? (
+                    <code className="bg-muted px-2 py-1 rounded">{task.delivery_to}</code>
+                  ) : (
+                    <span className="text-muted-foreground">-</span>
+                  )}
+                </p>
+              </div>
+              <div>
                 <span className="text-sm font-medium text-muted-foreground">{t('fields.nextRun')}</span>
                 <p className="mt-1 text-sm">{task.next_run ? formatDateTime(task.next_run) : '-'}</p>
               </div>

--- a/web/src/app/scheduled-tasks/new/page.tsx
+++ b/web/src/app/scheduled-tasks/new/page.tsx
@@ -51,9 +51,12 @@ export default function NewScheduledTaskPage() {
   const [contextMode, setContextMode] = useState('isolated');
   const [maxRuns, setMaxRuns] = useState('');
   const [channelBindingId, setChannelBindingId] = useState('');
+  const [deliveryTo, setDeliveryTo] = useState('');
 
   const agents = agentsData?.presets || [];
-  const channels = channelsData?.bindings?.filter((b) => b.enabled && !b.is_global) || [];
+  const channels = channelsData?.bindings?.filter((b) => b.enabled) || [];
+  const selectedChannel = channels.find((ch) => ch.id === channelBindingId);
+  const isGlobalBinding = selectedChannel?.is_global ?? false;
 
   const getPlaceholder = () => {
     switch (scheduleType) {
@@ -76,7 +79,13 @@ export default function NewScheduledTaskPage() {
       return;
     }
 
+    if (isGlobalBinding && !deliveryTo.trim()) {
+      toast.error(t('hints.deliveryToRequired'));
+      return;
+    }
+
     try {
+      const hasChannel = channelBindingId && channelBindingId !== 'none';
       await createTask.mutateAsync({
         name: name.trim(),
         agent_id: agentId,
@@ -85,7 +94,8 @@ export default function NewScheduledTaskPage() {
         schedule_value: scheduleValue.trim(),
         context_mode: contextMode,
         max_runs: maxRuns ? parseInt(maxRuns, 10) : null,
-        channel_binding_id: channelBindingId && channelBindingId !== 'none' ? channelBindingId : null,
+        channel_binding_id: hasChannel ? channelBindingId : null,
+        delivery_to: hasChannel && deliveryTo.trim() ? deliveryTo.trim() : null,
       });
       toast.success(t('messages.created'));
       router.push('/scheduled-tasks');
@@ -236,7 +246,7 @@ export default function NewScheduledTaskPage() {
                     <span className="text-sm text-muted-foreground">{tc('status.loading')}</span>
                   </div>
                 ) : (
-                  <Select value={channelBindingId} onValueChange={setChannelBindingId}>
+                  <Select value={channelBindingId} onValueChange={(v) => { setChannelBindingId(v); setDeliveryTo(''); }}>
                     <SelectTrigger id="channel-binding">
                       <SelectValue placeholder={t('fields.noChannel')} />
                     </SelectTrigger>
@@ -244,7 +254,7 @@ export default function NewScheduledTaskPage() {
                       <SelectItem value="none">{t('fields.noChannel')}</SelectItem>
                       {channels.map((ch) => (
                         <SelectItem key={ch.id} value={ch.id}>
-                          [{ch.channel_type}] {ch.name}
+                          [{ch.channel_type}] {ch.name}{ch.is_global ? ` ${t('fields.allGroups')}` : ''}
                         </SelectItem>
                       ))}
                     </SelectContent>
@@ -252,6 +262,30 @@ export default function NewScheduledTaskPage() {
                 )}
                 <p className="text-xs text-muted-foreground">{t('hints.channelBinding')}</p>
               </div>
+
+              {/* Delivery To (visible when channel selected) */}
+              {channelBindingId && channelBindingId !== 'none' && (
+                <div className="space-y-2">
+                  <Label htmlFor="delivery-to">
+                    {t('fields.deliveryTo')}
+                    {isGlobalBinding ? (
+                      <span className="text-destructive text-xs ml-1">*</span>
+                    ) : (
+                      <span className="text-muted-foreground text-xs ml-1">({tc('status.optional')})</span>
+                    )}
+                  </Label>
+                  <Input
+                    id="delivery-to"
+                    value={deliveryTo}
+                    onChange={(e) => setDeliveryTo(e.target.value)}
+                    placeholder={t('placeholders.deliveryTo')}
+                    required={isGlobalBinding}
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    {isGlobalBinding ? t('hints.deliveryToRequired') : t('hints.deliveryTo')}
+                  </p>
+                </div>
+              )}
 
               {/* Submit */}
               <div className="flex justify-end gap-3">

--- a/web/src/i18n/locales/en-US/scheduled-tasks.json
+++ b/web/src/i18n/locales/en-US/scheduled-tasks.json
@@ -17,10 +17,14 @@
     "lastRun": "Last Run",
     "runCount": "Run Count",
     "channelBinding": "Deliver To Channel",
-    "noChannel": "None (no delivery)"
+    "noChannel": "None (no delivery)",
+    "deliveryTo": "Target Chat ID",
+    "allGroups": "(all groups)"
   },
   "hints": {
-    "channelBinding": "Optionally send task results to a channel binding"
+    "channelBinding": "Optionally send task results to a channel binding",
+    "deliveryTo": "Specify the target chat/group ID for delivery",
+    "deliveryToRequired": "Required for all-groups bindings"
   },
   "scheduleTypes": {
     "cron": "Cron",
@@ -66,6 +70,7 @@
   "placeholders": {
     "cronValue": "0 */6 * * * (every 6 hours)",
     "intervalValue": "3600 (seconds)",
-    "onceValue": "2026-03-01T00:00:00"
+    "onceValue": "2026-03-01T00:00:00",
+    "deliveryTo": "oc_xxxxxxxxxxxx"
   }
 }

--- a/web/src/i18n/locales/es/scheduled-tasks.json
+++ b/web/src/i18n/locales/es/scheduled-tasks.json
@@ -17,10 +17,14 @@
     "lastRun": "Última Ejecución",
     "runCount": "Cantidad de Ejecuciones",
     "channelBinding": "Entregar al Canal",
-    "noChannel": "Ninguno (sin entrega)"
+    "noChannel": "Ninguno (sin entrega)",
+    "deliveryTo": "ID del Chat Destino",
+    "allGroups": "(todos los grupos)"
   },
   "hints": {
-    "channelBinding": "Opcional: enviar los resultados de la tarea a un canal vinculado"
+    "channelBinding": "Opcional: enviar los resultados de la tarea a un canal vinculado",
+    "deliveryTo": "Especifica el ID del chat/grupo de destino para la entrega",
+    "deliveryToRequired": "Requerido para vinculaciones de todos los grupos"
   },
   "scheduleTypes": {
     "cron": "Cron",
@@ -66,6 +70,7 @@
   "placeholders": {
     "cronValue": "0 */6 * * * (cada 6 horas)",
     "intervalValue": "3600 (segundos)",
-    "onceValue": "2026-03-01T00:00:00"
+    "onceValue": "2026-03-01T00:00:00",
+    "deliveryTo": "oc_xxxxxxxxxxxx"
   }
 }

--- a/web/src/i18n/locales/ja/scheduled-tasks.json
+++ b/web/src/i18n/locales/ja/scheduled-tasks.json
@@ -17,10 +17,14 @@
     "lastRun": "前回実行",
     "runCount": "実行回数",
     "channelBinding": "チャンネルに配信",
-    "noChannel": "なし（配信しない）"
+    "noChannel": "なし（配信しない）",
+    "deliveryTo": "ターゲットチャットID",
+    "allGroups": "（全グループ）"
   },
   "hints": {
-    "channelBinding": "オプション：タスク結果を指定のチャンネルバインディングに送信"
+    "channelBinding": "オプション：タスク結果を指定のチャンネルバインディングに送信",
+    "deliveryTo": "配信先のチャット/グループIDを指定",
+    "deliveryToRequired": "全グループバインディングには必須です"
   },
   "scheduleTypes": {
     "cron": "Cron",
@@ -66,6 +70,7 @@
   "placeholders": {
     "cronValue": "0 */6 * * *（6時間ごと）",
     "intervalValue": "3600（秒）",
-    "onceValue": "2026-03-01T00:00:00"
+    "onceValue": "2026-03-01T00:00:00",
+    "deliveryTo": "oc_xxxxxxxxxxxx"
   }
 }

--- a/web/src/i18n/locales/pt-BR/scheduled-tasks.json
+++ b/web/src/i18n/locales/pt-BR/scheduled-tasks.json
@@ -17,10 +17,14 @@
     "lastRun": "Última Execução",
     "runCount": "Contagem de Execuções",
     "channelBinding": "Entregar ao Canal",
-    "noChannel": "Nenhum (sem entrega)"
+    "noChannel": "Nenhum (sem entrega)",
+    "deliveryTo": "ID do Chat Destino",
+    "allGroups": "(todos os grupos)"
   },
   "hints": {
-    "channelBinding": "Opcional: enviar os resultados da tarefa para um canal vinculado"
+    "channelBinding": "Opcional: enviar os resultados da tarefa para um canal vinculado",
+    "deliveryTo": "Especifique o ID do chat/grupo de destino para entrega",
+    "deliveryToRequired": "Obrigatório para vinculações de todos os grupos"
   },
   "scheduleTypes": {
     "cron": "Cron",
@@ -66,6 +70,7 @@
   "placeholders": {
     "cronValue": "0 */6 * * * (a cada 6 horas)",
     "intervalValue": "3600 (segundos)",
-    "onceValue": "2026-03-01T00:00:00"
+    "onceValue": "2026-03-01T00:00:00",
+    "deliveryTo": "oc_xxxxxxxxxxxx"
   }
 }

--- a/web/src/i18n/locales/zh-CN/scheduled-tasks.json
+++ b/web/src/i18n/locales/zh-CN/scheduled-tasks.json
@@ -17,10 +17,14 @@
     "lastRun": "上次运行",
     "runCount": "运行次数",
     "channelBinding": "投递到渠道",
-    "noChannel": "无（不投递）"
+    "noChannel": "无（不投递）",
+    "deliveryTo": "目标会话 ID",
+    "allGroups": "（所有群）"
   },
   "hints": {
-    "channelBinding": "可选：将任务结果发送到指定的渠道绑定"
+    "channelBinding": "可选：将任务结果发送到指定的渠道绑定",
+    "deliveryTo": "指定投递目标的会话/群组 ID",
+    "deliveryToRequired": "全群绑定必须指定目标会话"
   },
   "scheduleTypes": {
     "cron": "Cron 表达式",
@@ -66,6 +70,7 @@
   "placeholders": {
     "cronValue": "0 */6 * * *（每6小时）",
     "intervalValue": "3600（秒）",
-    "onceValue": "2026-03-01T00:00:00"
+    "onceValue": "2026-03-01T00:00:00",
+    "deliveryTo": "oc_xxxxxxxxxxxx"
   }
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -2225,6 +2225,7 @@ export interface ScheduledTask {
   session_id: string | null;
   channel_binding_id: string | null;
   channel_binding_name: string | null;
+  delivery_to: string | null;
   status: string;
   next_run: string | null;
   last_run: string | null;
@@ -2243,6 +2244,7 @@ export interface ScheduledTaskCreateRequest {
   context_mode?: string;
   max_runs?: number | null;
   channel_binding_id?: string | null;
+  delivery_to?: string | null;
 }
 
 export interface ScheduledTaskUpdateRequest {
@@ -2253,6 +2255,7 @@ export interface ScheduledTaskUpdateRequest {
   context_mode?: string;
   max_runs?: number | null;
   channel_binding_id?: string | null;
+  delivery_to?: string | null;
 }
 
 export interface TaskRunLog {


### PR DESCRIPTION
## Summary
- Add `delivery_to` field to scheduled tasks, separating credential source (channel binding) from delivery target
- Global bindings (`external_id="*"`) can now be used for scheduled delivery when a target chat ID is provided
- Specific bindings can optionally use `delivery_to` to override the default target

## Changes
- **DB**: Add `delivery_to` column to `scheduled_tasks` table with safe idempotent migration
- **API**: Add `delivery_to` to create/update/response schemas; validate global binding + delivery_to combination; reject orphaned `delivery_to` without `channel_binding_id`
- **Services**: Pass `target_override` through scheduler → channel manager; store actual `target_id` in outbound message metadata for audit trail
- **Frontend**: Show global bindings in channel dropdown with "(all groups)" suffix; conditional delivery_to input (required for global, optional for specific)
- **i18n**: Add keys to all 5 languages (en-US, zh-CN, ja, es, pt-BR)
- **Tests**: 5 new test cases (17 total, all pass)

## Test plan
- [ ] `pytest tests/test_api/test_scheduler.py -v` — all 17 tests pass
- [ ] Visit `/scheduled-tasks/new` — global bindings appear in dropdown with "(all groups)" suffix
- [ ] Select global binding → delivery_to input shows as required
- [ ] Select specific binding → delivery_to input shows as optional
- [ ] Create task with global binding + delivery_to → succeeds
- [ ] Create task with global binding, no delivery_to → fails with 400
- [ ] Create task with delivery_to but no channel binding → fails with 400
- [ ] Task detail page shows delivery_to value

Closes #224