### PR TITLE
Stop injecting daily memory logs into system prompt

### DIFF
--- a/app/agent/agent.py
+++ b/app/agent/agent.py
@@ -767,6 +767,8 @@ class SkillsAgent:
                     "\nBefore answering anything about prior work, decisions, dates, "
                     "people, preferences, or todos: run memory_search on MEMORY.md + "
                     "memory/*.md; then use memory_get to pull only the needed lines. "
+                    "Note: memory/*.md daily logs are not included in this prompt — "
+                    "use memory_get to read them on demand. "
                     "If low confidence after search, say you checked."
                     "\nCitations: include Source: <path#line> when it helps the user "
                     "verify memory snippets."

--- a/app/services/memory_service.py
+++ b/app/services/memory_service.py
@@ -12,7 +12,7 @@ import asyncio
 import json
 import logging
 import uuid
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -197,25 +197,6 @@ def load_bootstrap_files(agent_id: Optional[str] = None) -> Dict[str, str]:
             result[filename] = content
             total_chars += len(content)
 
-    # Load recent daily memory logs (today + yesterday)
-    if agent_id:
-        memory_log_dir = base / "agents" / agent_id / "memory"
-        if memory_log_dir.exists():
-            today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-            yesterday = (datetime.now(timezone.utc) - timedelta(days=1)).strftime("%Y-%m-%d")
-            for date_str in [yesterday, today]:
-                log_path = memory_log_dir / f"{date_str}.md"
-                if log_path.exists():
-                    try:
-                        content = log_path.read_text(encoding="utf-8")
-                    except Exception:
-                        continue
-                    log_filename = f"memory/{date_str}.md"
-                    content = _truncate_content(content, PER_FILE_CHAR_LIMIT, log_filename)
-                    if total_chars + len(content) <= TOTAL_CHAR_LIMIT:
-                        result[log_filename] = content
-                        total_chars += len(content)
-
     return result
 
 
