### PR TITLE
Fix Feishu attachments inaccessible to executor containers

### DIFF
--- a/app/channels/feishu.py
+++ b/app/channels/feishu.py
@@ -21,6 +21,7 @@ import asyncio
 import json
 import logging
 import mimetypes
+import re
 from collections import OrderedDict
 from pathlib import Path
 from typing import Optional
@@ -381,7 +382,8 @@ class FeishuAdapter(ChannelAdapter):
             if not response.success():
                 logger.error(f"Download file failed: code={response.code} msg={response.msg}")
                 return None
-            filepath = MEDIA_DIR / f"{file_key}_{filename}"
+            safe_name = re.sub(r'[^\w.\-]', '_', filename)
+            filepath = MEDIA_DIR / f"{file_key}_{safe_name}"
             filepath.write_bytes(response.file.read())
             return filepath
         except Exception as e:

--- a/app/services/channel_manager.py
+++ b/app/services/channel_manager.py
@@ -14,6 +14,7 @@ import hashlib
 import logging
 import mimetypes
 import re
+import shutil
 import time
 from datetime import datetime
 from pathlib import Path
@@ -22,6 +23,7 @@ from typing import Optional
 from urllib.parse import parse_qs, urlparse
 
 from app.channels.base import ChannelAdapter, InboundMessage, OutboundMessage
+from app.tools.code_executor import WORKSPACES_BASE_DIR
 
 logger = logging.getLogger(__name__)
 
@@ -398,6 +400,30 @@ class ChannelManager:
                 binding_channel_type = binding.channel_type
 
                 await session.commit()
+
+            # Move media files into the shared workspace so executor
+            # containers can access them (api and executor share the
+            # workspaces volume, but /tmp is container-local).
+            # NOTE: src.name already includes the file_key prefix
+            # (e.g. "filekey_report.pdf") set by the channel adapter,
+            # so collisions across different uploads are not expected.
+            if msg.media:
+                ws_dir = WORKSPACES_BASE_DIR / session_id
+                ws_dir.mkdir(parents=True, exist_ok=True)
+                new_paths = []
+                for p in msg.media:
+                    src = Path(p)
+                    if src.exists():
+                        dst = ws_dir / src.name
+                        try:
+                            shutil.move(str(src), str(dst))
+                            new_paths.append(str(dst))
+                        except OSError as e:
+                            logger.warning(f"Failed to move media file {src} -> {dst}: {e}")
+                            new_paths.append(p)
+                    else:
+                        new_paths.append(p)
+                msg.media = new_paths
 
             # Build image_contents and augment prompt for media files
             image_contents = None


### PR DESCRIPTION
## Summary

- Move Feishu-downloaded media files from `/tmp/feishu_media/` (container-local) to `/app/workspaces/{session_id}/` (shared volume) before agent execution
- Sanitize filenames to replace spaces and shell-special characters with underscores

## Root Cause

The Feishu adapter downloads files to `/tmp/feishu_media/` in the API container, but `bash`/`execute_code` tools run in executor containers where `/tmp` is isolated. Only the `workspaces` volume is shared across containers.

## Test plan

- [ ] Send a file attachment (PDF/DOCX) via Feishu bot and verify the agent can read it with all tools (bash, execute_code, read)
- [ ] Send a file with spaces in the filename and verify it is accessible
- [ ] Verify image uploads still work correctly (base64 vision path)

Closes #226