@@ -243,6 +224,8 @@ def read_memory_file(agent_id: str, rel_path: str, from_line: int = 1, lines: in
     """Read a memory file by relative path, with optional line range.
 
     Returns None if path traversal is detected or file doesn't exist.
+    No truncation — aligns with OpenClaw which returns full content;
+    callers use from_line/lines for partial reads.
     """
     base = _memory_dir() / "agents" / agent_id
     resolved = (base / rel_path).resolve()

--- a/docs/docs/concepts/memory.md
+++ b/docs/docs/concepts/memory.md
@@ -1,0 +1,314 @@
+---
+sidebar_position: 2
+---
+
+# Agent Memory
+
+Agent memory gives agents the ability to remember information across sessions. Without memory, agents forget everything when context is compressed or a conversation ends. The memory system has two layers: **file-based bootstrap memory** loaded into every session, and **DB-backed memory entries** searchable via vector similarity.
+
+## Architecture Overview
+
+```
+                          System Prompt
+                              │
+                    ┌─────────┴──────────┐
+                    │  ## Agent Memory    │
+                    │  ┌───────────────┐  │
+                    │  │ SOUL.md       │  │  ← persona, tone
+                    │  │ USER.md       │  │  ← user preferences
+                    │  │ MEMORY.md     │  │  ← curated facts
+                    │  │ memory/*.md   │  │  ← daily logs
+                    │  └───────────────┘  │
+                    │  ### Memory Recall  │  ← search directive
+                    └────────────────────┘
+                              │
+              ┌───────────────┼───────────────┐
+              │               │               │
+         Normal Turn    Memory Tools     Flush Turn
+         (read-only)    (runtime CRUD)   (pre-compression)
+              │               │               │
+              │          ┌────┴────┐     ┌────┴────┐
+              │          │ search  │     │ read    │
+              │          │ save    │     │ write   │
+              │          │ get     │     │ (scoped)│
+              │          └────┬────┘     └────┬────┘
+              │               │               │
+              │          PostgreSQL       Filesystem
+              │          + pgvector      agents/{id}/
+              │               │               │
+              └───────────────┴───────────────┘
+```
+
+## File-Based Memory (Bootstrap Files)
+
+Bootstrap files are markdown files loaded into the system prompt at the start of every agent session. They provide persistent context that the agent always has access to.
+
+### Files
+
+| File | Purpose | Example Content |
+|------|---------|-----------------|
+| `SOUL.md` | Agent persona, tone, behavior | "You are a senior staff engineer. Be direct and concise." |
+| `USER.md` | User preferences and habits | "User prefers dark mode, Python, and code over prose." |
+| `MEMORY.md` | Curated long-term facts | "Project migrated from REST to gRPC on March 10." |
+| `memory/YYYY-MM-DD.md` | Daily session logs | Progress notes, decisions, TODOs from each day |
+
+### Directory Structure
+
+```
+memory/
+├── global/              # Shared across all agents
+│   ├── SOUL.md
+│   ├── USER.md
+│   └── MEMORY.md
+└── agents/
+    └── {agent-id}/      # Per-agent (overrides global)
+        ├── SOUL.md
+        ├── USER.md
+        ├── MEMORY.md
+        └── memory/
+            ├── 2026-03-01.md
+            └── 2026-03-02.md
+```
+
+**Override logic:** Per-agent files take precedence over global files of the same name. If an agent has its own `SOUL.md`, the global `SOUL.md` is ignored for that agent.
+
+### Truncation
+
+Large files are truncated to prevent system prompt bloat:
+
+| Limit | Value |
+|-------|-------|
+| Per-file limit | 20,000 chars |
+| Total limit (all files) | 60,000 chars |
+| Head ratio | 70% (kept from start) |
+| Tail ratio | 20% (kept from end) |
+
+When a file exceeds its limit, it's split into head + truncation marker + tail:
+
+```
+[first 70% of content]
+…(truncated MEMORY.md: kept 14000+4000 of 25000 chars)…
+[last 20% of content]
+```
+
+### Daily Log Loading
+
+At session start, the two most recent daily logs are loaded automatically:
+- `memory/YYYY-MM-DD.md` (today, UTC)
+- `memory/YYYY-MM-DD.md` (yesterday, UTC)
+
+This provides continuity between sessions without unbounded growth.
+
+## System Prompt Injection
+
+Bootstrap files are injected into the system prompt via `_build_memory_section()`. The resulting section looks like:
+
+```markdown
+## Agent Memory
+
+If SOUL.md is present, embody its persona and tone. Avoid stiff,
+generic replies; follow its guidance unless higher-priority
+instructions override it.
+
+### SOUL.md
+[file content]
+
+### USER.md
+[file content]
+
+### MEMORY.md
+[file content]
+
+### memory/2026-03-02.md
+[file content]
+
+### Memory Recall
+Before answering anything about prior work, decisions, dates,
+people, preferences, or todos: run memory_search on MEMORY.md +
+memory/*.md; then use memory_get to pull only the needed lines.
+If low confidence after search, say you checked.
+
+Citations: include Source: <path#line> when it helps the user
+verify memory snippets.
+```
+
+The SOUL.md persona instruction only appears when SOUL.md exists. The Memory Recall directive only appears when the agent has an `agent_id` (memory tools available).
+
+## Memory Flush (Autonomous Persistence)
+
+The memory flush is a **silent, fire-and-forget agent turn** that runs before context compression. It gives the LLM scoped read/write tools to persist important information from the conversation to memory files.
+
+### When It Triggers
+
+The flush fires when context compression is needed — i.e., when input tokens exceed 70% of the model's context window limit. Only agents with an `agent_id` get memory flush.
+
+### How It Works
+
+```
+1. Compression threshold reached
+2. Snapshot last 20 messages at call site
+3. asyncio.create_task() → fire-and-forget
+4. Compression proceeds concurrently
+5. Flush LLM decides what to remember
+6. Writes to SOUL.md / USER.md / MEMORY.md / memory/*.md
+7. NO_REPLY if nothing to store
+```
+
+### Flush Prompts
+
+**System prompt** (appended to agent's own system prompt):
+
+> Pre-compaction memory flush turn. The session is near auto-compaction; capture durable memories to disk. You may reply, but usually NO_REPLY is correct.
+
+**User prompt** (with placeholders filled):
+
+> Pre-compaction memory flush. Store durable memories now:
+> - SOUL.md for persona, tone, and behavior instructions
+> - USER.md for user preferences, habits, and background
+> - MEMORY.md for curated long-term facts worth remembering
+> - memory/{date}.md for session-specific progress and decisions
+>
+> Create memory/ directory if needed. IMPORTANT: If a file already exists, READ it first, then WRITE with new content appended — do not overwrite existing entries. If nothing to store, reply with NO_REPLY.
+>
+> Existing files:
+> {list of files with sizes}
+>
+> Current time: 2026-03-02 14:30:00 UTC
+
+### Scoped Tools
+
+The flush turn gets **only two tools** — dedicated read/write schemas restricted to the agent's memory directory:
+
+| Tool | Input | Returns |
+|------|-------|---------|
+| `read` | `file_path` (relative, e.g. `SOUL.md`) | `{"content": "..."}` or `{"error": "..."}` |
+| `write` | `file_path`, `content` | `{"success": true, "path": "..."}` or `{"error": "..."}` |
+
+Path traversal is blocked — any path resolving outside the agent's memory directory returns an access denied error.
+
+### Constraints
+
+| Parameter | Value |
+|-----------|-------|
+| Max turns | 3 |
+| Messages passed | Last 20 (sliced at call site to avoid exceeding context) |
+| Execution | Fire-and-forget (`asyncio.create_task`) |
+| Error handling | Logged but non-fatal |
+| NO_REPLY detection | Exact match: `^\s*NO_REPLY\s*$` |
+
+## DB-Backed Memory Entries
+
+For structured, searchable memory, entries are stored in PostgreSQL with pgvector embeddings.
+
+### Schema
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | UUID | Primary key |
+| `agent_id` | UUID (nullable) | `NULL` = global memory |
+| `content` | TEXT | Memory text (max 4096 chars) |
+| `category` | VARCHAR | `fact`, `preference`, `procedure`, `context`, `session_summary` |
+| `source` | VARCHAR | `manual`, `auto_flush`, `agent_tool`, `session_end` |
+| `embedding` | vector(1536) | pgvector embedding for semantic search |
+| `embedding_model` | VARCHAR | e.g. `text-embedding-3-small` |
+| `session_id` | UUID (nullable) | Optional session association |
+| `created_at` | TIMESTAMP(TZ) | UTC |
+| `updated_at` | TIMESTAMP(TZ) | UTC |
+
+### Search
+
+Two search modes with automatic fallback:
+
+1. **Vector search** (when embedding API key is configured):
+   - Query is embedded via OpenAI `text-embedding-3-small`
+   - Cosine similarity via pgvector `<=>` operator
+   - Returns results ranked by similarity (0–1)
+
+2. **Keyword fallback** (when no embedding API key):
+   - Case-insensitive `ILIKE` search
+   - Ordered by `created_at DESC`
+
+## Memory Tools (Runtime)
+
+During normal conversation, agents with an `agent_id` get three memory tools:
+
+### memory_search
+
+Search memory entries by semantic similarity.
+
+```json
+{
+  "query": "What date did we start the gRPC migration?",
+  "top_k": 5
+}
+```
+
+Returns matching entries with similarity scores.
+
+### memory_save
+
+Save new information to long-term memory.
+
+```json
+{
+  "content": "User prefers FastAPI over Flask for all new projects.",
+  "category": "preference"
+}
+```
+
+Categories: `fact`, `preference`, `procedure`, `context`.
+
+### memory_get
+
+Read a memory file by relative path, optionally with line range.
+
+```json
+{
+  "path": "memory/2026-03-02.md",
+  "from_line": 10,
+  "lines": 20
+}
+```
+
+Returns file content or error if not found.
+
+## API Endpoints
+
+### Bootstrap Files
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/memory/files?agent_id={id}` | List files with metadata |
+| `GET` | `/memory/files/{scope}/{filename}` | Read file content |
+| `PUT` | `/memory/files/{scope}/{filename}` | Write file content |
+| `DELETE` | `/memory/files/{scope}/{filename}` | Delete file |
+
+`scope` is either `"global"` or an agent UUID. `filename` is one of `SOUL.md`, `USER.md`, `MEMORY.md`.
+
+### Memory Entries
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/memory/entries?agent_id={id}&category={cat}&limit=50` | List entries |
+| `POST` | `/memory/entries` | Create entry |
+| `PUT` | `/memory/entries/{entry_id}` | Update entry |
+| `DELETE` | `/memory/entries/{entry_id}` | Delete entry |
+| `POST` | `/memory/search` | Semantic search |
+
+## Frontend
+
+The Memory tab on the agent detail page provides two sections:
+
+### Bootstrap File Editor
+
+- Tab interface for SOUL.md / USER.md / MEMORY.md
+- Scope toggle: Global vs Agent-specific
+- Monospace editor with save/delete actions
+- Dirty state indicator
+
+### Memory Entries List
+
+- Search bar with semantic search
+- Category badges (color-coded)
+- Similarity score display (when searching)
+- Add/delete entries with confirmation dialogs

--- a/docs/docs/concepts/memory.md
+++ b/docs/docs/concepts/memory.md
@@ -17,7 +17,8 @@ Agent memory gives agents the ability to remember information across sessions. W
                     │  │ SOUL.md       │  │  ← persona, tone
                     │  │ USER.md       │  │  ← user preferences
                     │  │ MEMORY.md     │  │  ← curated facts
-                    │  │ memory/*.md   │  │  ← daily logs
+                    │  │               │  │     (daily logs accessed
+                    │  │               │  │      via memory_get tool)
                     │  └───────────────┘  │
                     │  ### Memory Recall  │  ← search directive
                     └────────────────────┘
@@ -91,13 +92,9 @@ When a file exceeds its limit, it's split into head + truncation marker + tail:
 [last 20% of content]
 ```
 
-### Daily Log Loading
+### Daily Logs
 
-At session start, the two most recent daily logs are loaded automatically:
-- `memory/YYYY-MM-DD.md` (today, UTC)
-- `memory/YYYY-MM-DD.md` (yesterday, UTC)
-
-This provides continuity between sessions without unbounded growth.
+Daily log files (`memory/YYYY-MM-DD.md`) are **not** injected into the system prompt. They remain on disk and are accessible at runtime via the `memory_get` tool. This matches OpenClaw's approach — only `SOUL.md`, `USER.md`, and `MEMORY.md` are loaded into the prompt.
 
 ## System Prompt Injection
 
@@ -119,14 +116,13 @@ instructions override it.
 ### MEMORY.md
 [file content]
 
-### memory/2026-03-02.md
-[file content]
-
 ### Memory Recall
 Before answering anything about prior work, decisions, dates,
 people, preferences, or todos: run memory_search on MEMORY.md +
 memory/*.md; then use memory_get to pull only the needed lines.
-If low confidence after search, say you checked.
+Note: memory/*.md daily logs are not included in this prompt —
+use memory_get to read them on demand. If low confidence after
+search, say you checked.
 
 Citations: include Source: <path#line> when it helps the user
 verify memory snippets.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -10,6 +10,7 @@ const sidebars: SidebarsConfig = {
       label: 'Concepts',
       items: [
         'concepts/agents',
+        'concepts/memory',
         'concepts/skills',
         'concepts/executors',
         'concepts/tools',

--- a/tests/test_e2e/test_memory_bootstrap_real.py
+++ b/tests/test_e2e/test_memory_bootstrap_real.py
@@ -1,0 +1,316 @@
+"""
+Real E2E test: verify all 4 memory file types are properly utilized.
+
+- SOUL.md, USER.md, MEMORY.md → injected into system prompt
+- memory/*.md (daily logs) → NOT injected, accessed via memory_get tool
+
+Usage:
+    MOONSHOT_API_KEY=sk-xxx OPENAI_API_KEY=sk-xxx \
+    python -m pytest tests/test_e2e/test_memory_bootstrap_real.py -v -s
+"""
+
+import os
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from tests.test_e2e.conftest import parse_sse_events
+
+MOONSHOT_KEY = os.environ.get("MOONSHOT_API_KEY", "")
+pytestmark = pytest.mark.skipif(
+    not MOONSHOT_KEY, reason="MOONSHOT_API_KEY not set"
+)
+
+
+def _patch_api_key():
+    return patch.dict(os.environ, {"MOONSHOT_API_KEY": MOONSHOT_KEY})
+
+
+@pytest.mark.e2e_llm
+@pytest.mark.asyncio(loop_scope="class")
+class TestMemoryFileUtilization:
+    """Verify all 4 memory file types are correctly utilized by a real agent."""
+
+    _state: dict = {}
+
+    # ── Test 1: Create preset and setup memory files ─────────
+
+    async def test_01_setup(self, e2e_client, tmp_path_factory):
+        """Create an agent preset and populate all 4 memory file types."""
+        # Create preset in DB
+        resp = await e2e_client.post(
+            "/api/v1/agents",
+            json={
+                "name": f"memory-e2e-{uuid.uuid4().hex[:8]}",
+                "description": "E2E memory file test agent",
+                "skill_ids": [],
+                "mcp_servers": [],
+                "max_turns": 5,
+                "model_provider": "kimi",
+                "model_name": "kimi-k2.5",
+            },
+        )
+        assert resp.status_code == 200
+        preset = resp.json()
+        agent_id = preset["id"]
+        type(self)._state["agent_id"] = agent_id
+        type(self)._state["preset_id"] = agent_id
+        print(f"\n[Setup] Created preset: {agent_id}")
+
+        # Create memory root and files
+        root = tmp_path_factory.mktemp("memory")
+        type(self)._state["memory_root"] = root
+
+        agent_dir = root / "agents" / agent_id
+        agent_dir.mkdir(parents=True)
+
+        # 1) SOUL.md — distinctive persona
+        (agent_dir / "SOUL.md").write_text(
+            "You are Captain Cosmos, a space explorer. "
+            "Always start your reply with 'Greetings, Earthling!' "
+            "and refer to yourself as Captain Cosmos.",
+            encoding="utf-8",
+        )
+
+        # 2) USER.md — user preferences
+        (agent_dir / "USER.md").write_text(
+            "User's name is Zephyr. Zephyr prefers bullet-point answers "
+            "and dislikes long paragraphs. Zephyr's favorite language is Rust.",
+            encoding="utf-8",
+        )
+
+        # 3) MEMORY.md — curated facts
+        (agent_dir / "MEMORY.md").write_text(
+            "- Project Starlight launched on 2026-02-14\n"
+            "- The database was migrated from MySQL to CockroachDB on 2026-02-20\n"
+            "- Sprint velocity is 42 story points per week\n",
+            encoding="utf-8",
+        )
+
+        # 4) memory/YYYY-MM-DD.md — daily log (should NOT be in prompt)
+        daily_dir = agent_dir / "memory"
+        daily_dir.mkdir()
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        type(self)._state["today"] = today
+        (daily_dir / f"{today}.md").write_text(
+            "## Daily Log\n"
+            "- Fixed bug #789 in the warp drive module\n"
+            "- Deployed v3.2.1 to staging\n"
+            "- TODO: review PR #42 from Lieutenant Nova\n",
+            encoding="utf-8",
+        )
+
+        print(f"[Setup] Memory files created at {agent_dir}")
+        for f in sorted(agent_dir.rglob("*.md")):
+            print(f"  - {f.relative_to(agent_dir)}")
+
+    # ── Test 2: SOUL.md persona is active ─────────────────────
+
+    async def test_02_soul_md_persona(self, e2e_client, e2e_session_factories):
+        """Agent should adopt the Captain Cosmos persona from SOUL.md."""
+        agent_id = type(self)._state["agent_id"]
+        root = type(self)._state["memory_root"]
+
+        with (
+            _patch_api_key(),
+            patch("app.services.memory_service._memory_dir", return_value=root),
+            patch("app.api.v1.sessions.AsyncSessionLocal", e2e_session_factories["async"]),
+        ):
+            resp = await e2e_client.post(
+                "/api/v1/agent/run",
+                json={
+                    "request": "Introduce yourself in one sentence.",
+                    "agent_id": agent_id,
+                    "max_turns": 1,
+                    "model_provider": "kimi",
+                    "model_name": "kimi-k2.5",
+                    "session_id": uuid.uuid4().hex[:32],
+                },
+                timeout=60,
+            )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["success"] is True
+        answer = body.get("answer", "")
+        print(f"\n[SOUL.md] Answer:\n{answer}")
+
+        answer_lower = answer.lower()
+        assert any(w in answer_lower for w in ("captain cosmos", "earthling", "cosmos", "space")), (
+            f"SOUL.md persona not reflected in: {answer[:200]}"
+        )
+
+    # ── Test 3: USER.md preferences recognized ───────────────
+
+    async def test_03_user_md_preferences(self, e2e_client, e2e_session_factories):
+        """Agent should know user's name and preferences from USER.md."""
+        agent_id = type(self)._state["agent_id"]
+        root = type(self)._state["memory_root"]
+
+        with (
+            _patch_api_key(),
+            patch("app.services.memory_service._memory_dir", return_value=root),
+            patch("app.api.v1.sessions.AsyncSessionLocal", e2e_session_factories["async"]),
+        ):
+            resp = await e2e_client.post(
+                "/api/v1/agent/run",
+                json={
+                    "request": "What is my name and what programming language do I prefer?",
+                    "agent_id": agent_id,
+                    "max_turns": 1,
+                    "model_provider": "kimi",
+                    "model_name": "kimi-k2.5",
+                    "session_id": uuid.uuid4().hex[:32],
+                },
+                timeout=60,
+            )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["success"] is True
+        answer = body.get("answer", "")
+        print(f"\n[USER.md] Answer:\n{answer}")
+
+        answer_lower = answer.lower()
+        assert "zephyr" in answer_lower, f"User name not recognized: {answer[:200]}"
+        assert "rust" in answer_lower, f"Language preference not recognized: {answer[:200]}"
+
+    # ── Test 4: MEMORY.md facts available ─────────────────────
+
+    async def test_04_memory_md_facts(self, e2e_client, e2e_session_factories):
+        """Agent should know facts from MEMORY.md."""
+        agent_id = type(self)._state["agent_id"]
+        root = type(self)._state["memory_root"]
+
+        with (
+            _patch_api_key(),
+            patch("app.services.memory_service._memory_dir", return_value=root),
+            patch("app.api.v1.sessions.AsyncSessionLocal", e2e_session_factories["async"]),
+        ):
+            resp = await e2e_client.post(
+                "/api/v1/agent/run",
+                json={
+                    "request": (
+                        "When did Project Starlight launch and "
+                        "what database did we migrate to?"
+                    ),
+                    "agent_id": agent_id,
+                    "max_turns": 1,
+                    "model_provider": "kimi",
+                    "model_name": "kimi-k2.5",
+                    "session_id": uuid.uuid4().hex[:32],
+                },
+                timeout=60,
+            )
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["success"] is True
+        answer = body.get("answer", "")
+        print(f"\n[MEMORY.md] Answer:\n{answer}")
+
+        answer_lower = answer.lower()
+        assert any(d in answer_lower for d in ("2026-02-14", "february 14", "feb 14")), (
+            f"Launch date not found: {answer[:200]}"
+        )
+        assert "cockroachdb" in answer_lower or "cockroach" in answer_lower, (
+            f"Database migration fact not found: {answer[:200]}"
+        )
+
+    # ── Test 5: daily log NOT in bootstrap, accessible via memory_get ──
+
+    async def test_05_daily_log_not_in_prompt(self):
+        """Verify load_bootstrap_files does NOT include daily logs."""
+        agent_id = type(self)._state["agent_id"]
+        root = type(self)._state["memory_root"]
+        today = type(self)._state["today"]
+
+        with patch("app.services.memory_service._memory_dir", return_value=root):
+            from app.services.memory_service import load_bootstrap_files
+
+            files = load_bootstrap_files(agent_id)
+
+        print(f"\n[Bootstrap] Keys: {list(files.keys())}")
+
+        assert "SOUL.md" in files, "SOUL.md missing from bootstrap"
+        assert "USER.md" in files, "USER.md missing from bootstrap"
+        assert "MEMORY.md" in files, "MEMORY.md missing from bootstrap"
+        assert f"memory/{today}.md" not in files, (
+            f"Daily log memory/{today}.md should NOT be in bootstrap!"
+        )
+        assert not any(k.startswith("memory/") for k in files), (
+            "No memory/*.md keys should be in bootstrap files"
+        )
+
+    async def test_06_daily_log_via_memory_get(self, e2e_client, e2e_session_factories):
+        """Agent should use memory_get tool to read daily log content."""
+        agent_id = type(self)._state["agent_id"]
+        root = type(self)._state["memory_root"]
+        today = type(self)._state["today"]
+
+        with (
+            _patch_api_key(),
+            patch("app.services.memory_service._memory_dir", return_value=root),
+            patch("app.api.v1.sessions.AsyncSessionLocal", e2e_session_factories["async"]),
+        ):
+            resp = await e2e_client.post(
+                "/api/v1/agent/run/stream",
+                json={
+                    "request": (
+                        f"Use the memory_get tool to read memory/{today}.md "
+                        "and tell me what bugs were fixed today."
+                    ),
+                    "agent_id": agent_id,
+                    "max_turns": 5,
+                    "model_provider": "kimi",
+                    "model_name": "kimi-k2.5",
+                    "session_id": uuid.uuid4().hex[:32],
+                },
+                timeout=120,
+            )
+
+        assert resp.status_code == 200
+        events = parse_sse_events(resp.text)
+
+        # Inspect tool calls
+        tool_calls = [e for e in events if e.get("event_type") == "tool_call"]
+        tool_results = [e for e in events if e.get("event_type") == "tool_result"]
+
+        print(f"\n[Daily Log] Tool calls ({len(tool_calls)}):")
+        for tc in tool_calls:
+            print(f"  - {tc.get('tool_name')}: {str(tc.get('tool_input', ''))[:120]}")
+
+        print(f"[Daily Log] Tool results ({len(tool_results)}):")
+        for tr in tool_results:
+            print(f"  - {str(tr.get('content', ''))[:200]}")
+
+        # Verify memory_get was called
+        memory_get_calls = [
+            tc for tc in tool_calls if tc.get("tool_name") == "memory_get"
+        ]
+        assert len(memory_get_calls) > 0, (
+            f"Agent did not call memory_get! "
+            f"Calls: {[tc.get('tool_name') for tc in tool_calls]}"
+        )
+
+        # Check final answer contains daily log content
+        complete_events = [e for e in events if e.get("event_type") == "complete"]
+        if complete_events:
+            final_answer = complete_events[-1].get("answer", "")
+            print(f"\n[Daily Log] Final answer:\n{final_answer}")
+            final_lower = final_answer.lower()
+            assert "789" in final_lower or "warp" in final_lower, (
+                f"Daily log content not in answer: {final_answer[:200]}"
+            )
+
+    # ── Cleanup ───────────────────────────────────────────────
+
+    async def test_99_cleanup(self, e2e_client):
+        """Delete the test preset."""
+        pid = type(self)._state.get("preset_id")
+        if pid:
+            await e2e_client.delete(f"/api/v1/agents/{pid}")
+            print(f"\n[Cleanup] Deleted preset {pid}")

--- a/tests/test_services/test_memory_service.py
+++ b/tests/test_services/test_memory_service.py
@@ -506,66 +506,16 @@ class TestReadMemoryFile:
             result = memory_service.read_memory_file("test-agent", "memory/2026-03-02.md")
             assert result == "today's notes"
 
-
-class TestLoadBootstrapFilesWithDailyLogs:
-    """Tests for load_bootstrap_files() daily log loading."""
-
-    def test_loads_todays_log(self, tmp_path: Path):
-        """Should include today's daily log when loading bootstrap files."""
-        from datetime import datetime as dt, timezone
-        agent_id = "test-agent-daily"
-        agent_dir = tmp_path / "agents" / agent_id
-        memory_dir = agent_dir / "memory"
-        memory_dir.mkdir(parents=True)
-        today = dt.now(timezone.utc).strftime("%Y-%m-%d")
-        (memory_dir / f"{today}.md").write_text("today's progress", encoding="utf-8")
+    def test_large_file_returned_in_full(self, tmp_path: Path):
+        """Large files should be returned without truncation (aligns with OpenClaw)."""
+        agent_dir = tmp_path / "agents" / "test-agent"
+        agent_dir.mkdir(parents=True)
+        big_content = "x" * 50_000
+        (agent_dir / "MEMORY.md").write_text(big_content, encoding="utf-8")
 
         with patch.object(memory_service, "_memory_dir", return_value=tmp_path):
-            result = memory_service.load_bootstrap_files(agent_id)
-            assert f"memory/{today}.md" in result
-            assert result[f"memory/{today}.md"] == "today's progress"
-
-    def test_loads_yesterdays_log(self, tmp_path: Path):
-        """Should include yesterday's daily log when loading bootstrap files."""
-        from datetime import datetime as dt, timedelta as td, timezone
-        agent_id = "test-agent-daily"
-        agent_dir = tmp_path / "agents" / agent_id
-        memory_dir = agent_dir / "memory"
-        memory_dir.mkdir(parents=True)
-        yesterday = (dt.now(timezone.utc) - td(days=1)).strftime("%Y-%m-%d")
-        (memory_dir / f"{yesterday}.md").write_text("yesterday's progress", encoding="utf-8")
-
-        with patch.object(memory_service, "_memory_dir", return_value=tmp_path):
-            result = memory_service.load_bootstrap_files(agent_id)
-            assert f"memory/{yesterday}.md" in result
-
-    def test_no_daily_logs_without_agent_id(self, tmp_path: Path):
-        """Without agent_id, no daily logs should be loaded."""
-        with patch.object(memory_service, "_memory_dir", return_value=tmp_path):
-            result = memory_service.load_bootstrap_files(agent_id=None)
-            # No memory/ keys
-            assert not any(k.startswith("memory/") for k in result)
-
-    def test_daily_logs_respect_total_limit(self, tmp_path: Path):
-        """Daily logs should not exceed total char limit."""
-        from datetime import datetime as dt, timezone
-        agent_id = "test-agent-limit"
-        agent_dir = tmp_path / "agents" / agent_id
-
-        # Fill up with large bootstrap files first
-        for f in memory_service.BOOTSTRAP_FILES:
-            (agent_dir).mkdir(parents=True, exist_ok=True)
-            (agent_dir / f).write_text("x" * memory_service.PER_FILE_CHAR_LIMIT, encoding="utf-8")
-
-        memory_dir = agent_dir / "memory"
-        memory_dir.mkdir(parents=True, exist_ok=True)
-        today = dt.now(timezone.utc).strftime("%Y-%m-%d")
-        (memory_dir / f"{today}.md").write_text("y" * 10000, encoding="utf-8")
-
-        with patch.object(memory_service, "_memory_dir", return_value=tmp_path):
-            result = memory_service.load_bootstrap_files(agent_id)
-            total = sum(len(v) for v in result.values())
-            assert total <= memory_service.TOTAL_CHAR_LIMIT
+            result = memory_service.read_memory_file("test-agent", "MEMORY.md")
+            assert result == big_content
 
 
 # ─── Save Memory Sync Tests ─────────────────────────────────


### PR DESCRIPTION
## Summary

- Align with OpenClaw: only `SOUL.md`, `USER.md`, `MEMORY.md` are injected into the system prompt; daily logs (`memory/*.md`) are accessed via `memory_get` tool at runtime
- Remove 17-line daily log loading block from `load_bootstrap_files()`
- Update Memory Recall directive to explicitly tell the agent daily logs require `memory_get`
- Add real E2E test verifying all 4 memory file types work correctly (SOUL persona, USER prefs, MEMORY facts, daily log via tool)

## Test plan

- [x] `pytest tests/test_services/test_memory_service.py` — 39 passed (4 daily-log-injection tests removed, 1 no-truncation test added)
- [x] `pytest tests/test_agent/test_agent_memory.py` — 47 passed unchanged
- [x] `pytest tests/test_e2e/test_memory_bootstrap_real.py -v -s` — 7/7 passed with real LLM (Kimi K2.5)

Closes #235